### PR TITLE
Ajout d'un paramètre pour activer l'auto-activation des badges

### DIFF
--- a/app/Resources/views/default/index.html.twig
+++ b/app/Resources/views/default/index.html.twig
@@ -41,7 +41,7 @@
                     <a href="{{ path("user_self_register") }}" class="waves-effect waves-light light-green btn"><i
                                 class="material-icons left">card_membership</i>Je ré-adhérer en ligne</a>
                 {% else %}
-                    {% if autoactivate_swipe_cards %}
+                    {% if swipe_cards.autoactivate.enabled %}
                         {{ render(controller("AppBundle:SwipeCard:homepage")) }}
                     {% endif %}
                     {{ render(controller("AppBundle:Booking:homepage")) }}

--- a/app/Resources/views/default/index.html.twig
+++ b/app/Resources/views/default/index.html.twig
@@ -41,40 +41,48 @@
                     <a href="{{ path("user_self_register") }}" class="waves-effect waves-light light-green btn"><i
                                 class="material-icons left">card_membership</i>Je ré-adhérer en ligne</a>
                 {% else %}
-                {{ render(controller("AppBundle:SwipeCard:homepage")) }}
-                {{ render(controller("AppBundle:Booking:homepage")) }}
+                    {% if autoactivate_swipe_cards %}
+                        {{ render(controller("AppBundle:SwipeCard:homepage")) }}
+                    {% endif %}
+                    {{ render(controller("AppBundle:Booking:homepage")) }}
                 {% endif %}
             {% else %}
                 <a href="{{ path("booking_admin") }}" class="waves-effect waves-light btn teal"><i
                             class="material-icons left">date_range</i>Gérer les créneaux</a>
             {% endif %}
 
-                    <h5>Construire</h5>
-                    {% if is_granted("access_tools",app.user)  %}
-                        <a href="{{ path("user_office_tools") }}" class="waves-effect waves-light btn teal"><i class="material-icons left">list</i>Poste adhésion / ré-adhésion</a>
-                    {% endif %}
-                    <a href="{{ path("tasks_list") }}" class="waves-effect waves-light btn"><i class="material-icons left">list</i>Taches en cours</a>
-                    {% if is_granted("view",codes | first) or is_granted("create",codes | first)  %}
-                        <br>
-                    {% endif %}
-                    {% if not is_granted("ROLE_ADMIN") %}
-                        {% if is_granted("view",codes | first)  %}
-                            {% if (codes | first).registrar == app.user %}
-                                {% if codes | length > 1 %} {# last code is users one, but other codes exist #}
-                                    <a href="{{ path("code_new") }}" class="waves-effect waves-light btn deep-purple lighten-1"><i class="material-icons left">vpn_key</i>Changer code boîtier à clefs</a>
-                                {% elseif is_granted("create",codes | first) %}
-                                    <a href="{{ path("code_new") }}" class="waves-effect waves-light btn deep-purple darken-1"><i class="material-icons left">vpn_key</i>Déposer les clefs</a>
-                                {% endif %}
-                            {% else %}
-                                <a href="{{ path("codes_list") }}" class="waves-effect waves-light btn deep-purple lighten-1"><i class="material-icons left">vpn_key</i>Voir code{% if codes | length > 1%}s{% endif %} boîtier à clefs</a>
-                                {% if is_granted("create",codes | first)  %}
-                                    <a href="{{ path("code_new") }}" class="waves-effect waves-light btn deep-purple darken-1"><i class="material-icons left">vpn_key</i>Déposer les clefs</a>
-                                {% endif %}
-                            {% endif %}
+            <h5>Construire</h5>
+            {% if is_granted("access_tools",app.user) %}
+                <a href="{{ path("user_office_tools") }}" class="waves-effect waves-light btn teal"><i class="material-icons left">list</i>Poste
+                    adhésion / ré-adhésion</a>
+            {% endif %}
+            <a href="{{ path("tasks_list") }}" class="waves-effect waves-light btn"><i class="material-icons left">list</i>Taches en cours</a>
+            {% if is_granted("view",codes | first) or is_granted("create",codes | first) %}
+                <br>
+            {% endif %}
+            {% if not is_granted("ROLE_ADMIN") %}
+                {% if is_granted("view",codes | first) %}
+                    {% if (codes | first).registrar == app.user %}
+                        {% if codes | length > 1 %} {# last code is users one, but other codes exist #}
+                            <a href="{{ path("code_new") }}" class="waves-effect waves-light btn deep-purple lighten-1"><i
+                                        class="material-icons left">vpn_key</i>Changer code boîtier à clefs</a>
                         {% elseif is_granted("create",codes | first) %}
-                                <a href="{{ path("code_new") }}" class="waves-effect waves-light btn deep-purple darken-1"><i class="material-icons left">vpn_key</i>Déposer les clefs</a>
+                            <a href="{{ path("code_new") }}" class="waves-effect waves-light btn deep-purple darken-1"><i class="material-icons left">vpn_key</i>Déposer
+                                les clefs</a>
+                        {% endif %}
+                    {% else %}
+                        <a href="{{ path("codes_list") }}" class="waves-effect waves-light btn deep-purple lighten-1"><i class="material-icons left">vpn_key</i>Voir
+                            code{% if codes | length > 1 %}s{% endif %} boîtier à clefs</a>
+                        {% if is_granted("create",codes | first) %}
+                            <a href="{{ path("code_new") }}" class="waves-effect waves-light btn deep-purple darken-1"><i class="material-icons left">vpn_key</i>Déposer
+                                les clefs</a>
                         {% endif %}
                     {% endif %}
+                {% elseif is_granted("create",codes | first) %}
+                    <a href="{{ path("code_new") }}" class="waves-effect waves-light btn deep-purple darken-1"><i
+                                class="material-icons left">vpn_key</i>Déposer les clefs</a>
+                {% endif %}
+            {% endif %}
 
             {% if is_granted("ROLE_USER_MANAGER") %}
                 <h5>Gérer les membres</h5>
@@ -141,7 +149,7 @@
             });
         })
         {% if not is_granted("IS_AUTHENTICATED_REMEMBERED") %}
