### PR TITLE
Rajout de plusieurs fonctionnalités pour modifier facilement un créneau existant

### DIFF
--- a/app/Resources/views/admin/booking/_partial/shift.html.twig
+++ b/app/Resources/views/admin/booking/_partial/shift.html.twig
@@ -62,11 +62,13 @@
                 {% if shift.shifter %}{# is booked #}
                     <li id="shift{{ shift.id }}">
                         <div class="collapsible-header">
-                        {% if shift.formation %}<b data-formation="{{ shift.formation.name }}">{% endif %}
-                            #{{ shift.shifter.membership.memberNumber }}&nbsp;{{ shift.shifter.firstname }}&nbsp;{{ shift.shifter.lastname }}
-                            {% if shift.formation %}</b>&nbsp;({{ shift.formation.name }}){% endif %}
-                            {% if not shift.formation and shift.shifter.formations | length > 0 %}&nbsp;<b class="orange-text">({{ shift.shifter.formations | join(', ') }})</b>{% endif %}
-                            {% if shift.isDismissed() %}<div class="red-text" style="padding-left: 5px">(en attente de reprise)</div>{% endif %}
+                            <div class="col s12">
+                                {% if shift.formation %}<b data-formation="{{ shift.formation.name }}">{% endif %}
+                                #{{ shift.shifter.membership.memberNumber }}&nbsp;{{ shift.shifter.firstname }}&nbsp;{{ shift.shifter.lastname }}
+                                {% if shift.formation %}</b>&nbsp;({{ shift.formation.name }}){% endif %}
+                                {% if not shift.formation and shift.shifter.formations | length > 0 %}&nbsp;<b class="orange-text">({{ shift.shifter.formations | join(', ') }})</b>{% endif %}
+                                {% if shift.isDismissed() %}<div class="red-text" style="padding-left: 5px">(en attente de reprise)</div>{% endif %}
+                            </div>
                         </div>
                         <div class="collapsible-body">
                             {% if use_fly_and_fixed %}
@@ -89,25 +91,35 @@
                 {% else %}
                     <li id="shift{{ shift.id }}">
                         <div class="collapsible-header">
-                            {% if shift.formation %}
-                                <b data-formation="{{ shift.formation.name }}">
-                            {% else %}
-                                <b>
-                            {% endif %}
+                            <div class="col {% if not shift.lastShifter %}s11{% else %}s12{% endif %}">
+                                {% if shift.formation %}
+                                    <b data-formation="{{ shift.formation.name }}">
+                                {% else %}
+                                    <b>
+                                {% endif %}
                                 <span style="font-style: italic">
-                            {% if shift.lastShifter %}réservé à {{ shift.lastShifter.displayName }}
-                            {% else %}libre
-                            {% endif %}
-                            </span>
-                            {% if shift.formation %}
-                                </b>&nbsp;({{ shift.formation.name }})
-                            {% else %}
-                                </b>&nbsp;(sans formation particulière)
+                                    {% if shift.lastShifter %}réservé à {{ shift.lastShifter.displayName }}
+                                    {% else %}libre
+                                    {% endif %}
+                                </span>
+                                {% if shift.formation %}
+                                    </b>&nbsp;({{ shift.formation.name }})
+                                {% else %}
+                                    </b>&nbsp;(sans formation particulière)
+                                {% endif %}
+                            </div>
+                            {% if not shift.lastShifter %}
+                                <div class="col s1 right-align">
+                                    {{ form_start(shift_delete_form[shift.id]) }}
+                                    {{ form_widget(shift_delete_form[shift.id]) }}
+                                    <a href="#" onclick="var r = confirm('Supprimer ce poste ?!'); if (r == true) {$(this).closest('form').submit();}; event.stopPropagation();" title="Supprimer ce poste" class="red-text">✗</a>
+                                    {{ form_end(shift_delete_form[shift.id]) }}
+                                </div>
                             {% endif %}
                         </div>
                         <div class="collapsible-body">
                                 <div class="row">
-                                    <div class="input-field col {% if use_fly_and_fixed %}s7{% else %}s9{% endif %}">
+                                    <div class="col {% if use_fly_and_fixed %}s7{% else %}s9{% endif %}">
                                         <input id ="benef{{ shift.id }}" type="text" class="empty-shift" name="beneficiary" placeholder="Beneficiaire">
                                     </div>
                                     {% if use_fly_and_fixed %}

--- a/app/Resources/views/admin/booking/_partial/shift.html.twig
+++ b/app/Resources/views/admin/booking/_partial/shift.html.twig
@@ -153,13 +153,16 @@
         </a>
         {% if bucket.first.locked %}
             <a href="{{ path('unlock_shift', {'id':  bucket.first.id }) }}" class="btn orange">
-                <i class="material-icons left">unlock</i>Déverrouiller ce créneau
+                <i class="material-icons left">unlock</i>Déverrouiller
             </a>
         {% else %}
             <a href="{{ path('lock_shift', {'id':  bucket.first.id }) }}" class="btn orange">
-                <i class="material-icons left">lock</i>Verrouiller ce créneau
+                <i class="material-icons left">lock</i>Verrouiller
             </a>
         {% endif %}
+        <a href="{{ path('shift_edit', {'id':  bucket.first.id }) }}" class="btn deep-purple">
+            <i class="material-icons left">edit</i>Editer
+        </a>
         <a href="#" title="Supprimer tous les créneaux à cette heure et ce poste" onclick="var r = confirm('Supprimer les créneaux et les réservations ?!'); if (r == true) {
             $('#form_shift_id').val({{ bucket.first.id }});$('#delete_bucket').submit();}" class="red btn">
             <i class="material-icons left">delete</i>Supprimer

