### PR TITLE
Annulation créneau moins de 48h à l'avance

### DIFF
--- a/app/Resources/views/booking/_partial/home_shift.html.twig
+++ b/app/Resources/views/booking/_partial/home_shift.html.twig
@@ -5,11 +5,7 @@
             <i class="material-icons">person</i>{{ shift.shifter.firstname }} / <b class="{{ shift.job.color }}-text">{{ shift.job.name }}</b>
         </p>
     </div>
-    {% if (shift.getIsUpcoming()) %}
-        <div class="card-action">
-            <a href="#contact{{ shift.id }}" class="modal-trigger"><i class="material-icons right">more</i></a><span>à venir</span>
-        </div>
-    {% elseif (shift.getIsCurrent()) %}
+    {% if (shift.getIsCurrent()) %}
         <div class="card-action">
             <a href="#contact{{ shift.id }}" id="more{{ shift.id }}" class="modal-trigger"><i class="material-icons right">more</i></a><span>créneau en cours</span>
         </div>
@@ -40,7 +36,10 @@
 
         {% else %}
             <div class="card-action">
-                <a href="#dismiss{{ shift.id }}" class="modal-trigger btn-flat red white-text">Annuler ?!</a>
+                <a href="#dismiss{{ shift.id }}" class="modal-trigger btn-flat red white-text">Annuler</a>
+                {% if (shift.getIsUpcoming()) %}
+                    <a href="#contact{{ shift.id }}" class="modal-trigger btn-flat" title="Contacter les bénévoles du créneau"><i class="material-icons">email</i></a>
+                {% endif %}
             </div>
             <div id="dismiss{{ shift.id }}" class="modal black-text">
                 <form action="{{ path('shift_dismiss',{'id':shift.id}) }}" method="post">

--- a/app/Resources/views/booking/_partial/home_shift_contactform.html.twig
+++ b/app/Resources/views/booking/_partial/home_shift_contactform.html.twig
@@ -45,7 +45,6 @@
         </div>
         <div class="responses row">
             <div class="chip orange lighten-4"><a href="#!" class="grey-text">Je suis en retard</a></div>
-            <div class="chip red lighten-4"><a href="#!" class="grey-text">Je ne vais pas pouvoir venir</a></div>
             <div class="chip blue lighten-4"><a href="#!" class="grey-text">Est-ce que tout va bien ?</a></div>
         </div>
     </div>

--- a/app/Resources/views/emails/dismissed_shift.html.twig
+++ b/app/Resources/views/emails/dismissed_shift.html.twig
@@ -1,0 +1,3 @@
+Le bénévole {{ beneficiary.displayName }} a annulé le créneau {{ shift.job.name }} du {{ shift.start | date('d-m-Y') }} de {{ shift.start | date('G\\hi') }} à {{ shift.end | date('G\\hi') }}<br />
+Raison renseigné par le bénévole:<br />
+{{ reason }}

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -94,6 +94,7 @@ services:
                 - { name: kernel.event_listener, event: code.new, method: onCodeNew }
                 - { name: kernel.event_listener, event: shift.booked, method: onShiftBooked }
                 - { name: kernel.event_listener, event: shift.deleted, method: onShiftDeleted }
+                - { name: kernel.event_listener, event: shift.dismissed, method: onShiftDismissed }
                 - { name: kernel.event_listener, event: member.cycle.start, method: onMemberCycleStart }
                 - { name: kernel.event_listener, event: member.cycle.half, method: onMemberCycleHalf }
                 - { name: kernel.event_listener, event: member.created, method: onMemberCreated }

--- a/src/AppBundle/Controller/BookingController.php
+++ b/src/AppBundle/Controller/BookingController.php
@@ -344,6 +344,7 @@ class BookingController extends Controller
         $beneficiary = $shift->getShifter();
         $em = $this->getDoctrine()->getManager();
         $shift->setShifter(null);
+        $shift->setBooker(null);
         $em->persist($shift);
         $em->flush();
 

--- a/src/AppBundle/Controller/BookingController.php
+++ b/src/AppBundle/Controller/BookingController.php
@@ -341,20 +341,15 @@ class BookingController extends Controller
             return $this->redirectToRoute("booking");
         }
 
-        $membership = $shift->getShifter()->getMembership();
-
+        $beneficiary = $shift->getShifter();
         $em = $this->getDoctrine()->getManager();
-
-        $shift->setIsDismissed(true);
-        $shift->setDismissedTime(new DateTime('now'));
-        $shift->setDismissedReason($request->get("reason"));
-        $shift->setShifter($shift->getBooker());
-
+        $shift->setShifter(null);
         $em->persist($shift);
         $em->flush();
 
+        $reason = $request->get("reason");
         $dispatcher = $this->get('event_dispatcher');
-        $dispatcher->dispatch(ShiftDismissedEvent::NAME, new ShiftDismissedEvent($shift, $membership));
+        $dispatcher->dispatch(ShiftDismissedEvent::NAME, new ShiftDismissedEvent($shift, $beneficiary, $reason));
 
         return $this->redirectToRoute('homepage');
     }

--- a/src/AppBundle/Event/ShiftDismissedEvent.php
+++ b/src/AppBundle/Event/ShiftDismissedEvent.php
@@ -2,7 +2,7 @@
 
 namespace AppBundle\Event;
 
-use AppBundle\Entity\Membership;
+use AppBundle\Entity\Beneficiary;
 use AppBundle\Entity\Shift;
 use Symfony\Component\EventDispatcher\Event;
 
@@ -11,20 +11,22 @@ class ShiftDismissedEvent extends Event
     const NAME = 'shift.dismissed';
 
     private $shift;
-    private $membership;
+    private $beneficiary;
+    private $reason;
 
-    public function __construct(Shift $shift, Membership $membership)
+    public function __construct(Shift $shift, Beneficiary $beneficiary, string $reason)
     {
         $this->shift = $shift;
-        $this->membership = $membership;
+        $this->beneficiary = $beneficiary;
+        $this->reason = $reason;
     }
 
     /**
-     * @return Membership
+     * @return Beneficiary
      */
-    public function getMembership()
+    public function getBeneficiary()
     {
-        return $this->membership;
+        return $this->beneficiary;
     }
 
     /**
@@ -33,5 +35,13 @@ class ShiftDismissedEvent extends Event
     public function getShift()
     {
         return $this->shift;
+    }
+
+    /**
+     * @return string
+     */
+    public function getReason()
+    {
+        return $this->reason;
     }
 }

--- a/src/AppBundle/EventListener/TimeLogEventListener.php
+++ b/src/AppBundle/EventListener/TimeLogEventListener.php
@@ -69,7 +69,6 @@ class TimeLogEventListener
         }
     }
 
-
     /**
      * @param ShiftDismissedEvent $event
      * @throws \Doctrine\ORM\ORMException
@@ -77,7 +76,7 @@ class TimeLogEventListener
     public function onShiftDismissed(ShiftDismissedEvent $event)
     {
         $this->logger->info("Time Log Listener: onShiftDismissed");
-        $this->deleteShiftLogs($event->getShift(), $event->getMembership());
+        $this->deleteShiftLogs($event->getShift(), $event->getBeneficiary()->getMembership());
     }
 
     /**


### PR DESCRIPTION
Ne pas bloquer l'annulation même au dernier moment.
En revanche, envoi d'un mail à l'adresse créneau si moins de 48 heures à l'avance.