### PR TITLE
Utilisation du bundle de migration doctrine

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -14,6 +14,7 @@ class AppKernel extends Kernel
             new Symfony\Bundle\MonologBundle\MonologBundle(),
             new Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle(),
             new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
+            new Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle(),
             new Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
             new Evheniy\JqueryBundle\JqueryBundle(),
             new Evheniy\MaterializeBundle\MaterializeBundle(),

--- a/app/DoctrineMigrations/Version20181103153303_initial.php
+++ b/app/DoctrineMigrations/Version20181103153303_initial.php
@@ -1,0 +1,188 @@
+<?php declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20181103153303_initial extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+        $this->abortIf(
+            $schema->hasTable('fos_user') && !$schema->hasTable('membership'),
+            'Some tables appear to be missing from your database, you have to migrate manually your database.'
+        );
+
+        $this->skipIf($schema->hasTable('fos_user'), 'Good ! The database seems to be already populated, skipping this migration...');
+
+        $this->addSql('CREATE TABLE access_token (id INT AUTO_INCREMENT NOT NULL, client_id INT NOT NULL, user_id INT DEFAULT NULL, token VARCHAR(255) NOT NULL, expires_at INT DEFAULT NULL, scope VARCHAR(255) DEFAULT NULL, UNIQUE INDEX UNIQ_B6A2DD685F37A13B (token), INDEX IDX_B6A2DD6819EB6921 (client_id), INDEX IDX_B6A2DD68A76ED395 (user_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE client (id INT AUTO_INCREMENT NOT NULL, service_id INT DEFAULT NULL, random_id VARCHAR(255) NOT NULL, redirect_uris LONGTEXT NOT NULL COMMENT \'(DC2Type:array)\', secret VARCHAR(255) NOT NULL, allowed_grant_types LONGTEXT NOT NULL COMMENT \'(DC2Type:array)\', INDEX IDX_C7440455ED5CA9E6 (service_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE fos_user (id INT AUTO_INCREMENT NOT NULL, username VARCHAR(180) NOT NULL, username_canonical VARCHAR(180) NOT NULL, email VARCHAR(180) NOT NULL, email_canonical VARCHAR(180) NOT NULL, enabled TINYINT(1) NOT NULL, salt VARCHAR(255) DEFAULT NULL, password VARCHAR(255) NOT NULL, last_login DATETIME DEFAULT NULL, confirmation_token VARCHAR(180) DEFAULT NULL, password_requested_at DATETIME DEFAULT NULL, roles LONGTEXT NOT NULL COMMENT \'(DC2Type:array)\', UNIQUE INDEX UNIQ_957A647992FC23A8 (username_canonical), UNIQUE INDEX UNIQ_957A6479A0D96FBF (email_canonical), UNIQUE INDEX UNIQ_957A6479C05FB297 (confirmation_token), PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE users_clients (user_id INT NOT NULL, client_id INT NOT NULL, INDEX IDX_F0C85ABEA76ED395 (user_id), INDEX IDX_F0C85ABE19EB6921 (client_id), PRIMARY KEY(user_id, client_id)) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE refresh_token (id INT AUTO_INCREMENT NOT NULL, client_id INT NOT NULL, user_id INT DEFAULT NULL, token VARCHAR(255) NOT NULL, expires_at INT DEFAULT NULL, scope VARCHAR(255) DEFAULT NULL, UNIQUE INDEX UNIQ_C74F21955F37A13B (token), INDEX IDX_C74F219519EB6921 (client_id), INDEX IDX_C74F2195A76ED395 (user_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE service (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(255) NOT NULL, description VARCHAR(255) NOT NULL, icon VARCHAR(255) NOT NULL, slug VARCHAR(255) NOT NULL, public TINYINT(1) DEFAULT \'0\', url VARCHAR(255) DEFAULT NULL, logo VARCHAR(255) DEFAULT NULL, logo_size INT DEFAULT NULL, updated_at DATETIME NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE anonymous_beneficiary (id INT AUTO_INCREMENT NOT NULL, registrar_id INT DEFAULT NULL, email VARCHAR(255) NOT NULL, amount VARCHAR(255) NOT NULL, mode INT NOT NULL, created_at DATETIME NOT NULL, UNIQUE INDEX UNIQ_4864BDFAE7927C74 (email), INDEX IDX_4864BDFAD1AA2FC1 (registrar_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE note (id INT AUTO_INCREMENT NOT NULL, author_id INT DEFAULT NULL, membership_id INT DEFAULT NULL, parent_id INT DEFAULT NULL, text LONGTEXT NOT NULL, created_at DATETIME NOT NULL, INDEX IDX_CFBDFA14F675F31B (author_id), INDEX IDX_CFBDFA141FB354CD (membership_id), INDEX IDX_CFBDFA14727ACA70 (parent_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE time_log (id INT AUTO_INCREMENT NOT NULL, membership_id INT NOT NULL, shift_id INT DEFAULT NULL, date DATETIME NOT NULL, time SMALLINT NOT NULL, description VARCHAR(255) NOT NULL, INDEX IDX_55BE03AF1FB354CD (membership_id), INDEX IDX_55BE03AFBB70BC0E (shift_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE code (id INT AUTO_INCREMENT NOT NULL, registrar_id INT DEFAULT NULL, value VARCHAR(255) DEFAULT NULL, created_at DATETIME NOT NULL, closed TINYINT(1) DEFAULT \'0\' NOT NULL, INDEX IDX_77153098D1AA2FC1 (registrar_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE auth_code (id INT AUTO_INCREMENT NOT NULL, client_id INT NOT NULL, user_id INT DEFAULT NULL, token VARCHAR(255) NOT NULL, redirect_uri LONGTEXT NOT NULL, expires_at INT DEFAULT NULL, scope VARCHAR(255) DEFAULT NULL, UNIQUE INDEX UNIQ_5933D02C5F37A13B (token), INDEX IDX_5933D02C19EB6921 (client_id), INDEX IDX_5933D02CA76ED395 (user_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE period_position (id INT AUTO_INCREMENT NOT NULL, formation_id INT DEFAULT NULL, nb_of_shifter INT NOT NULL, INDEX IDX_2367D4965200282E (formation_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE period_position_period (period_position_id INT NOT NULL, period_id INT NOT NULL, INDEX IDX_A0A94FFFA95DF5B1 (period_position_id), INDEX IDX_A0A94FFFEC8B7ADE (period_id), PRIMARY KEY(period_position_id, period_id)) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE address (id INT AUTO_INCREMENT NOT NULL, street1 VARCHAR(255) NOT NULL, street2 VARCHAR(255) DEFAULT NULL, zipcode VARCHAR(255) NOT NULL, city VARCHAR(255) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE event (id INT AUTO_INCREMENT NOT NULL, updated_at DATETIME NOT NULL, title VARCHAR(255) NOT NULL, description LONGTEXT NOT NULL, img VARCHAR(255) DEFAULT NULL, img_size INT DEFAULT NULL, date DATETIME NOT NULL, min_date_of_last_registration DATETIME DEFAULT NULL, need_proxy TINYINT(1) DEFAULT \'0\', PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE shift (id INT AUTO_INCREMENT NOT NULL, shifter_id INT DEFAULT NULL, booker_id INT DEFAULT NULL, last_shifter_id INT DEFAULT NULL, formation_id INT DEFAULT NULL, job_id INT DEFAULT NULL, start DATETIME NOT NULL, end DATETIME NOT NULL, booked_time DATETIME DEFAULT NULL, is_dismissed TINYINT(1) DEFAULT \'0\' NOT NULL, dismissed_time DATETIME DEFAULT NULL, dismissed_reason VARCHAR(255) DEFAULT NULL, INDEX IDX_A50B3B45A7DA74C1 (shifter_id), INDEX IDX_A50B3B458B7E4006 (booker_id), INDEX IDX_A50B3B454EAE1E2B (last_shifter_id), INDEX IDX_A50B3B455200282E (formation_id), INDEX IDX_A50B3B45BE04EA9 (job_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE period (id INT AUTO_INCREMENT NOT NULL, job_id INT DEFAULT NULL, day_of_week SMALLINT NOT NULL, start TIME NOT NULL, end TIME NOT NULL, INDEX IDX_C5B81ECEBE04EA9 (job_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE job (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(255) NOT NULL, color VARCHAR(255) NOT NULL, UNIQUE INDEX UNIQ_FBD8E0F85E237E06 (name), PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE task (id INT AUTO_INCREMENT NOT NULL, registrar_id INT DEFAULT NULL, title VARCHAR(255) NOT NULL, created_at DATETIME NOT NULL, due_date DATE DEFAULT NULL, closed TINYINT(1) DEFAULT \'0\', priority SMALLINT NOT NULL, status VARCHAR(255) DEFAULT NULL, INDEX IDX_527EDB25D1AA2FC1 (registrar_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE tasks_commissions (task_id INT NOT NULL, commission_id INT NOT NULL, INDEX IDX_C14A17118DB60186 (task_id), INDEX IDX_C14A1711202D1EB2 (commission_id), PRIMARY KEY(task_id, commission_id)) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE tasks_beneficiaries (task_id INT NOT NULL, beneficiary_id INT NOT NULL, INDEX IDX_1C93D30B8DB60186 (task_id), INDEX IDX_1C93D30BECCAAFA0 (beneficiary_id), PRIMARY KEY(task_id, beneficiary_id)) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE registration (id INT AUTO_INCREMENT NOT NULL, membership_id INT DEFAULT NULL, registrar_id INT DEFAULT NULL, date DATETIME NOT NULL, created_at DATETIME NOT NULL, amount VARCHAR(255) NOT NULL, mode INT NOT NULL, INDEX IDX_62A8A7A71FB354CD (membership_id), INDEX IDX_62A8A7A7D1AA2FC1 (registrar_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE beneficiary (id INT AUTO_INCREMENT NOT NULL, address_id INT DEFAULT NULL, user_id INT NOT NULL, membership_id INT DEFAULT NULL, commission_id INT DEFAULT NULL, lastname VARCHAR(255) NOT NULL, firstname VARCHAR(255) NOT NULL, phone VARCHAR(255) DEFAULT NULL, UNIQUE INDEX UNIQ_7ABF446AF5B7AF75 (address_id), UNIQUE INDEX UNIQ_7ABF446AA76ED395 (user_id), INDEX IDX_7ABF446A1FB354CD (membership_id), INDEX IDX_7ABF446A202D1EB2 (commission_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE beneficiaries_commissions (beneficiary_id INT NOT NULL, commission_id INT NOT NULL, INDEX IDX_F87A72B6ECCAAFA0 (beneficiary_id), INDEX IDX_F87A72B6202D1EB2 (commission_id), PRIMARY KEY(beneficiary_id, commission_id)) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE beneficiaries_formations (beneficiary_id INT NOT NULL, formation_id INT NOT NULL, INDEX IDX_4B438FE7ECCAAFA0 (beneficiary_id), INDEX IDX_4B438FE75200282E (formation_id), PRIMARY KEY(beneficiary_id, formation_id)) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE helloasso_payment (id INT AUTO_INCREMENT NOT NULL, registration_id INT DEFAULT NULL, created_at DATETIME NOT NULL, payment_id INT NOT NULL, campaign_id INT DEFAULT NULL, date DATETIME NOT NULL, amount DOUBLE PRECISION NOT NULL, email VARCHAR(255) NOT NULL, payer_first_name VARCHAR(255) NOT NULL, payer_last_name VARCHAR(255) NOT NULL, status VARCHAR(255) NOT NULL, UNIQUE INDEX UNIQ_A1B39AB64C3A3BB (payment_id), UNIQUE INDEX UNIQ_A1B39AB6833D8F43 (registration_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE commission (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(255) NOT NULL, description LONGTEXT NOT NULL, email VARCHAR(255) NOT NULL, next_meeting_desc VARCHAR(255) DEFAULT NULL, next_meeting_date DATETIME DEFAULT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE formation (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(180) NOT NULL, roles LONGTEXT NOT NULL COMMENT \'(DC2Type:array)\', UNIQUE INDEX UNIQ_404021BF5E237E06 (name), PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE proxy (id INT AUTO_INCREMENT NOT NULL, event_id INT DEFAULT NULL, owner INT DEFAULT NULL, giver INT DEFAULT NULL, created_at DATETIME NOT NULL, INDEX IDX_7372C9BE71F7E88B (event_id), INDEX IDX_7372C9BECF60E67C (owner), INDEX IDX_7372C9BE5DE37FD9 (giver), PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE membership (id INT AUTO_INCREMENT NOT NULL, last_registration_id INT DEFAULT NULL, main_beneficiary_id INT DEFAULT NULL, member_number INT NOT NULL, withdrawn TINYINT(1) DEFAULT \'0\', frozen TINYINT(1) DEFAULT \'0\', frozen_change TINYINT(1) DEFAULT \'0\', first_shift_date DATE DEFAULT NULL, UNIQUE INDEX UNIQ_86FFD2856986CF73 (last_registration_id), UNIQUE INDEX UNIQ_86FFD28562C6E4EA (main_beneficiary_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE swipe_card (id INT AUTO_INCREMENT NOT NULL, beneficiary_id INT DEFAULT NULL, created_at DATETIME NOT NULL, disabled_at DATETIME DEFAULT NULL, number INT NOT NULL, enable TINYINT(1) DEFAULT \'0\', code VARCHAR(255) NOT NULL, UNIQUE INDEX UNIQ_9CD0127677153098 (code), INDEX IDX_9CD01276ECCAAFA0 (beneficiary_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE access_token ADD CONSTRAINT FK_B6A2DD6819EB6921 FOREIGN KEY (client_id) REFERENCES client (id)');
+        $this->addSql('ALTER TABLE access_token ADD CONSTRAINT FK_B6A2DD68A76ED395 FOREIGN KEY (user_id) REFERENCES fos_user (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE client ADD CONSTRAINT FK_C7440455ED5CA9E6 FOREIGN KEY (service_id) REFERENCES service (id)');
+        $this->addSql('ALTER TABLE users_clients ADD CONSTRAINT FK_F0C85ABEA76ED395 FOREIGN KEY (user_id) REFERENCES fos_user (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE users_clients ADD CONSTRAINT FK_F0C85ABE19EB6921 FOREIGN KEY (client_id) REFERENCES client (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE refresh_token ADD CONSTRAINT FK_C74F219519EB6921 FOREIGN KEY (client_id) REFERENCES client (id)');
+        $this->addSql('ALTER TABLE refresh_token ADD CONSTRAINT FK_C74F2195A76ED395 FOREIGN KEY (user_id) REFERENCES fos_user (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE anonymous_beneficiary ADD CONSTRAINT FK_4864BDFAD1AA2FC1 FOREIGN KEY (registrar_id) REFERENCES fos_user (id) ON DELETE SET NULL');
+        $this->addSql('ALTER TABLE note ADD CONSTRAINT FK_CFBDFA14F675F31B FOREIGN KEY (author_id) REFERENCES fos_user (id)');
+        $this->addSql('ALTER TABLE note ADD CONSTRAINT FK_CFBDFA141FB354CD FOREIGN KEY (membership_id) REFERENCES membership (id)');
+        $this->addSql('ALTER TABLE note ADD CONSTRAINT FK_CFBDFA14727ACA70 FOREIGN KEY (parent_id) REFERENCES note (id)');
+        $this->addSql('ALTER TABLE time_log ADD CONSTRAINT FK_55BE03AF1FB354CD FOREIGN KEY (membership_id) REFERENCES membership (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE time_log ADD CONSTRAINT FK_55BE03AFBB70BC0E FOREIGN KEY (shift_id) REFERENCES shift (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE code ADD CONSTRAINT FK_77153098D1AA2FC1 FOREIGN KEY (registrar_id) REFERENCES fos_user (id) ON DELETE SET NULL');
+        $this->addSql('ALTER TABLE auth_code ADD CONSTRAINT FK_5933D02C19EB6921 FOREIGN KEY (client_id) REFERENCES client (id)');
+        $this->addSql('ALTER TABLE auth_code ADD CONSTRAINT FK_5933D02CA76ED395 FOREIGN KEY (user_id) REFERENCES fos_user (id)');
+        $this->addSql('ALTER TABLE period_position ADD CONSTRAINT FK_2367D4965200282E FOREIGN KEY (formation_id) REFERENCES formation (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE period_position_period ADD CONSTRAINT FK_A0A94FFFA95DF5B1 FOREIGN KEY (period_position_id) REFERENCES period_position (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE period_position_period ADD CONSTRAINT FK_A0A94FFFEC8B7ADE FOREIGN KEY (period_id) REFERENCES period (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE shift ADD CONSTRAINT FK_A50B3B45A7DA74C1 FOREIGN KEY (shifter_id) REFERENCES beneficiary (id)');
+        $this->addSql('ALTER TABLE shift ADD CONSTRAINT FK_A50B3B458B7E4006 FOREIGN KEY (booker_id) REFERENCES beneficiary (id)');
+        $this->addSql('ALTER TABLE shift ADD CONSTRAINT FK_A50B3B454EAE1E2B FOREIGN KEY (last_shifter_id) REFERENCES beneficiary (id)');
+        $this->addSql('ALTER TABLE shift ADD CONSTRAINT FK_A50B3B455200282E FOREIGN KEY (formation_id) REFERENCES formation (id) ON DELETE SET NULL');
+        $this->addSql('ALTER TABLE shift ADD CONSTRAINT FK_A50B3B45BE04EA9 FOREIGN KEY (job_id) REFERENCES job (id)');
+        $this->addSql('ALTER TABLE period ADD CONSTRAINT FK_C5B81ECEBE04EA9 FOREIGN KEY (job_id) REFERENCES job (id)');
+        $this->addSql('ALTER TABLE task ADD CONSTRAINT FK_527EDB25D1AA2FC1 FOREIGN KEY (registrar_id) REFERENCES fos_user (id) ON DELETE SET NULL');
+        $this->addSql('ALTER TABLE tasks_commissions ADD CONSTRAINT FK_C14A17118DB60186 FOREIGN KEY (task_id) REFERENCES task (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE tasks_commissions ADD CONSTRAINT FK_C14A1711202D1EB2 FOREIGN KEY (commission_id) REFERENCES commission (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE tasks_beneficiaries ADD CONSTRAINT FK_1C93D30B8DB60186 FOREIGN KEY (task_id) REFERENCES task (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE tasks_beneficiaries ADD CONSTRAINT FK_1C93D30BECCAAFA0 FOREIGN KEY (beneficiary_id) REFERENCES beneficiary (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE registration ADD CONSTRAINT FK_62A8A7A71FB354CD FOREIGN KEY (membership_id) REFERENCES membership (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE registration ADD CONSTRAINT FK_62A8A7A7D1AA2FC1 FOREIGN KEY (registrar_id) REFERENCES fos_user (id) ON DELETE SET NULL');
+        $this->addSql('ALTER TABLE beneficiary ADD CONSTRAINT FK_7ABF446AF5B7AF75 FOREIGN KEY (address_id) REFERENCES address (id)');
+        $this->addSql('ALTER TABLE beneficiary ADD CONSTRAINT FK_7ABF446AA76ED395 FOREIGN KEY (user_id) REFERENCES fos_user (id)');
+        $this->addSql('ALTER TABLE beneficiary ADD CONSTRAINT FK_7ABF446A1FB354CD FOREIGN KEY (membership_id) REFERENCES membership (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE beneficiary ADD CONSTRAINT FK_7ABF446A202D1EB2 FOREIGN KEY (commission_id) REFERENCES commission (id) ON DELETE SET NULL');
+        $this->addSql('ALTER TABLE beneficiaries_commissions ADD CONSTRAINT FK_F87A72B6ECCAAFA0 FOREIGN KEY (beneficiary_id) REFERENCES beneficiary (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE beneficiaries_commissions ADD CONSTRAINT FK_F87A72B6202D1EB2 FOREIGN KEY (commission_id) REFERENCES commission (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE beneficiaries_formations ADD CONSTRAINT FK_4B438FE7ECCAAFA0 FOREIGN KEY (beneficiary_id) REFERENCES beneficiary (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE beneficiaries_formations ADD CONSTRAINT FK_4B438FE75200282E FOREIGN KEY (formation_id) REFERENCES formation (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE helloasso_payment ADD CONSTRAINT FK_A1B39AB6833D8F43 FOREIGN KEY (registration_id) REFERENCES registration (id) ON DELETE SET NULL');
+        $this->addSql('ALTER TABLE proxy ADD CONSTRAINT FK_7372C9BE71F7E88B FOREIGN KEY (event_id) REFERENCES event (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE proxy ADD CONSTRAINT FK_7372C9BECF60E67C FOREIGN KEY (owner) REFERENCES beneficiary (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE proxy ADD CONSTRAINT FK_7372C9BE5DE37FD9 FOREIGN KEY (giver) REFERENCES membership (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE membership ADD CONSTRAINT FK_86FFD2856986CF73 FOREIGN KEY (last_registration_id) REFERENCES registration (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE membership ADD CONSTRAINT FK_86FFD28562C6E4EA FOREIGN KEY (main_beneficiary_id) REFERENCES beneficiary (id) ON DELETE SET NULL');
+        $this->addSql('ALTER TABLE swipe_card ADD CONSTRAINT FK_9CD01276ECCAAFA0 FOREIGN KEY (beneficiary_id) REFERENCES beneficiary (id)');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE access_token DROP FOREIGN KEY FK_B6A2DD6819EB6921');
+        $this->addSql('ALTER TABLE users_clients DROP FOREIGN KEY FK_F0C85ABE19EB6921');
+        $this->addSql('ALTER TABLE refresh_token DROP FOREIGN KEY FK_C74F219519EB6921');
+        $this->addSql('ALTER TABLE auth_code DROP FOREIGN KEY FK_5933D02C19EB6921');
+        $this->addSql('ALTER TABLE access_token DROP FOREIGN KEY FK_B6A2DD68A76ED395');
+        $this->addSql('ALTER TABLE users_clients DROP FOREIGN KEY FK_F0C85ABEA76ED395');
+        $this->addSql('ALTER TABLE refresh_token DROP FOREIGN KEY FK_C74F2195A76ED395');
+        $this->addSql('ALTER TABLE anonymous_beneficiary DROP FOREIGN KEY FK_4864BDFAD1AA2FC1');
+        $this->addSql('ALTER TABLE note DROP FOREIGN KEY FK_CFBDFA14F675F31B');
+        $this->addSql('ALTER TABLE code DROP FOREIGN KEY FK_77153098D1AA2FC1');
+        $this->addSql('ALTER TABLE auth_code DROP FOREIGN KEY FK_5933D02CA76ED395');
+        $this->addSql('ALTER TABLE task DROP FOREIGN KEY FK_527EDB25D1AA2FC1');
+        $this->addSql('ALTER TABLE registration DROP FOREIGN KEY FK_62A8A7A7D1AA2FC1');
+        $this->addSql('ALTER TABLE beneficiary DROP FOREIGN KEY FK_7ABF446AA76ED395');
+        $this->addSql('ALTER TABLE client DROP FOREIGN KEY FK_C7440455ED5CA9E6');
+        $this->addSql('ALTER TABLE note DROP FOREIGN KEY FK_CFBDFA14727ACA70');
+        $this->addSql('ALTER TABLE period_position_period DROP FOREIGN KEY FK_A0A94FFFA95DF5B1');
+        $this->addSql('ALTER TABLE beneficiary DROP FOREIGN KEY FK_7ABF446AF5B7AF75');
+        $this->addSql('ALTER TABLE proxy DROP FOREIGN KEY FK_7372C9BE71F7E88B');
+        $this->addSql('ALTER TABLE time_log DROP FOREIGN KEY FK_55BE03AFBB70BC0E');
+        $this->addSql('ALTER TABLE period_position_period DROP FOREIGN KEY FK_A0A94FFFEC8B7ADE');
+        $this->addSql('ALTER TABLE shift DROP FOREIGN KEY FK_A50B3B45BE04EA9');
+        $this->addSql('ALTER TABLE period DROP FOREIGN KEY FK_C5B81ECEBE04EA9');
+        $this->addSql('ALTER TABLE tasks_commissions DROP FOREIGN KEY FK_C14A17118DB60186');
+        $this->addSql('ALTER TABLE tasks_beneficiaries DROP FOREIGN KEY FK_1C93D30B8DB60186');
+        $this->addSql('ALTER TABLE helloasso_payment DROP FOREIGN KEY FK_A1B39AB6833D8F43');
+        $this->addSql('ALTER TABLE membership DROP FOREIGN KEY FK_86FFD2856986CF73');
+        $this->addSql('ALTER TABLE shift DROP FOREIGN KEY FK_A50B3B45A7DA74C1');
+        $this->addSql('ALTER TABLE shift DROP FOREIGN KEY FK_A50B3B458B7E4006');
+        $this->addSql('ALTER TABLE shift DROP FOREIGN KEY FK_A50B3B454EAE1E2B');
+        $this->addSql('ALTER TABLE tasks_beneficiaries DROP FOREIGN KEY FK_1C93D30BECCAAFA0');
+        $this->addSql('ALTER TABLE beneficiaries_commissions DROP FOREIGN KEY FK_F87A72B6ECCAAFA0');
+        $this->addSql('ALTER TABLE beneficiaries_formations DROP FOREIGN KEY FK_4B438FE7ECCAAFA0');
+        $this->addSql('ALTER TABLE proxy DROP FOREIGN KEY FK_7372C9BECF60E67C');
+        $this->addSql('ALTER TABLE membership DROP FOREIGN KEY FK_86FFD28562C6E4EA');
+        $this->addSql('ALTER TABLE swipe_card DROP FOREIGN KEY FK_9CD01276ECCAAFA0');
+        $this->addSql('ALTER TABLE tasks_commissions DROP FOREIGN KEY FK_C14A1711202D1EB2');
+        $this->addSql('ALTER TABLE beneficiary DROP FOREIGN KEY FK_7ABF446A202D1EB2');
+        $this->addSql('ALTER TABLE beneficiaries_commissions DROP FOREIGN KEY FK_F87A72B6202D1EB2');
+        $this->addSql('ALTER TABLE period_position DROP FOREIGN KEY FK_2367D4965200282E');
+        $this->addSql('ALTER TABLE shift DROP FOREIGN KEY FK_A50B3B455200282E');
+        $this->addSql('ALTER TABLE beneficiaries_formations DROP FOREIGN KEY FK_4B438FE75200282E');
+        $this->addSql('ALTER TABLE note DROP FOREIGN KEY FK_CFBDFA141FB354CD');
+        $this->addSql('ALTER TABLE time_log DROP FOREIGN KEY FK_55BE03AF1FB354CD');
+        $this->addSql('ALTER TABLE registration DROP FOREIGN KEY FK_62A8A7A71FB354CD');
+        $this->addSql('ALTER TABLE beneficiary DROP FOREIGN KEY FK_7ABF446A1FB354CD');
+        $this->addSql('ALTER TABLE proxy DROP FOREIGN KEY FK_7372C9BE5DE37FD9');
+        $this->addSql('DROP TABLE access_token');
+        $this->addSql('DROP TABLE client');
+        $this->addSql('DROP TABLE fos_user');
+        $this->addSql('DROP TABLE users_clients');
+        $this->addSql('DROP TABLE refresh_token');
+        $this->addSql('DROP TABLE service');
+        $this->addSql('DROP TABLE anonymous_beneficiary');
+        $this->addSql('DROP TABLE note');
+        $this->addSql('DROP TABLE time_log');
+        $this->addSql('DROP TABLE code');
+        $this->addSql('DROP TABLE auth_code');
+        $this->addSql('DROP TABLE period_position');
+        $this->addSql('DROP TABLE period_position_period');
+        $this->addSql('DROP TABLE address');
+        $this->addSql('DROP TABLE event');
+        $this->addSql('DROP TABLE shift');
+        $this->addSql('DROP TABLE period');
+        $this->addSql('DROP TABLE job');
+        $this->addSql('DROP TABLE task');
+        $this->addSql('DROP TABLE tasks_commissions');
+        $this->addSql('DROP TABLE tasks_beneficiaries');
+        $this->addSql('DROP TABLE registration');
+        $this->addSql('DROP TABLE beneficiary');
+        $this->addSql('DROP TABLE beneficiaries_commissions');
+        $this->addSql('DROP TABLE beneficiaries_formations');
+        $this->addSql('DROP TABLE helloasso_payment');
+        $this->addSql('DROP TABLE commission');
+        $this->addSql('DROP TABLE formation');
+        $this->addSql('DROP TABLE proxy');
+        $this->addSql('DROP TABLE membership');
+        $this->addSql('DROP TABLE swipe_card');
+    }
+}

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -73,6 +73,13 @@ doctrine:
     naming_strategy: doctrine.orm.naming_strategy.underscore
     auto_mapping: true
 