--- a/app/Resources/views/admin/booking/_partial/shift.html.twig
+++ b/app/Resources/views/admin/booking/_partial/shift.html.twig
@@ -148,6 +148,25 @@
                 {% endif %}
             {% endfor %}
         </ul>
+        {{ form_start(shift_add_form[bucket.first.id]) }}
+        {{ form_widget(shift_add_form[bucket.first.id].date) }}
+        {{ form_widget(shift_add_form[bucket.first.id].start) }}
+        {{ form_widget(shift_add_form[bucket.first.id].end) }}
+        {{ form_widget(shift_add_form[bucket.first.id].job) }}
+        <div class="row valign-wrapper">
+            <div class="col s3">
+                {{ form_label(shift_add_form[bucket.first.id].number) }}
+                {{ form_widget(shift_add_form[bucket.first.id].number) }}
+            </div>
+            <div class="col s6">
+                {{ form_label(shift_add_form[bucket.first.id].formation) }}
+                {{ form_widget(shift_add_form[bucket.first.id].formation) }}
+            </div>
+            <div class="col s3">
+                <button type="submit" class="btn waves-effect waves-light teal"><i class="material-icons left">add</i>Ajouter</button>
+            </div>
+        </div>
+        {{ form_end(shift_add_form[bucket.first.id]) }}
         <a href="{{ path('mail_bucketshift', {'id':  bucket.first.id }) }}" class="btn">
             <i class="material-icons left">mail</i>Envoyer un email aux membres
         </a>

--- a/app/Resources/views/admin/shift/edit.html.twig
+++ b/app/Resources/views/admin/shift/edit.html.twig
@@ -1,0 +1,19 @@
+{% extends 'layout.html.twig' %}
+
+{% block breadcrumps %}
+    <a href="{{ path('homepage') }}"><i class="material-icons">home</i></a> <i class="material-icons">chevron_right</i>
+    <a href="{{ path('admin') }}"><i class="material-icons">tune</i>admin</a> <i class="material-icons">chevron_right</i>
+    <a href="{{ path('booking_admin') }}"><i class="material-icons">date_range</i>Créneaux admin</a> <i class="material-icons">chevron_right</i>
+    <i class="material-icons">add</i>Editer
+{% endblock %}
+
+{% block content %}
+    <h4> Editer créneau / <span class="{{ shift.job.color }}-text">{{ shift.job.name }}</span></h4>
+    <h5>{{ shift.start|date_fr_long }} de {{ shift.start|date('G\\hi') }} à {{ shift.end|date('G\\hi') }}</h5>
+    {{ form_start(form) }}
+    {{ form_widget(form) }}
+    <div>
+        <button type="submit" class="btn waves-effect waves-light">Sauvegarder</button>
+    </div>
+    {{ form_end(form) }}
+{% endblock %}

--- a/src/AppBundle/Controller/BookingController.php
+++ b/src/AppBundle/Controller/BookingController.php
@@ -229,13 +229,22 @@ class BookingController extends Controller
                 ->add('shift_id', HiddenType::class)
                 ->getForm();
 
