### PR TITLE
Commande pour fermer les comptes automatiquement

### DIFF
--- a/src/AppBundle/Command/CloseMembershipCommand.php
+++ b/src/AppBundle/Command/CloseMembershipCommand.php
@@ -1,0 +1,46 @@
+<?php
+namespace AppBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CloseMembershipCommand extends ContainerAwareCommand
+{
+    protected function configure()
+    {
+        $this
+            ->setName('app:member:close')
+            ->setDescription('Close memberships with unrenewed registration')
+            ->setHelp('This command close memberships when the registration has not been renewed after a delay specified parameters')
+            ->addArgument('delay', InputArgument::REQUIRED, "Delay (example: '1 month')");
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output->writeln('<fg=green;>close accounts command</>');
+
+        $delay = $input->getArgument('delay');
+        $date = new \DateTime('now');
+        $date->modify('-'.$delay);
+
+        $em = $this->getContainer()->get('doctrine')->getManager();
+
+        $members = $em->getRepository('AppBundle:Membership')->findWithExpiredRegistrationFrom($date);
+        $count = 0;
+        foreach ($members as $member) {
+            $member->setWithdrawn(true);
+            $em->persist($member);
+            $count++;
+            $message = 'Close membership #' . $member->getMemberNumber();
+            $output->writeln($message);
+        }
+
+        $em->flush();
+
+        $message = $count . ' membership(s) closed';
+        $output->writeln($message);
+    }
+
+}

--- a/src/AppBundle/Repository/MembershipRepository.php
+++ b/src/AppBundle/Repository/MembershipRepository.php
@@ -11,9 +11,9 @@ namespace AppBundle\Repository;
 class MembershipRepository extends \Doctrine\ORM\EntityRepository
 {
 
-    public function findWithNewCycleStarting($date =  null)
+    public function findWithNewCycleStarting($date = null)
     {
-        if (!($date)){
+        if (!($date)) {
             $date = new \Datetime('now');
         }
 
@@ -24,16 +24,16 @@ class MembershipRepository extends \Doctrine\ORM\EntityRepository
             ->andWhere('u.firstShiftDate is not NULL')
             ->andWhere('u.firstShiftDate != :now')
             ->andWhere('MOD(DATE_DIFF(:now, u.firstShiftDate), 28) = 0')
-            ->setParameter('now',$date);
+            ->setParameter('now', $date);
 
         return $qb
             ->getQuery()
             ->getResult();
     }
 
-    public function findWithHalfCyclePast($date =  null)
+    public function findWithHalfCyclePast($date = null)
     {
-        if (!($date)){
+        if (!($date)) {
             $date = new \Datetime('now');
         }
         $qb = $this->createQueryBuilder('u');
@@ -62,8 +62,26 @@ class MembershipRepository extends \Doctrine\ORM\EntityRepository
         $qb->select('u')
             ->from($this->_entityName, 'u')
             ->where('u.roles LIKE :roles')
-            ->setParameter('roles', '%"'.$role.'"%');
+            ->setParameter('roles', '%"' . $role . '"%');
 
         return $qb->getQuery()->getResult();
     }
+
+    /**
+     * @param \DateTime $from
+     *
+     * @return array
+     */
+    public function findWithExpiredRegistrationFrom($from)
+    {
+        $qb = $this->createQueryBuilder('m');
+        $qb->join('m.lastRegistration', 'r')
+            ->where('m.withdrawn = false')
+            ->andWhere("DATE_ADD(r.date, 1, 'YEAR') < :from")
+            ->setParameter('from', $from);
+
+        return $qb->getQuery()->getResult();
+    }
+
+
 }


### PR DESCRIPTION
Fermeture de compte automatique lorsque l'adhésion n'est pas renouvelée, avec un délai configurable en paramètre de la commande:
```
php bin/console app:member:close "1 month"
```
La première exécution de cette commande va fermer 642 comptes.