+doctrine_migrations:
+  dir_name: "%kernel.root_dir%/DoctrineMigrations"
+  namespace: Application\Migrations
+  table_name: migration_versions
+  name: Application Migrations
+  organize_migrations: false # Version >=1.2 Possible values are: "BY_YEAR", "BY_YEAR_AND_MONTH", false
+
 # Swiftmailer Configuration
 swiftmailer:
   transport: '%mailer_transport%'

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "files": [ "vendor/symfony/symfony/src/Symfony/Component/VarDumper/Resources/functions/dump.php" ]
     },
     "require": {
-        "php": ">=5.5.9",
+        "php": ">=7.1",
         "codeitnowin/barcode": "^3.0",
         "components/jquery": "^3.2",
         "doctrine/doctrine-bundle": "^1.6",

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "934ddd804e810a2c0d9dfc34220d5fb3",
+    "content-hash": "f4e4a826efc1c243379e024f69237633",
     "packages": [
         {
             "name": "behat/transliterator",
@@ -742,6 +742,67 @@
             "time": "2018-03-27T09:22:12+00:00"
         },
         {
+            "name": "doctrine/doctrine-migrations-bundle",
+            "version": "v1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/DoctrineMigrationsBundle.git",
+                "reference": "a9e506369f931351a2a6dd2aef588a822802b1b7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/DoctrineMigrationsBundle/zipball/a9e506369f931351a2a6dd2aef588a822802b1b7",
+                "reference": "a9e506369f931351a2a6dd2aef588a822802b1b7",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/doctrine-bundle": "~1.0",
+                "doctrine/migrations": "^1.1",
+                "php": ">=5.4.0",
+                "symfony/framework-bundle": "~2.7|~3.3|~4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.36"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Bundle\\MigrationsBundle\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                },
+                {
+                    "name": "Doctrine Project",
+                    "homepage": "http://www.doctrine-project.org"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "Symfony DoctrineMigrationsBundle",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "dbal",
+                "migrations",
+                "schema"
+            ],
+            "time": "2017-11-01T09:13:26+00:00"
+        },
+        {
             "name": "doctrine/event-manager",
             "version": "v1.0.0",
             "source": {
@@ -989,6 +1050,80 @@
                 "parser"
             ],
             "time": "2014-09-09T13:34:57+00:00"
+        },
+        {
+            "name": "doctrine/migrations",
+            "version": "v1.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/migrations.git",
+                "reference": "215438c0eef3e5f9b7da7d09c6b90756071b43e6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/migrations/zipball/215438c0eef3e5f9b7da7d09c6b90756071b43e6",
+                "reference": "215438c0eef3e5f9b7da7d09c6b90756071b43e6",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/dbal": "~2.6",
+                "ocramius/proxy-manager": "^1.0|^2.0",
+                "php": "^7.1",
+                "symfony/console": "~3.3|^4.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^1.0",
+                "doctrine/orm": "~2.5",
+                "jdorn/sql-formatter": "~1.1",
+                "mikey179/vfsstream": "^1.6",
+                "phpunit/phpunit": "~7.0",
+                "squizlabs/php_codesniffer": "^3.0",
+                "symfony/yaml": "~3.3|^4.0"
+            },
+            "suggest": {
+                "jdorn/sql-formatter": "Allows to generate formatted SQL with the diff command.",
+                "symfony/yaml": "Allows the use of yaml for migration configuration files."
+            },
+            "bin": [
+                "bin/doctrine-migrations"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "v1.8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\DBAL\\Migrations\\": "lib/Doctrine/DBAL/Migrations",
+                    "Doctrine\\Migrations\\": "lib/Doctrine/Migrations"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Michael Simonson",
+                    "email": "contact@mikesimonson.com"
+                }
+            ],
+            "description": "Database Schema migrations using Doctrine DBAL",
+            "homepage": "https://www.doctrine-project.org/projects/migrations.html",
+            "keywords": [
+                "database",
+                "migrations"
+            ],
+            "time": "2018-06-06T21:00:30+00:00"
         },
         {
             "name": "doctrine/orm",
@@ -2099,6 +2234,125 @@
                 "psr-3"
             ],
             "time": "2017-06-19T01:22:40+00:00"