+            $shift_delete_form = array();
+            foreach ($shifts as $shift) {
+                $shift_delete_form[$shift->getId()] = $this->createFormBuilder()
+                    ->setAction($this->generateUrl('shift_delete', array('id' => $shift->getId())))
+                    ->setMethod('DELETE')
+                    ->getForm()->createView();
+            }
+
             return $this->render('admin/booking/index.html.twig', [
                 'form' => $form->createView(),
                 'bucketsByDay' => $bucketsByDay,
                 'hours' => $hours,
                 'jobs' => $jobs,
                 'delete_bucket_form' => $delete_bucket_form->createView(),
-                'beneficiaries' => $beneficiaries
+                'beneficiaries' => $beneficiaries,
+                'shift_delete_form' => $shift_delete_form
             ]);
         }
     }

--- a/src/AppBundle/Controller/BookingController.php
+++ b/src/AppBundle/Controller/BookingController.php
@@ -231,11 +231,18 @@ class BookingController extends Controller
                 ->getForm();
 
             $shift_delete_form = array();
+            $shift_add_form = array();
             foreach ($shifts as $shift) {
                 $shift_delete_form[$shift->getId()] = $this->createFormBuilder()
                     ->setAction($this->generateUrl('shift_delete', array('id' => $shift->getId())))
                     ->setMethod('DELETE')
                     ->getForm()->createView();
+                $shift_add_form[$shift->getId()] = $this->createForm(
+                    ShiftType::class,
+                    $shift,
+                    array('action' => $this->generateUrl('shift_new'), 'only_add_formation' => true)
+                  )
+                ->createView();
             }
 
             return $this->render('admin/booking/index.html.twig', [
@@ -245,7 +252,8 @@ class BookingController extends Controller
                 'jobs' => $jobs,
                 'delete_bucket_form' => $delete_bucket_form->createView(),
                 'beneficiaries' => $beneficiaries,
-                'shift_delete_form' => $shift_delete_form
+                'shift_delete_form' => $shift_delete_form,
+                'shift_add_form' => $shift_add_form
             ]);
         }
     }

--- a/src/AppBundle/Controller/ShiftController.php
+++ b/src/AppBundle/Controller/ShiftController.php
@@ -63,4 +63,31 @@ class ShiftController extends Controller
         ));
     }
 
+    /**
+     * remove a shift.
+     *
+     * @Route("/shift/{id}", name="shift_delete")
+     * @Security("has_role('ROLE_SHIFT_MANAGER')")
+     * @Method("DELETE")
+     */
+    public function removeShiftAction(Request $request, Shift $shift)
+    {
+        $session = new Session();
+
+        $form = $this->createFormBuilder()
+            ->setAction($this->generateUrl('shift_delete', array('id' => $shift->getId())))
+            ->setMethod('DELETE')
+            ->getForm();
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $em = $this->getDoctrine()->getManager();
+            $em->remove($shift);
+            $em->flush();
+            $session->getFlashBag()->add('success', 'Le créneau a bien été supprimé !');
+        }
+
+        return $this->redirectToRoute('booking_admin');
+    }
+
 }

--- a/src/AppBundle/Controller/ShiftController.php
+++ b/src/AppBundle/Controller/ShiftController.php
@@ -55,7 +55,7 @@ class ShiftController extends Controller
             $em->persist($shift);
             $em->flush();
             $session->getFlashBag()->add('success', 'Le créneau a bien été créé !');
