### PR TITLE
Fix beneficiary can book twice same shiftbucket.

### DIFF
--- a/src/AppBundle/Entity/ShiftBucket.php
+++ b/src/AppBundle/Entity/ShiftBucket.php
@@ -102,13 +102,20 @@ class ShiftBucket
             });
         }else{
             $user = $beneficiary->getUser();
-            $bookableShifts = $this->shifts->filter(function (Shift $shift) use ($user) {
-                return
-                    ($this->getStart() > $user->endOfCycle(1) || $this->getDuration() <= $user->remainingToBook(1))
-                    && ($this->getStart() < $user->startOfCycle(2) || $this->getDuration() <= $user->remainingToBook(2))
-                    && (($shift->getIsDismissed() && $shift->getBooker()->getId() != $user->getId())
-                        || !$shift->getShifter());
-            });
+            if ($this->canBookInterval($user))
+            {
+                $bookableShifts = $this->shifts->filter(function (Shift $shift) use ($user) {
+                    return
+                        ($this->getStart() > $user->endOfCycle(1) || $this->getDuration() <= $user->remainingToBook(1))
+                        && ($this->getStart() < $user->startOfCycle(2) || $this->getDuration() <= $user->remainingToBook(2))
+                        && (($shift->getIsDismissed() && $shift->getBooker()->getId() != $user->getId())
+                            || !$shift->getShifter());
+                });
+            }
+            else
+            {
+                $bookableShifts = new ArrayCollection();
+            }
         }
         return $bookableShifts;
     }


### PR DESCRIPTION
Merci de vérifier que cela fix bien #17.

Fix #17.

4b54b1e removed part of the code (call to canBookInterval) which ensured
user had not already booked a shift at the same period (same start, same
end).