### PR TITLE
check if user (membership) can book current and next cycle

### DIFF
--- a/src/AppBundle/Controller/BookingController.php
+++ b/src/AppBundle/Controller/BookingController.php
@@ -47,7 +47,7 @@ class BookingController extends Controller
 
         if ($beneficiary) {//not ADMIN or SUPER_ADMIN
             //todo : do not check for whole membership but only connected beneficiary
-            $canBook = $beneficiary->getMembership()->canBook();
+            $canBook = $beneficiary->getMembership()->canBook(null,null,0) || $beneficiary->getMembership()->canBook(null,null,1);
         }
 
 


### PR DESCRIPTION
Quick fix pour le souci sur user 1468 : impossible d'anticiper son bénévolat.
au lieu de faire un membership->canBook() général, on vérifie sur le cycle courant et le suivant (0 et 1).