### PR TITLE
exception fix

### DIFF
--- a/src/AppBundle/Controller/MembershipController.php
+++ b/src/AppBundle/Controller/MembershipController.php
@@ -703,7 +703,8 @@ class MembershipController extends Controller
                     $member->setFrozenChange(false);
 
                     $em->persist($member);
-                    $em->remove($a_beneficiary);
+                    if ($a_beneficiary)
+                        $em->remove($a_beneficiary);
                     $em->flush();
 
                     $dispatcher = $this->get('event_dispatcher');


### PR DESCRIPTION
EntityManager#remove() expects parameter 1 to be an entity object, NULL given.
EntityManager.php:610

Cas adhésion complète non issue d'une réunion info.