### PR TITLE
♻️(user) refactoriser la génération aléatoire de mot de passe

### DIFF
--- a/src/AppBundle/Entity/User.php
+++ b/src/AppBundle/Entity/User.php
@@ -185,14 +185,7 @@ class User extends BaseUser
 
     static function randomPassword()
     {
-        $alphabet = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890';
-        $pass = array(); //remember to declare $pass as an array
-        $alphaLength = strlen($alphabet) - 1; //put the length -1 in cache
-        for ($i = 0; $i < 8; $i++) {
-            $n = rand(0, $alphaLength);
-            $pass[] = $alphabet[$n];
-        }
-        return implode($pass); //turn the array into a string
+        return \bin2hex(\random_bytes(20));
     }
 
     /**


### PR DESCRIPTION
## Objet

La fonction `User::randomPassword` ne génère pas vraiment un mot de passe aléatoire. Depuis php 7.0 il existe des méthodes permettant de générer de vraies chaine aléatoires qui peuvent être utilisées pour générer des mots de passe.

## Proposition

- [x] refactoriser la méthode `User::randomPassword`. A vérifier mais il se pourrait aussi que ce soit plus performant avec ces fonctions.