-            var barcode_submit_url="{{ path('check') }}";
+        var barcode_submit_url = "{{ path('check') }}";
         {% endif %}
     </script>
     {% if not is_granted("IS_AUTHENTICATED_REMEMBERED") %}

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -43,18 +43,21 @@ twig:
   debug: '%kernel.debug%'
   strict_variables: '%kernel.debug%'
   form_themes:
-      - "form/fields.html.twig"
+    - "form/fields.html.twig"
   globals:
-      site_name: "%site_name%"
-      main_color: "%main_color%"
-      project_name: "%project_name%"
-      project_url: "%project_url%"
-      project_url_display: "%project_url_display%"
-      helloasso_registration_campaign_url: "%helloasso_registration_campaign_url%"
-      due_duration_by_cycle: '%due_duration_by_cycle%'
-      support_email: '%transactional_mailer_user%'
-      images_tmp_dir: '%images_tmp_dir%'
-      shift_service: "@shift_service"
+    site_name: "%site_name%"
+    main_color: "%main_color%"
+    project_name: "%project_name%"
+    project_url: "%project_url%"
+    project_url_display: "%project_url_display%"
+    helloasso_registration_campaign_url: "%helloasso_registration_campaign_url%"
+    due_duration_by_cycle: '%due_duration_by_cycle%'
+    support_email: '%transactional_mailer_user%'
+    images_tmp_dir: '%images_tmp_dir%'
+    shift_service: "@shift_service"
+    swipe_cards:
+      autoactivate:
+        enabled: '%swipe_cards.autoactivate.enabled%'
 
 # Doctrine Configuration
 doctrine:
@@ -169,27 +172,27 @@ vich_uploader:
       delete_on_remove: true
       namer: vich_uploader.namer_origname
 
-liip_imagine :
-  resolvers :
-    default :
-        web_path : ~
+liip_imagine:
+  resolvers:
+    default:
+      web_path: ~
   loaders:
     default:
       filesystem:
         data_root: '%kernel.project_dir%/web/'
