### PR TITLE
Feature/deactivate old jobs

### DIFF
--- a/app/DoctrineMigrations/Version20190325220124_disable_jobs.php
+++ b/app/DoctrineMigrations/Version20190325220124_disable_jobs.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20190325220124_disable_jobs extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE job ADD enabled TINYINT(1) DEFAULT \'1\' NOT NULL');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE job DROP enabled');
+    }
+}

--- a/app/Resources/views/admin/job/_form.html.twig
+++ b/app/Resources/views/admin/job/_form.html.twig
@@ -1,0 +1,34 @@
+{{ form_start(form) }}
+<div class="row">
+    {{ form_label(form.name) }}
+    {{ form_errors(form.name) }}
+    {{ form_widget(form.name) }}
+</div>
+<div class="row">
+    {{ form_label(form.color) }}<br>
+    <a href="https://materializecss.com/color.html" target="_blank"><i class="material-icons left">link</i> Couleur
+        materialize</a>
+    <span class="badge red">red</span>
+    <span class="badge pink">pink</span>
+    <span class="badge purple">purple</span>
+    <span class="badge deep-purple">deep-purple</span>
+    <span class="badge indigo">indigo</span>
+    <span class="badge blue">blue</span>
+    <span class="badge light-blue">light-blue</span>
+    <span class="badge cyan">cyan</span>
+    <span class="badge teal">teal</span>
+    <span class="badge green">green</span>
+    <span class="badge light-green">light-green</span>
+    <span class="badge lime">lime</span>
+    <span class="badge gray">...</span>
+    {{ form_errors(form.color) }}
+    {{ form_widget(form.color) }}
+</div>
+<div class="row">
+    {{ form_errors(form.enabled) }}
+    {{ form_widget(form.enabled) }}
+    {{ form_label(form.enabled) }}
+</div>
+<button type="submit" class="btn-large waves-effect waves-light">Enregistrer</button>
+{{ form_end(form) }}
+

--- a/app/Resources/views/admin/job/edit.html.twig
+++ b/app/Resources/views/admin/job/edit.html.twig
@@ -1,14 +1,15 @@
 {% extends 'layout.html.twig' %}
 
 {% block content %}
-    <h4 class="">editer job</h4>
+    <h4 class="">éditer job</h4>
 
-    {{ form_start(form) }}
-        {{ form_widget(form) }}
-    <button type="submit" class="btn-large waves-effect waves-light">Enregistrer</button>
-    {{ form_end(form) }}
+    {% include "/admin/job/_form.html.twig" with { form: form  } %}
 
-    {{ form_start(delete_form) }}
-    <button type="submit" class="btn-large waves-effect waves-light red"><i class="material-icons left">delete</i>Supprimer</button>
-    {{ form_end(delete_form) }}
+    {% if is_granted("ROLE_SUPER_ADMIN") %}
+        {{ form_start(delete_form) }}
+        <button type="submit" class="btn-large waves-effect waves-light red"><i class="material-icons left">delete</i>Supprimer
+        </button>
+        {{ form_end(delete_form) }}
+    {% endif %}
+
 {% endblock %}

--- a/app/Resources/views/admin/job/list.html.twig
+++ b/app/Resources/views/admin/job/list.html.twig
@@ -14,7 +14,7 @@
         <tr>
             <th>id</th>
             <th>Poste</th>
-            <th>couleur</th>
+            <th>Couleur</th>
             <th>Actions</th>
         </tr>
         </thead>
@@ -23,7 +23,7 @@
         {% for job in jobs %}
             <tr>
                 <td>{{ job.id }}</td>
-                <td>{{ job.name }}</td>
+                <td {% if not job.enabled %}style="text-decoration: line-through"{% endif %}>{{ job.name }}</td>
                 <td class="{{ job.color }} white-text">{{ job.color }}</td>
                 <td><a href="{{ path("job_edit",{'id':job.id}) }}"><i class="material-icons">edit</i>editer</a></td>
             </tr>

--- a/app/Resources/views/admin/job/new.html.twig
+++ b/app/Resources/views/admin/job/new.html.twig
@@ -4,10 +4,13 @@
     <h4 class="">Nouveau poste</h4>
 
     {{ form_start(form) }}
+
+    <div class="row">
         {{ form_label(form.name) }}
         {{ form_errors(form.name) }}
         {{ form_widget(form.name) }}
-
+    </div>
+    <div class="row">
         {{ form_label(form.color) }}<br>
         <a href="https://materializecss.com/color.html" target="_blank"><i class="material-icons left">link</i> Couleur materialize</a>
         <span class="badge red">red</span>
@@ -25,6 +28,12 @@
         <span class="badge gray">...</span>
         {{ form_errors(form.color) }}
         {{ form_widget(form.color) }}
+    </div>
+    <div class="row">
+        {{ form_errors(form.enabled) }}
+        {{ form_widget(form.enabled) }}
+        {{ form_label(form.enabled) }}
+    </div>
         <button type="submit" class="btn-large waves-effect waves-light">Créer</button>
     {{ form_end(form) }}
 {% endblock %}

--- a/app/Resources/views/admin/job/new.html.twig
+++ b/app/Resources/views/admin/job/new.html.twig
@@ -3,38 +3,8 @@
 {% block content %}
     <h4 class="">Nouveau poste</h4>
 
-    {{ form_start(form) }}
+    {% include "/admin/job/_form.html.twig" with { form: form  } %}
 
