### PR TITLE
Amélioration du label du menu pour geler son compte

### DIFF
--- a/app/Resources/views/Profile/show_content.html.twig
+++ b/app/Resources/views/Profile/show_content.html.twig
@@ -18,7 +18,7 @@
             </div>
         </li>
         <li>
-            <div class="collapsible-header"><i class="material-icons">build</i>Actions</div>
+            <div class="collapsible-header"><i class="material-icons">ac_unit</i>Gel du compte</div>
             <div class="collapsible-body">
                 {% include "member/_partial/frozen.html.twig" with { member: member  } %}
             </div>


### PR DESCRIPTION
Actuellement il faut ouvrir le collapsible panel 'Actions' pour geler son compte, ce n'est pas très intuitif.
Sachant qu'il n'y a que cette fonctionnalité dans ce panel j'ai renommé en Gel du compte.