-            return $this->redirectToRoute('admin');
+            return $this->redirectToRoute('booking_admin');
         }
 
         return $this->render('admin/shift/new.html.twig', array(

--- a/src/AppBundle/Form/DataTransformer/JobToNumberTransformer.php
+++ b/src/AppBundle/Form/DataTransformer/JobToNumberTransformer.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace AppBundle\Form\DataTransformer;
+
+use AppBundle\Entity\Job;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Form\DataTransformerInterface;
+use Symfony\Component\Form\Exception\TransformationFailedException;
+
+class JobToNumberTransformer implements DataTransformerInterface
+{
+    private $entityManager;
+
+    public function __construct(EntityManagerInterface $entityManager)
+    {
+        $this->entityManager = $entityManager;
+    }
+
+    /**
+    * Transforms an object (job) to a string (id).
+    *
+    * @param  Job|null $job
+    * @return string
+    */
+    public function transform($job)
+    {
+        if (null === $job) {
+            return '';
+        }
+
+        return $job->getId();
+    }
+
+    /**
+     * Transforms a string (id) to an object (job).
+     *
+     * @param  string $jobId
+     * @return Job
+     * @throws TransformationFailedException if object (job) is not found
+     */
+    public function reverseTransform($jobId)
+    {
+        if (!$jobId) {
+            return;
+        }
+
+        $job = $this->entityManager
+                    ->getRepository(Job::class)
+                    ->find($jobId)
+        ;
+
+        if (null === $job) {
+            throw new TransformationFailedException(sprintf(
+                'Aucune formation ne correspond à l\'id "%s" !',
+                $jobId
+            ));
+        }
+
+        return $job;
+    }
+}

--- a/src/AppBundle/Form/ShiftType.php
+++ b/src/AppBundle/Form/ShiftType.php
@@ -4,49 +4,73 @@ namespace AppBundle\Form;
 
 use AppBundle\Entity\Shift;
 use AppBundle\Repository\JobRepository;
+use AppBundle\Form\DataTransformer\JobToNumberTransformer;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\DataMapperInterface;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ShiftType extends AbstractType implements DataMapperInterface
 {
+
+    private $transformer;
+
+    public function __construct(JobToNumberTransformer $transformer)
+    {
+        $this->transformer = $transformer;
+    }
+
     /**
      * {@inheritdoc}
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder
-            ->add('date', TextType::class, array('label' => 'Date', 'attr' => array('class' => 'datepicker')))
-            ->add('start', TextType::class, array('label' => 'Heure de début', 'attr' => array('class' => 'timepicker')))
-            ->add('end', TextType::class, array('label' => 'Heure de fin', 'attr' => array('class' => 'timepicker')))
-            ->add('job', EntityType::class, array(
-                'label' => 'Type',
-                'class' => 'AppBundle:Job',
-                'choice_label' => 'name',
-                'multiple' => false,
-                'required' => true,
-                'query_builder' => function(JobRepository $repository) {
-                    $qb = $repository->createQueryBuilder('j');
-                    return $qb
-                        ->where($qb->expr()->eq('j.enabled', '?1'))
-                        ->setParameter('1', '1')
-                        ->orderBy('j.name', 'ASC');
-                }
-            ))
-            ->setDataMapper($this);
+        if (!$options['only_add_formation']) {
+            $builder
+                ->add('date', TextType::class, array('label' => 'Date', 'attr' => array('class' => 'datepicker')))
+                ->add('start', TextType::class, array('label' => 'Heure de début', 'attr' => array('class' => 'timepicker')))
+                ->add('end', TextType::class, array('label' => 'Heure de fin', 'attr' => array('class' => 'timepicker')))
+                ->add('job', EntityType::class, array(
+                    'label' => 'Type',
+                    'class' => 'AppBundle:Job',
+                    'choice_label' => 'name',
+                    'multiple' => false,
+                    'required' => true,
+                    'query_builder' => function(JobRepository $repository) {
+                        $qb = $repository->createQueryBuilder('j');
+                        return $qb
+                            ->where($qb->expr()->eq('j.enabled', '?1'))
+                            ->setParameter('1', '1')
+                            ->orderBy('j.name', 'ASC');
+                    }
+                ))
+                ->setDataMapper($this);
+        } else {
+            $builder
+                ->add('date', HiddenType::class)
+                ->add('start', HiddenType::class)
+                ->add('end', HiddenType::class)
+                ->add('job', HiddenType::class);
 
-        $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) {
+            $builder->get("job")
+                    ->addModelTransformer($this->transformer);
+            $builder
+                ->setDataMapper($this);
+        }
+
+        $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) use ($options) {
             $shift = $event->getData();
             $form = $event->getForm();
 
             // checks if the Shift object is "new"
             // If no data is passed to the form, the data is "null".
-            if (!$shift || null === $shift->getId()) {
+            if (!$shift || null === $shift->getId() || $options['only_add_formation']) {
                 $form->add('formation', EntityType::class, array(
                     'label' => 'Formation',
                     'class' => 'AppBundle:Formation',
@@ -125,5 +149,12 @@ class ShiftType extends AbstractType implements DataMapperInterface
         if (array_key_exists('formation', $forms)) {
             $data->setFormation($forms['formation']->getData());
         }
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'only_add_formation' => false,
+        ]);
     }
 }


### PR DESCRIPTION
Cette PR rajoute le possibilité de :
- supprimer un role d'un créneau
- rajouter un role dans un créneau existant depuis la page 'Gérer les créneaux'
- éditer un créneau pour modifier la date, l'heure de début/fin et le type de créneau