### PR TITLE
Bugfix: Ne pas supprimer les logs de temps lors de la suppression d'un bénéficiaire

### DIFF
--- a/app/DoctrineMigrations/Version20190530085721_fix_time_log_cascade.php
+++ b/app/DoctrineMigrations/Version20190530085721_fix_time_log_cascade.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20190530085721_fix_time_log_cascade extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE time_log DROP FOREIGN KEY FK_55BE03AFBB70BC0E');
+        $this->addSql('ALTER TABLE time_log ADD CONSTRAINT FK_55BE03AFBB70BC0E FOREIGN KEY (shift_id) REFERENCES shift (id) ON DELETE SET NULL');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE time_log DROP FOREIGN KEY FK_55BE03AFBB70BC0E');
+        $this->addSql('ALTER TABLE time_log ADD CONSTRAINT FK_55BE03AFBB70BC0E FOREIGN KEY (shift_id) REFERENCES shift (id) ON DELETE CASCADE');
+    }
+}

--- a/src/AppBundle/Entity/Shift.php
+++ b/src/AppBundle/Entity/Shift.php
@@ -96,7 +96,7 @@ class Shift
     private $job;
 
     /**
-     * @ORM\OneToMany(targetEntity="TimeLog", mappedBy="shift",cascade={"persist", "remove"}, orphanRemoval=true)
+     * @ORM\OneToMany(targetEntity="TimeLog", mappedBy="shift")
      */
     private $timeLogs;
 

--- a/src/AppBundle/Entity/TimeLog.php
+++ b/src/AppBundle/Entity/TimeLog.php
@@ -66,7 +66,7 @@ class TimeLog
 
     /**
      * @ORM\ManyToOne(targetEntity="Shift", inversedBy="timeLogs")
-     * @ORM\JoinColumn(name="shift_id", referencedColumnName="id", onDelete="CASCADE")
+     * @ORM\JoinColumn(name="shift_id", referencedColumnName="id", onDelete="SET NULL")
      */
     private $shift;
 


### PR DESCRIPTION
Découvert suite à un ticket d'une membre qui s'est retrouvée en retard de ses créneaux d'un coup. La suppression de sa deuxième bénéficiaire avait supprimé tous les log de temps associés.

Pour être plus propre et garder aussi l'historique des créneaux il ne faudrait pas supprimer les bénéficiaires mais avoir une fonctionnalité qui permet de les désactiver. Mais c'est pas urgent, le cas est assez rare. 