### PR TITLE
Alertes créneaux annulés

### DIFF
--- a/src/AppBundle/EventListener/EmailingEventListener.php
+++ b/src/AppBundle/EventListener/EmailingEventListener.php
@@ -193,7 +193,7 @@ class EmailingEventListener
         $beneficiary = $event->getBeneficiary();
         if ($shift->getIsUpcoming()) {
             $warn = (new \Swift_Message("[ESPACE MEMBRES] Crénéau annulé moins de 48 heures à l'avance"))
-                ->setFrom($this->container->getParameter('shift_mailer_user'))
+                ->setFrom($this->container->getParameter('transactional_mailer_user'))
                 ->setTo($this->container->getParameter('shift_mailer_user'))
                 ->setBody(
                     $this->renderView(


### PR DESCRIPTION
Changement du sender pour les alertes de créneaux annulés moins de 48h avant.

Apparemment quand un email est envoyé de creneaux@lelefan.org vers creneaux@lelefan.org, celui-ci n’apparaît pas dans l'interface de ticketing.