-    <div class="row">
-        {{ form_label(form.name) }}
-        {{ form_errors(form.name) }}
-        {{ form_widget(form.name) }}
-    </div>
-    <div class="row">
-        {{ form_label(form.color) }}<br>
-        <a href="https://materializecss.com/color.html" target="_blank"><i class="material-icons left">link</i> Couleur materialize</a>
-        <span class="badge red">red</span>
-        <span class="badge pink">pink</span>
-        <span class="badge purple">purple</span>
-        <span class="badge deep-purple">deep-purple</span>
-        <span class="badge indigo">indigo</span>
-        <span class="badge blue">blue</span>
-        <span class="badge light-blue">light-blue</span>
-        <span class="badge cyan">cyan</span>
-        <span class="badge teal">teal</span>
-        <span class="badge green">green</span>
-        <span class="badge light-green">light-green</span>
-        <span class="badge lime">lime</span>
-        <span class="badge gray">...</span>
-        {{ form_errors(form.color) }}
-        {{ form_widget(form.color) }}
-    </div>
-    <div class="row">
-        {{ form_errors(form.enabled) }}
-        {{ form_widget(form.enabled) }}
-        {{ form_label(form.enabled) }}
-    </div>
-        <button type="submit" class="btn-large waves-effect waves-light">Créer</button>
-    {{ form_end(form) }}
+
 {% endblock %}
 

--- a/src/AppBundle/Controller/JobController.php
+++ b/src/AppBundle/Controller/JobController.php
@@ -49,6 +49,7 @@ class JobController extends Controller
         $session = new Session();
 
         $job = new Job();
+        $job->setEnabled(true);
 
         $em = $this->getDoctrine()->getManager();
 

--- a/src/AppBundle/Entity/Job.php
+++ b/src/AppBundle/Entity/Job.php
@@ -50,6 +50,12 @@ class Job
      */
     private $periods;
 
+    /**
+     * @var bool
+     *
+     * @ORM\Column(name="enabled", type="boolean", nullable=false, options={"default" : 1})
+     */
+    private $enabled;
 
     /**
      * Get id
@@ -186,5 +192,21 @@ class Job
     public function getPeriods()
     {
         return $this->periods;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isEnabled()
+    {
+        return $this->enabled;
+    }
+
+    /**
+     * @param bool $enabled
+     */
+    public function setEnabled(bool $enabled)
+    {
+        $this->enabled = $enabled;
     }
 }

--- a/src/AppBundle/Form/JobType.php
+++ b/src/AppBundle/Form/JobType.php
@@ -3,16 +3,11 @@
 namespace AppBundle\Form;
 
 use AppBundle\Entity\Job;
-use AppBundle\Entity\PeriodPosition;
-use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
-use Symfony\Component\Form\Extension\Core\Type\IntegerType;
-use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Validator\Constraints\NotBlank;
 
 class JobType extends AbstractType
 {
@@ -23,7 +18,8 @@ class JobType extends AbstractType
     {
         $builder
             ->add('name',TextType::class,array('label'=>'Nom du poste de bénévolat'))
-            ->add('color',TextType::class,array('label'=>'Couleur des créneaux dans le planning'));
+            ->add('color',TextType::class,array('label'=>'Couleur des créneaux dans le planning'))
+            ->add('enabled',CheckboxType::class,array('required' => false, 'label'=>'Poste activé'));
     }
 
     /**

--- a/src/AppBundle/Form/PeriodType.php
+++ b/src/AppBundle/Form/PeriodType.php
@@ -2,19 +2,14 @@
 
 namespace AppBundle\Form;
 
-use AppBundle\Entity\Job;
 use AppBundle\Entity\Period;
-use AppBundle\Entity\PeriodPosition;
-use AppBundle\Entity\PeriodRoom;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
-use Symfony\Component\Form\Extension\Core\Type\IntegerType;
-use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Validator\Constraints\NotBlank;
+use AppBundle\Repository\JobRepository;
 
 class PeriodType extends AbstractType
 {
@@ -40,7 +35,14 @@ class PeriodType extends AbstractType
                 'class' => 'AppBundle:Job',
                 'choice_label'=> 'name',
                 'multiple'     => false,
-                'required' => true
+                'required' => true,
+                'query_builder' => function(JobRepository $repository) {
+                    $qb = $repository->createQueryBuilder('j');
+                    return $qb
+                        ->where($qb->expr()->eq('j.enabled', '?1'))
+                        ->setParameter('1', '1')
+                        ->orderBy('j.name', 'ASC');
+                }
             ));
     }
 

--- a/src/AppBundle/Form/ShiftType.php
+++ b/src/AppBundle/Form/ShiftType.php
@@ -3,14 +3,11 @@
 namespace AppBundle\Form;
 
 use AppBundle\Entity\Shift;
+use AppBundle\Repository\JobRepository;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
-use Symfony\Component\Form\Extension\Core\Type\CollectionType;
-use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
-use AppBundle\Form\ShiftMapper;
-use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Form\DataMapperInterface;
 
 class ShiftType extends AbstractType implements DataMapperInterface
@@ -36,7 +33,14 @@ class ShiftType extends AbstractType implements DataMapperInterface
                 'class' => 'AppBundle:Job',
                 'choice_label' => 'name',
                 'multiple' => false,
-                'required' => true
+                'required' => true,
+                'query_builder' => function(JobRepository $repository) {
+                    $qb = $repository->createQueryBuilder('j');
+                    return $qb
+                        ->where($qb->expr()->eq('j.enabled', '?1'))
+                        ->setParameter('1', '1')
+                        ->orderBy('j.name', 'ASC');
+                }
             ))
             ->setDataMapper($this);
     }


### PR DESCRIPTION
Désactivation des postes de bénévolats obsolètes.

Permet de faire du clean dans les dropdowns sans supprimer les jobs obsolètes (et donc les créneaux associés). A appliquer par exemple aux jobs "Aménagement du sous-sol" et "Biennales ...".