### PR TITLE
paiements HelloAsso. "last_registration_id n'est pas mis à jour"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ LICENSE
 .buildpath
 .gitignore.swp
 .project
+.env
 .settings/
 
 #script to download and import last prod DB to develop in local env

--- a/app/DoctrineMigrations/Version20200125080621.php
+++ b/app/DoctrineMigrations/Version20200125080621.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20200125080621 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE membership DROP FOREIGN KEY FK_86FFD2856986CF73');
+        $this->addSql('DROP INDEX UNIQ_86FFD2856986CF73 ON membership');
+        $this->addSql('ALTER TABLE membership DROP last_registration_id');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE membership ADD last_registration_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE membership ADD CONSTRAINT FK_86FFD2856986CF73 FOREIGN KEY (last_registration_id) REFERENCES registration (id) ON DELETE CASCADE');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_86FFD2856986CF73 ON membership (last_registration_id)');
+    }
+}

--- a/src/AppBundle/Command/DoctorCommand.php
+++ b/src/AppBundle/Command/DoctorCommand.php
@@ -115,11 +115,6 @@ class DoctorCommand extends ContainerAwareCommand
             $em = $this->getContainer()->get('doctrine')->getManager();
             $members = $em->getRepository('AppBundle:Membership')->findAll();
             foreach ($members as $member) {
-                if ($member->getRegistrations()->count() && $member->getRegistrations()->first())
-                    $member->setLastRegistration($member->getRegistrations()->first());
-                else
-                    $member->setLastRegistration();
-                $em->persist($member);
                 foreach ($member->getRegistrations() as $registration) {
                     if ($registration->getCreatedAt()->format('Y') < 0) {
                         $registration->setCreatedAt($registration->getDate());

--- a/src/AppBundle/Command/ImportUsersCommand.php
+++ b/src/AppBundle/Command/ImportUsersCommand.php
@@ -209,16 +209,6 @@ class ImportUsersCommand extends CsvCommand
                         $registration->setRegistrar($registrar);
                         $registration->setMode($mode);
                         $em->persist($registration);
-
-                        if ($membership_is_new){
-                            $membership->setLastRegistration($registration);
-                            $em->persist($membership);
-                        }else if ($membership->getLastRegistration()){
-                            if ($membership->getLastRegistration()->getDate()<$registration->getDate()){
-                                $membership->setLastRegistration($registration);
-                                $em->persist($membership);
-                            }
-                        }
                     }
 
                     foreach ($commissions as $commission_id){

--- a/src/AppBundle/Controller/MembershipController.php
+++ b/src/AppBundle/Controller/MembershipController.php
@@ -686,8 +686,7 @@ class MembershipController extends Controller
                 if (!$member->getLastRegistration()->getRegistrar())
                     $member->getLastRegistration()->setRegistrar($this->getUser());
             } else if ($a_beneficiary->getMode() === Registration::TYPE_HELLOASSO) {
-                $member->removeRegistration($member->getLastRegistration());
-                $member->setLastRegistration(null);
+                $member->removeRegistration($registration); //no registration yet
             }
 
             $member->setWithdrawn(false);

--- a/src/AppBundle/Entity/Membership.php
+++ b/src/AppBundle/Entity/Membership.php
@@ -62,13 +62,6 @@ class Membership
     private $registrations;
 
     /**
-     * @ORM\OneToOne(targetEntity="Registration",cascade={"persist"})
-     * @ORM\JoinColumn(name="last_registration_id", referencedColumnName="id", onDelete="CASCADE")
-     * @Assert\Valid
-     */
-    private $lastRegistration;
-
-    /**
      * @ORM\OneToMany(targetEntity="Beneficiary", mappedBy="membership", cascade={"persist", "remove"})
      */
     private $beneficiaries;
@@ -167,11 +160,6 @@ class Membership
     public function addRegistration(\AppBundle\Entity\Registration $registration)
     {
         $this->registrations[] = $registration;
-
-        if (!$this->getLastRegistration() || $registration->getDate() > $this->getLastRegistration()->getDate()){
-            $this->setLastRegistration($registration);
-        }
-
         return $this;
     }
 
@@ -183,12 +171,6 @@ class Membership
     public function removeRegistration(\AppBundle\Entity\Registration $registration)
     {
         $this->registrations->removeElement($registration);
-
-        if ($this->getLastRegistration() === $registration){
-            if ($this->getRegistrations()->count()){
-                $this->setLastRegistration($this->getRegistrations()->first());
-            }
-        }
     }
 
     /**
@@ -373,25 +355,13 @@ class Membership
     }
 
     /**
-     * Set lastRegistration
-     *
-     * @param \AppBundle\Entity\Registration $lastRegistration
-     *
-     * @return Membership
-     */
-    public function setLastRegistration(\AppBundle\Entity\Registration $lastRegistration = null)
-    {
-        $this->lastRegistration = $lastRegistration;
-        return $this;
-    }
-    /**
      * Get lastRegistration
      *
      * @return \AppBundle\Entity\Registration
      */
     public function getLastRegistration()
     {
-        return $this->lastRegistration;
+        return $this->getRegistrations()->first();
     }
 
     /**

--- a/src/AppBundle/EventListener/HelloassoEventListener.php
+++ b/src/AppBundle/EventListener/HelloassoEventListener.php
@@ -102,8 +102,10 @@ class HelloassoEventListener
                 $registration->setAmount($payment->getAmount());
                 $registration->setCreatedAt($payment->getDate()); //created at payment date
 
-                if ($beneficiary->getMembership()->getLastRegistration()){
-                    $expire = clone $beneficiary->getMembership()->getExpire();
+                $membership = $beneficiary->getMembership();
+
+                if ($membership->getLastRegistration()){
+                    $expire = clone $membership->getExpire();
                     if ($expire > $payment->getDate()) // a least one year
                         $registration->setDate($expire);
                     else
@@ -114,15 +116,16 @@ class HelloassoEventListener
 
                 $registration->setHelloassoPayment($payment);
                 $registration->setMode(Registration::TYPE_HELLOASSO);
-                $registration->setMembership($beneficiary->getMembership());
+                $registration->setMembership($membership);
 
                 $this->_em->persist($registration);
                 $payment->setRegistration($registration);
-                $beneficiary->getMembership()->addRegistration($registration);
+                $membership->addRegistration($registration);
 
-                if ($beneficiary->getMembership()->isWithdrawn()){
-                    $beneficiary->getMembership()->setWithdrawn(false); //open
+                if ($membership->isWithdrawn()){
+                    $membership->setWithdrawn(false); //open
                 }
+                $this->_em->persist($membership);
 
                 $this->_em->flush();
 


### PR DESCRIPTION
Suppression de l'attribut et utilisation de la liste des registrations triée par date.