### PR TITLE
fix 'Call to a member function getMainBeneficiary() on null'

### DIFF
--- a/src/AppBundle/Controller/MembershipController.php
+++ b/src/AppBundle/Controller/MembershipController.php
@@ -454,6 +454,13 @@ class MembershipController extends Controller
             $em = $this->getDoctrine()->getManager();
             $ms = $em->getRepository('AppBundle:Membership')->findOneBy(array('member_number' => $member_number));
 
+            if (!$ms){
+                $request->getSession()->getFlashBag()->add('warning', 'Oups, aucun membre trouvé avec ce numéro d\'adhérent');
+                return $this->render('user/tools/find_me.html.twig', array(
+                    'form' => $form->createView(),
+                ));
+            }
+
             return $this->render('beneficiary/confirm.html.twig', array(
                 'beneficiary' => $ms->getMainBeneficiary(),
             ));


### PR DESCRIPTION
fix

> CRITICAL
> 
> Uncaught PHP Exception Symfony\Component\Debug\Exception\FatalThrowableError: "Call to a member function getMainBeneficiary() on null" at /var/www/membres/src/AppBundle/Controller/MembershipController.php line 458
> Extra
>     "user": "anon."
> }
> Context
>     "exception": {
>         "class": "Symfony\\Component\\Debug\\Exception\\FatalThrowableError",
>         "message": "Call to a member function getMainBeneficiary() on null",
>         "code": 0,
>         "file": "\/var\/www\/membres\/src\/AppBundle\/Controller\/MembershipController.php:458",
>         "trace": [
>             "\/var\/www\/membres\/vendor\/symfony\/symfony\/src\/Symfony\/Component\/HttpKernel\/HttpKernel.php:151",
>             "\/var\/www\/membres\/vendor\/symfony\/symfony\/src\/Symfony\/Component\/HttpKernel\/HttpKernel.php:68",
>             "\/var\/www\/membres\/vendor\/symfony\/symfony\/src\/Symfony\/Component\/HttpKernel\/Kernel.php:200",
>             "\/var\/www\/membres\/web\/app.php:19"
>         ]
>     }
> }