### PR TITLE
Notification par mail pour les exceptions en prod

### DIFF
--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -20,6 +20,16 @@ monolog:
             path: '%kernel.logs_dir%/%kernel.environment%.log'
             level: debug
             channels: ['!event']
+        mattermost:
+            type: slackwebhook
+            webhook_url: '%logging.mattermost.url%'
+            channel: '%logging.mattermost.channel%'
+            bot_name: 'Monolog'
+            use_attachment: true,
+            icon_emoji: ''
+            use_short_attachment: true
+            include_extra: true
+            level: '%logging.mattermost.level%'
         console:
             type: console
             process_psr_3_messages: false
@@ -30,6 +40,14 @@ monolog:
             type: server_log
             process_psr_3_messages: false
             host: 127.0.0.1:9911
+        swiftmailer:
+            type: swift_mailer
+            from_email: '%transactional_mailer_user%'
+            to_email: '%logging.swiftmailer.recipient%'
+            subject: '%%level_name%% detected on %site_name% !'
+            level: '%logging.swiftmailer.level%'
+            formatter: monolog.formatter.html
+            content_type: text/html
         # uncomment to get logging in your browser
         # you may have to allow bigger header sizes in your Web server configuration
         #firephp:

--- a/app/config/config_prod.yml
+++ b/app/config/config_prod.yml
@@ -1,22 +1,42 @@
 imports:
     - { resource: config.yml }
 
-#doctrine:
-#    orm:
-#        metadata_cache_driver: apc
-#        result_cache_driver: apc
-#        query_cache_driver: apc
-
 monolog:
     handlers:
         main:
             type: fingers_crossed
             action_level: info
-            handler: nested
-        nested:
+            handler: grouped
+        grouped:
+            type: group
+            members: [file, mattermost, deduplicated]
+        file:
             type: stream
             path: '%kernel.logs_dir%/%kernel.environment%.log'
             level: debug
         console:
             type: console
             process_psr_3_messages: false
+        mattermost:
+            type: slackwebhook
+            webhook_url: '%logging.mattermost.url%'
+            channel: '%logging.mattermost.channel%'
+            bot_name: 'Monolog'
+            use_attachment: true,
+            icon_emoji: ''
+            use_short_attachment: true
+            include_extra: true
+            level: '%logging.mattermost.level%'
+        # Avoid getting spammed multiple times by the same exception
+        deduplicated:
+            type: deduplication
+            time: 20
+            handler: swiftmailer
+        swiftmailer:
+            type: swift_mailer
+            from_email: '%transactional_mailer_user%'
+            to_email: '%logging.swiftmailer.recipient%'
+            subject: '%%level_name%% detected on %site_name% !'
+            level: '%logging.swiftmailer.level%'
+            formatter: monolog.formatter.html
+            content_type: text/html

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -42,3 +42,12 @@ parameters:
     shift_mailer_user: ~
     #ip of the spot, comma separated if many
     place_local_ip_address: '127.0.0.1,192.168.0.x'
+
+    logging.mattermost.enabled: false
+    logging.mattermost.level: 'critical'
+    logging.mattermost.url: ~
+    logging.mattermost.channel: ~
+
+    logging.swiftmailer.enabled: false
+    logging.swiftmailer.level: 'critical'
+    logging.swiftmailer.recipient: ~

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -84,7 +84,29 @@ services:
                 - { name: kernel.event_listener, event: member.cycle.start, method: onMemberCycleStart }
                 - { name: kernel.event_listener, event: member.cycle.half, method: onMemberCycleHalf }
                 - { name: kernel.event_listener, event: member.created, method: onMemberCreated }
+
     shift_service:
             class:  AppBundle\Service\ShiftService
             public: true
             arguments: ["@doctrine.orm.entity_manager", "%due_duration_by_cycle%", "%min_shift_duration%"]
+
+    logger.user_processor:
+            class: AppBundle\Monolog\MonologUserProcessor
+            arguments:
+                - '@security.token_storage'
+            tags:
+                - { name: monolog.processor, method: processRecord }
+
+    logging.handler.mattermost:
+            class: AppBundle\Monolog\ToggleableHandler
+            decorates: monolog.handler.mattermost
+            arguments:
+                - '@logging.handler.mattermost.inner'
+                - '%logging.mattermost.enabled%'
+
+    logging.handler.swiftmailer:
+            class: AppBundle\Monolog\ToggleableHandler
+            decorates: monolog.handler.swiftmailer
+            arguments:
+                - '@logging.handler.swiftmailer.inner'
+                - '%logging.swiftmailer.enabled%'

--- a/src/AppBundle/Monolog/MonologUserProcessor.php
+++ b/src/AppBundle/Monolog/MonologUserProcessor.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace AppBundle\Monolog;
+
+use AppBundle\Entity\User;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+
+class MonologUserProcessor
+{
+    private $tokenStorage;
+
+    public function __construct(TokenStorage $tokenStorage)
+    {
+        $this->tokenStorage = $tokenStorage;
+    }
+
+    public function processRecord(array $record)
+    {
+        /** @var User $user */
+        $user = $this->tokenStorage->getToken() ? $this->tokenStorage->getToken()->getUser() : null;
+
+        if (is_object($user)) {
+            $text = $user->getId();
+            $beneficiary = $user->getBeneficiary();
+            if ($beneficiary) {
+                $text .= ' (' . $beneficiary->getDisplayName() . ')';
+            }
+            $record['extra']['user'] = $text;
+        } else if ($user) {
+            $record['extra']['user'] = $user;
+        }
+
+        return $record;
+    }
+}

--- a/src/AppBundle/Monolog/ToggleableHandler.php
+++ b/src/AppBundle/Monolog/ToggleableHandler.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace AppBundle\Monolog;
+
+use Monolog\Handler\AbstractHandler;
+
+/**
+ * A special Monolog handler allowing an existing handler to be enabled or disabled based on a parameter
+ */
+class ToggleableHandler extends AbstractHandler
+{
+    /**
+     * @var bool
+     */
+    private $enabled;
+    /**
+     * @var AbstractHandler
+     */
+    private $nestedHandler;
+
+    public function __construct(AbstractHandler $nestedHandler, $enabled = true)
+    {
+        parent::__construct();
+        $this->enabled = $enabled;
+        $this->nestedHandler = $nestedHandler;
+    }
+
+    /**
+     * Some handlers like SwiftMailer use specific methods, so redirect everything to the nested handler
+     */
+    public function __call($method, $args)
+    {
+        return call_user_func_array(array($this->nestedHandler, $method), $args);
+    }
+
+    public function handle(array $record)
+    {
+        if ($this->enabled) {
+            $this->nestedHandler->handle($record);
+        }
+    }
+}


### PR DESCRIPTION
Ça nous permettrait d'être au courant rapidement des problèmes en prod.
Les mails ont la stacktrace complète avec l'utilisateur concerné.
Pour l'instant j'ai mis le niveau à error mais il faudra peut être qu'on y descende à critical si on se fait trop spammer.

Reste à voir aussi quelle boite mail on pourrait utiliser pour ça.