### PR TITLE
Ne pas limiter le nombre de contributions

### DIFF
--- a/app/Resources/views/booking/home_dashboard.html.twig
+++ b/app/Resources/views/booking/home_dashboard.html.twig
@@ -45,10 +45,11 @@
                 <p><i class="material-icons">warning</i> Pense à réserver tes créneaux. <br>Tu as
                     encore {{ remaining | duration_from_minutes }} à réserver.</p>
             {% else %}
+                {% set duration_to_book = (shift_service.shiftTimeByCycle(member) - member.timeCount(member.endOfCycle)) %}
                 <p>Bravo
                     ! {% if member.beneficiaries | length %}Vos{% else %}Tes{% endif %} {{ due_duration_by_cycle | duration_from_minutes }}
                     ont été planifiées sur le cycle actuel.</p>
-                {% if beneficiariesWhoCanBook | length > 0 %}
+                {% if beneficiariesWhoCanBook | length > 0 and duration_to_book > 0%}
                     <p>
                         {% if beneficiariesWhoCanBook | length > 1 %}
                             {% for b in beneficiariesWhoCanBook %} {{ b.firstname }} {% if loop.index < loop.length %} et {% endif %}{% endfor %}peuvent

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -101,3 +101,5 @@ parameters:
     logging.swiftmailer.recipient: ~
 
     new_users_start_as_beginner: true
+
+    unlimited_book_duration: false

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -134,6 +134,7 @@ services:
                 - "%due_duration_by_cycle%"
                 - "%min_shift_duration%"
                 - "%new_users_start_as_beginner%"
+                - "%unlimited_book_duration%"
 
     logger.user_processor:
             class: AppBundle\Monolog\MonologUserProcessor

--- a/src/AppBundle/Service/ShiftService.php
+++ b/src/AppBundle/Service/ShiftService.php
@@ -18,13 +18,15 @@ class ShiftService
     protected $due_duration_by_cycle;
     protected $min_shift_duration;
     private $newUserStartAsBeginner;
+    private $unlimitedBookDuration;
 
-    public function __construct($em, $due_duration_by_cycle, $min_shift_duration, $newUserStartAsBeginner)
+    public function __construct($em, $due_duration_by_cycle, $min_shift_duration, $newUserStartAsBeginner, $unlimitedBookDuration)
     {
         $this->em = $em;
         $this->due_duration_by_cycle = $due_duration_by_cycle;
         $this->min_shift_duration = $min_shift_duration;
         $this->newUserStartAsBeginner = $newUserStartAsBeginner;
+        $this->unlimitedBookDuration = $unlimitedBookDuration;
     }
 
     /**
@@ -67,6 +69,10 @@ class ShiftService
      */
     public function canBookDuration(Beneficiary $beneficiary, $duration, $cycle = 0)
     {
+        if (true === $this->unlimitedBookDuration) {
+            return true;
+        }
+
         $member = $beneficiary->getMembership();
         $beneficiary_counter = $beneficiary->getTimeCount($cycle);
 

--- a/tests/AppBundle/Service/ShiftServiceTest.php
+++ b/tests/AppBundle/Service/ShiftServiceTest.php
@@ -27,7 +27,7 @@ class ShiftServiceTest extends TestCase
             ->getMockBuilder(EntityManager::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->shiftService = new ShiftService($this->em, 180, 90, false);
+        $this->shiftService = new ShiftService($this->em, 180, 90, false, false);
     }
 
     public function testShiftTimeByCycle()
@@ -86,7 +86,7 @@ class ShiftServiceTest extends TestCase
         $shiftService = $this
             ->getMockBuilder(ShiftService::class)
             ->setMethods(['isShiftEmpty', 'canBookDuration', 'isBeginner'])
-            ->setConstructorArgs([$this->em, 180, 90, false])
+            ->setConstructorArgs([$this->em, 180, 90, false, false])
             ->getMock()
         ;
         $shiftService->expects($this->any())
@@ -130,7 +130,7 @@ class ShiftServiceTest extends TestCase
         $shiftService = $this
             ->getMockBuilder(ShiftService::class)
             ->setMethods(['hasPreviousValidShifts'])
-            ->setConstructorArgs([$this->em, 180, 90, $newUserStartAsBeginner])
+            ->setConstructorArgs([$this->em, 180, 90, $newUserStartAsBeginner, false])
             ->getMock()
         ;
 


### PR DESCRIPTION
Dans notre coop, le nombre de contributions par cycles n'est pas limité. Plus exactement, une fois le temps minimum de contribution atteint il est possible d'en fait plus. Dans notre cas il faut réaliser 2h30/mois mais je souhaite en faire 5h notre règlement le permet. Pour cette formation nous n'avons pas le choix en réalité.

Ce sujet a été discuté sur l'issue #317 et @janssens a suggéré d'introduire un paramètre permettant d'avoir une durée de contribution illimitée.

Je me suis penché sur le sujet, cette première contribution est naive, je me suis basé sur ce que j'ai trouvé en parcourant les templates et formulaires. En gros je ne désactive pas les créneaux, je permets ainsi de m'inscrire autant de fois que je le souhaite. Et sur la homepage j'ai fait un changement pour avoir des messages cohérents.

Il y a certainement d'autres points à modifier mais... je ne sais pas lesquels. J'attends vos retours :-)