### PR TITLE
Quick fixes for quick registrations

### DIFF
--- a/src/AppBundle/Controller/MembershipController.php
+++ b/src/AppBundle/Controller/MembershipController.php
@@ -15,6 +15,7 @@ use AppBundle\Entity\User;
 use AppBundle\Event\AnonymousBeneficiaryCreatedEvent;
 use AppBundle\Event\BeneficiaryAddEvent;
 use AppBundle\Event\MemberCreatedEvent;
+use AppBundle\EventListener\SetFirstPasswordListener;
 use AppBundle\Form\BeneficiaryType;
 use AppBundle\Form\MembershipType;
 use AppBundle\Form\NoteType;
@@ -624,6 +625,10 @@ class MembershipController extends Controller
             if (!$a_beneficiary){
                 $session->getFlashBag()->add('error', 'Cette url n\'est plus valide');
                 return $this->redirectToRoute("homepage");
+            }else{
+                if ($a_beneficiary->getJoinTo()){ //adding beneficiary to an existing membership : wrong place
+                    return $this->redirectToRoute('member_add_beneficiary', array('code' => $this->container->get('AppBundle\Helper\SwipeCard')->vigenereEncode($email)));
+                }
             }
         }
 

--- a/src/AppBundle/EventListener/SetFirstPasswordListener.php
+++ b/src/AppBundle/EventListener/SetFirstPasswordListener.php
@@ -2,6 +2,7 @@
 
 namespace AppBundle\EventListener;
 
+use AppBundle\Entity\Beneficiary;
 use AppBundle\Entity\Membership;
 use AppBundle\Entity\User;
 use Doctrine\ORM\EntityManagerInterface;
@@ -43,11 +44,11 @@ class SetFirstPasswordListener{
     {
         $entity = $args->getObject();
 
-        // only for users created trow "Membership" entity
-        if (!$entity instanceof Membership) {
+        // only for users created trow "Beneficiary" entity
+        if (!$entity instanceof Beneficiary) {
             return;
         }
-        $user = $entity->getMainBeneficiary()->getUser();
+        $user = $entity->getUser();
 
         if (!$user->getId()){
             $user->addRole(self::ROLE_PASSWORD_TO_SET);


### PR DESCRIPTION
- Mail with link sent on recall was wrong for case "adding to an existing membership"
- Adding redirect on case of wrong url used
- Force changing password on all beneficiary (not only the main one of a new membership)
- remove welcome mail on adding a new beneficiary on existing membership : done by another observer