+        },
+        {
+            "name": "ocramius/package-versions",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Ocramius/PackageVersions.git",
+                "reference": "4489d5002c49d55576fa0ba786f42dbb009be46f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Ocramius/PackageVersions/zipball/4489d5002c49d55576fa0ba786f42dbb009be46f",
+                "reference": "4489d5002c49d55576fa0ba786f42dbb009be46f",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0.0",
+                "php": "^7.1.0"
+            },
+            "require-dev": {
+                "composer/composer": "^1.6.3",
+                "ext-zip": "*",
+                "infection/infection": "^0.7.1",
+                "phpunit/phpunit": "^7.0.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PackageVersions\\Installer",
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PackageVersions\\": "src/PackageVersions"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                }
+            ],
+            "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
+            "time": "2018-02-05T13:05:30+00:00"
+        },
+        {
+            "name": "ocramius/proxy-manager",
+            "version": "2.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Ocramius/ProxyManager.git",
+                "reference": "14b137b06b0f911944132df9d51e445a35920ab1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Ocramius/ProxyManager/zipball/14b137b06b0f911944132df9d51e445a35920ab1",
+                "reference": "14b137b06b0f911944132df9d51e445a35920ab1",
+                "shasum": ""
+            },
+            "require": {
+                "ocramius/package-versions": "^1.1.3",
+                "php": "^7.2.0",
+                "zendframework/zend-code": "^3.3.0"
+            },
+            "require-dev": {
+                "couscous/couscous": "^1.6.1",
+                "ext-phar": "*",
+                "humbug/humbug": "1.0.0-RC.0@RC",
+                "nikic/php-parser": "^3.1.1",
+                "padraic/phpunit-accelerator": "dev-master@DEV",
+                "phpbench/phpbench": "^0.12.2",
+                "phpstan/phpstan": "dev-master#856eb10a81c1d27c701a83f167dc870fd8f4236a as 0.9.999",
+                "phpstan/phpstan-phpunit": "dev-master#5629c0a1f4a9c417cb1077cf6693ad9753895761",
+                "phpunit/phpunit": "^6.4.3",
+                "squizlabs/php_codesniffer": "^2.9.1"
+            },
+            "suggest": {
+                "ocramius/generated-hydrator": "To have very fast object to array to object conversion for ghost objects",
+                "zendframework/zend-json": "To have the JsonRpc adapter (Remote Object feature)",
+                "zendframework/zend-soap": "To have the Soap adapter (Remote Object feature)",
+                "zendframework/zend-xmlrpc": "To have the XmlRpc adapter (Remote Object feature)"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "ProxyManager\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "http://ocramius.github.io/"
+                }
+            ],
+            "description": "A library providing utilities to generate, instantiate and generally operate with Object Proxies",
+            "homepage": "https://github.com/Ocramius/ProxyManager",
+            "keywords": [
+                "aop",
+                "lazy loading",
+                "proxy",
+                "proxy pattern",
+                "service proxies"
+            ],
+            "time": "2018-09-27T13:45:01+00:00"
         },
         {
             "name": "ornicar/gravatar-bundle",
@@ -3686,6 +3940,113 @@
                 "upload"
             ],
             "time": "2017-12-09T13:34:29+00:00"
