### PR TITLE
🐳(dev) allow usage of app_dev.php in a docker stack

### DIFF
--- a/doc/dev.md
+++ b/doc/dev.md
@@ -22,3 +22,9 @@ Pour récupérer les mails envoyés (mode DEV)
 
 ## Materialize
 * [official doc](https://materializecss.com/)
+
+## Docker
+
+Si vous souhaitez développer en utilisant Docker, n'oubliez pas de définir
+la variable d'environnement `DEV_MODE_ENABLED` dans le container qui exécute
+le code de l'application.

--- a/web/app_dev.php
+++ b/web/app_dev.php
@@ -12,7 +12,10 @@ use Symfony\Component\HttpFoundation\Request;
 // Feel free to remove this, extend it, or make something more sophisticated.
 if (isset($_SERVER['HTTP_CLIENT_IP'])
     || isset($_SERVER['HTTP_X_FORWARDED_FOR'])
-    || !(in_array(@$_SERVER['REMOTE_ADDR'], ['127.0.0.1', '::1'], true) || PHP_SAPI === 'cli-server')
+    || (
+        !(in_array(@$_SERVER['REMOTE_ADDR'], array('127.0.0.1', 'fe80::1', '::1')) || PHP_SAPI === 'cli-server')
+        && false === getenv('DEV_MODE_ENABLED')
+    )
 ) {
     header('HTTP/1.0 403 Forbidden');
     exit('You are not allowed to access this file. Check '.basename(__FILE__).' for more information.');


### PR DESCRIPTION
## Objet

Afin de pouvoir développer/tester l'application dans un environnement docker tout en utilisant le point d'entrée `app_dev.php`, ~~il est nécessaire d'autoriser les ips utilisées par le réseau que docker crée sur la machine.~~ une variable d'environnement doit permettre son utilisation.

## Proposition

- [x] modifier le fichier `web/app_dev.php` et tester la présence de la variable d'environnement `DEV_MODE_ENABLED`