-  filter_sets :
-    cache : ~
-    card :
-      quality : 75
-      filters :
-        thumbnail  : { size : [600, 100], position : center, color : '#000000' }
-    service_logo :
-      quality : 75
-      filters :
+  filter_sets:
+    cache: ~
+    card:
+      quality: 75
+      filters:
+        thumbnail: { size: [600, 100], position: center, color: '#000000' }
+    service_logo:
+      quality: 75
+      filters:
         # create a thumbnail: set size to 120x90 and use the "outbound" mode
         # to crop the image when the size ratio of the input differs
-#        service_logo  : { size : [120, 120], mode : outbound }
-        thumbnail  : { size : [120, 120], position : center, color : '#FFFFFF' }
+        #        service_logo  : { size : [120, 120], mode : outbound }
+        thumbnail: { size: [120, 120], position: center, color: '#FFFFFF' }
         # create a 2px black border: center the thumbnail on a black background
         # 4px larger to create a 2px border around the final image
 #        background : { size : [124, 94], position : center, color : '#000000' }

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -57,6 +57,8 @@ parameters:
         - "%emails.admin%"
         - "%emails.noreply%"
 
+    shift_mailer_user: ~
+
     # A secret key that's used to generate certain security-related tokens
     secret: ThisTokenIsNotSoSecretChangeIt
 
@@ -65,23 +67,31 @@ parameters:
     router.request_context.scheme: https
     router.request_context.base_url:
 
+    # Branding
     site_name: Espace membre @ MyLocalCoop
     project_name: My Local Coop
     project_url: https://localcoop.local/
     project_url_display: localcoop.local
-    wiki_keys_url: ~
     main_color: #51CAE9
-    helloasso_registration_campaign_url: https://www.helloasso.com/associations/my-local-coop/adhesions/re-adhesion
-    helloasso_api_key:
-    helloasso_api_password:
-    due_duration_by_cycle: 180
-    min_shift_duration: 90
-    registration_duration: '1 year'
-    cycle_duration: '28 days'
-    shift_mailer_user: ~
     local_currency_name: 'monnaie locale'
     #ip of the spot, comma separated if many
     place_local_ip_address: '127.0.0.1,192.168.0.x'
+
+    wiki_keys_url: ~
+
+    # Registration
+    registration_duration: '1 year'
+    helloasso_registration_campaign_url: https://www.helloasso.com/associations/my-local-coop/adhesions/re-adhesion
+    helloasso_api_key:
+    helloasso_api_password:
+
+    # Shifting configuration
+    due_duration_by_cycle: 180
+    min_shift_duration: 90
+    cycle_duration: '28 days'
+
+    # Swipe cards
+    swipe_cards.autoactivate.enabled: false
 
     logging.mattermost.enabled: false
     logging.mattermost.level: 'critical'

--- a/src/AppBundle/Controller/DefaultController.php
+++ b/src/AppBundle/Controller/DefaultController.php
@@ -150,7 +150,8 @@ class DefaultController extends Controller
         return $this->render('default/index.html.twig', [
             'base_dir' => realpath($this->getParameter('kernel.project_dir')) . DIRECTORY_SEPARATOR,
             'events' => $futur_events,
-            'codes' => $codes
+            'codes' => $codes,
+            'autoactivate_swipe_cards' => $this->getParameter('swipe_cards.autoactivate.enabled')
         ]);
     }
 

--- a/src/AppBundle/Controller/DefaultController.php
+++ b/src/AppBundle/Controller/DefaultController.php
@@ -150,8 +150,7 @@ class DefaultController extends Controller
         return $this->render('default/index.html.twig', [
             'base_dir' => realpath($this->getParameter('kernel.project_dir')) . DIRECTORY_SEPARATOR,
             'events' => $futur_events,
-            'codes' => $codes,
-            'autoactivate_swipe_cards' => $this->getParameter('swipe_cards.autoactivate.enabled')
+            'codes' => $codes
         ]);
     }
 


### PR DESCRIPTION
Pour les autres coops et pour nous. Je pense que c'est mieux de cacher l'activation des badges tant qu'on a pas les cartes plastiques. Cela évitera d'embrouiller les membres.