+        },
+        {
+            "name": "zendframework/zend-code",
+            "version": "3.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-code.git",
+                "reference": "c21db169075c6ec4b342149f446e7b7b724f95eb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-code/zipball/c21db169075c6ec4b342149f446e7b7b724f95eb",
+                "reference": "c21db169075c6ec4b342149f446e7b7b724f95eb",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1",
+                "zendframework/zend-eventmanager": "^2.6 || ^3.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "~1.0",
+                "ext-phar": "*",
+                "phpunit/phpunit": "^6.2.3",
+                "zendframework/zend-coding-standard": "^1.0.0",
+                "zendframework/zend-stdlib": "^2.7 || ^3.0"
+            },
+            "suggest": {
+                "doctrine/annotations": "Doctrine\\Common\\Annotations >=1.0 for annotation features",
+                "zendframework/zend-stdlib": "Zend\\Stdlib component"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3.x-dev",
+                    "dev-develop": "3.4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Code\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "provides facilities to generate arbitrary code using an object oriented interface",
+            "homepage": "https://github.com/zendframework/zend-code",
+            "keywords": [
+                "code",
+                "zf2"
+            ],
+            "time": "2018-08-13T20:36:59+00:00"
+        },
+        {
+            "name": "zendframework/zend-eventmanager",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-eventmanager.git",
+                "reference": "a5e2583a211f73604691586b8406ff7296a946dd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-eventmanager/zipball/a5e2583a211f73604691586b8406ff7296a946dd",
+                "reference": "a5e2583a211f73604691586b8406ff7296a946dd",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "athletic/athletic": "^0.1",
+                "container-interop/container-interop": "^1.1.0",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2",
+                "zendframework/zend-coding-standard": "~1.0.0",
+                "zendframework/zend-stdlib": "^2.7.3 || ^3.0"
+            },
+            "suggest": {
+                "container-interop/container-interop": "^1.1.0, to use the lazy listeners feature",
+                "zendframework/zend-stdlib": "^2.7.3 || ^3.0, to use the FilterChain feature"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev",
+                    "dev-develop": "3.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\EventManager\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Trigger and listen to events within a PHP application",
+            "homepage": "https://github.com/zendframework/zend-eventmanager",
+            "keywords": [
+                "event",
+                "eventmanager",
+                "events",
+                "zf2"
+            ],
+            "time": "2018-04-25T15:33:34+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
Maintenant qu'on a migré sur le nouveau modèle, j'en profite !
Ça sera très utile pour les prochains changements du schéma et surtout pour les autres coop qui nous utilisent.
La migration initiale sera automatiquement ignorée au premier lancement des migrations. (sauf si pas migré sur le nouveau modèle)

Doc : https://symfony.com/doc/current/bundles/DoctrineMigrationsBundle/index.html#usage
