### PR TITLE
Ajout du numéro d'adhérent sur la page d'accueil

### DIFF
--- a/app/Resources/views/default/index.html.twig
+++ b/app/Resources/views/default/index.html.twig
@@ -15,7 +15,7 @@
         <div class="container center">
             <div class="section no-pad-bot">
                 <h3 class="header">
-                    Bonjour {% if app.user.beneficiary %}{{ app.user.beneficiary.firstname }}{% else %}{{ app.user.username }}{% endif %}</h3>
+                    Bonjour {% if app.user.beneficiary %}{{ app.user.beneficiary.firstname }}<br>#{{ app.user.beneficiary.membership.memberNumber }}{% else %}{{ app.user.username }}{% endif %}</h3>
                 {% if is_granted("ROLE_SUPER_ADMIN") %}
                     <p class="col s12">
                         <span class="orange-text">&lt;warning&gt;</span>


### PR DESCRIPTION
En plénière nous nous sommes rendu compte que les membres n'avait pas la possibilité de connaitre leur numéro d'adhérent, ce qui sera nécessaire pour l'inscrire sur les badges.

![Capture d’écran du 2019-05-16 20-15-35](https://user-images.githubusercontent.com/10038524/57877433-2661c280-7818-11e9-875d-b2764f200f0f.png)
 