### PR TITLE
Add the possibility to do more shifts if some are available in the next following days

### DIFF
--- a/app/Resources/views/booking/_partial/list.html.twig
+++ b/app/Resources/views/booking/_partial/list.html.twig
@@ -8,7 +8,7 @@
         {% endif %}
         {% for bucketsByjob in bucketsByDay %}
         <li>
-            <div class="collapsible-header {% if (not beneficiary or shift_service.canBookOnCycle(beneficiary,current_cycle)) %}active {% else %}not-allowed {% endif %}"><i class="material-icons">{% if (not beneficiary or shift_service.canBookOnCycle(beneficiary,current_cycle)) %}event_available{% else %}event_busy{% endif %}</i>{{ (bucketsByjob|first|first).start|date_fr_long }}</div>
+            <div class="collapsible-header {% if (not beneficiary or shift_service.canBookOnCycle(beneficiary,current_cycle) or shift_service.canBookExtraShiftBucket(beneficiary, bucketsByjob|first|first)) %}active {% else %}not-allowed {% endif %}"><i class="material-icons">{% if (not beneficiary or shift_service.canBookOnCycle(beneficiary,current_cycle)  or shift_service.canBookExtraShiftBucket(beneficiary, bucketsByjob|first|first)) %}event_available{% else %}event_busy{% endif %}</i>{{ (bucketsByjob|first|first).start|date_fr_long }}</div>
             <div class="collapsible-body" style="padding: 1rem 0">
                 {% for buckets in bucketsByjob %}
                     <div class="row" style="display: flex;min-height: 40px;">
@@ -34,7 +34,7 @@
                                     {% endfor %}
                                     {# / compute lines #}
                                     {% if shift_service.isBucketBookable(bucket, beneficiary) or not beneficiary %}
-                                        {% include "booking/_partial/shift.html.twig" with { beneficiary: beneficiary, user: app.user, bucket: bucket, start: hours|first, end: hours|last, line:l  } %}
+                                        {% include "booking/_partial/shift.html.twig" with { beneficiary: beneficiary, user: app.user, bucket: bucket, start: hours|first, end: hours|last, line:l, cycle: current_cycle  } %}
                                     {% else %}
                                         {% include "booking/_partial/disabled_shift.html.twig" with { bucket: bucket,start: hours|first, end: hours|last, line:l  } %}
                                     {% endif %}

--- a/app/Resources/views/booking/_partial/modal.html.twig
+++ b/app/Resources/views/booking/_partial/modal.html.twig
@@ -7,6 +7,20 @@
         <h5>Réserver ce créneau / <span class="{{ firstBookable.job.color }}-text">{{ firstBookable.job.name }}</span></h5>
         <h6>{{ bucket.start|date_fr_long }} de {{ bucket.start|date('G\\hi') }} à {{ bucket.end|date('G\\hi') }}</h6>
 
+        {% if not shift_service.canBookDuration(beneficiary, bucket.getFirst.getDuration, cycle) %}
+          <div class="alert card red lighten-4 red-text text-darken-4">
+            <div class="card-content">
+              {% if not shift_service.canBookDuration(beneficiary, shift_service.getMinimalShiftDuration, cycle) %}
+                <span class="card-title">Attention, tu as déjà fait ton quota d'heures sur ce cycle.</span>
+                <p>Ce créneau ne sera pas comptabilisé dans ton calcul d'heures car seul un maximum de {{ due_duration_by_cycle | duration_from_minutes }} est comptabilisé par cycle.</p>
+              {% else %}
+                <span class="card-title">Attention, avec ce créneau tu dépasseras les {{ due_duration_by_cycle | duration_from_minutes }} de bénévolat sur ton cycle.</span>
+                <p>Ce créneau ne sera qu'en partie comptabilisé dans ton calcul d'heures, car seul un maximum de {{ due_duration_by_cycle | duration_from_minutes }} est comptabilisé par cycle.</p>
+              {% endif %}
+            </div>
+          </div>
+        {% endif %}
+
         {% if availableShifts | length == 1 %}
             {% if not firstBookable.formation and beneficiary.formations | length %}
                 <div class="row">

--- a/app/Resources/views/booking/_partial/shift.html.twig
+++ b/app/Resources/views/booking/_partial/shift.html.twig
@@ -67,5 +67,5 @@
     </a>
 </div>
 {% if firstBookableShift %}
-    {% include "booking/_partial/modal.html.twig" with { beneficiary: beneficiary, user: app.user, bucket: bucket } %}
+    {% include "booking/_partial/modal.html.twig" with { beneficiary: beneficiary, user: app.user, bucket: bucket, cycle: cycle } %}
 {% endif %}

--- a/app/Resources/views/booking/home_dashboard.html.twig
+++ b/app/Resources/views/booking/home_dashboard.html.twig
@@ -52,7 +52,7 @@
                 <p>Bravo
                     ! {% if member.beneficiaries | length %}Vos{% else %}Tes{% endif %} {{ due_duration_by_cycle | duration_from_minutes }}
                     ont été planifiées sur le cycle actuel.</p>
-                {% if beneficiariesWhoCanBook | length > 0 and duration_to_book > 0 and not unlimited_book_duration %}
+                {% if beneficiariesWhoCanBook | length > 0 and duration_to_book > 0 and not allow_extra_shifts %}
                     <p>
                         {% if beneficiariesWhoCanBook | length > 1 %}
                             {% for b in beneficiariesWhoCanBook %} {{ b.firstname }} {% if loop.index < loop.length %} et {% endif %}{% endfor %}peuvent
@@ -61,7 +61,7 @@
                         {% endif %} encore
                         effectuer {{ (shift_service.shiftTimeByCycle(member) - member.timeCount(member.endOfCycle)) | duration_from_minutes }}
                         .</p>
-                {% elseif (unlimited_book_duration) %}
+                {% elseif (allow_extra_shifts) %}
                     <p>
                         {% if member.beneficiaries | length %}
                             Vous pouvez

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -56,7 +56,8 @@ twig:
     images_tmp_dir: '%images_tmp_dir%'
     shift_service: "@shift_service"
     maximum_nb_of_beneficiaries_in_membership: '%maximum_nb_of_beneficiaries_in_membership%'
-    unlimited_book_duration: '%unlimited_book_duration%'
+    allow_extra_shifts: '%allow_extra_shifts%'
+    max_time_in_advance_to_book_extra_shifts : '%max_time_in_advance_to_book_extra_shifts%'
     code_generation_enabled: '%code_generation_enabled%'
     local_currency_name: '%local_currency_name%'
     use_fly_and_fixed: '%use_fly_and_fixed%'

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -93,7 +93,8 @@ parameters:
     cycle_duration: '28 days'
     maximum_nb_of_beneficiaries_in_membership: 2
     new_users_start_as_beginner: true
-    unlimited_book_duration: false
+    allow_extra_shifts: true
+    max_time_in_advance_to_book_extra_shifts: '3 days'
     display_gauge: true
     use_fly_and_fixed: false
 

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -154,7 +154,8 @@ services:
                 - "%due_duration_by_cycle%"
                 - "%min_shift_duration%"
                 - "%new_users_start_as_beginner%"
-                - "%unlimited_book_duration%"
+                - "%allow_extra_shifts%"
+                - "%max_time_in_advance_to_book_extra_shifts%"
 
     logger.user_processor:
             class: AppBundle\Monolog\MonologUserProcessor

--- a/src/AppBundle/Entity/Shift.php
+++ b/src/AppBundle/Entity/Shift.php
@@ -432,8 +432,21 @@ class Shift
      * @return boolean
      */
     public function getIsUpcoming(){
-        $intwodays = new \DateTime('2 days');
-        return !$this->getIsPast() && !$this->getIsCurrent() && ($intwodays > $this->start);
+        return $this->isBefore('2 days');
+    }
+
+    /**
+     * Return true if the shift starts before the duration given as parameter
+     *
+     * @param string $duration
+     *
+     * @return boolean
+     */
+    public function isBefore($duration)
+    {
+        $futureDate = new \DateTime($duration);
+        $futureDate->setTime(23, 59, 59);
+        return !$this->getIsPast() && !$this->getIsCurrent() && ($futureDate > $this->start);
     }
 
     /**

--- a/src/AppBundle/Twig/Extension/AppExtension.php
+++ b/src/AppBundle/Twig/Extension/AppExtension.php
@@ -71,7 +71,7 @@ class AppExtension extends AbstractExtension
 
         for ($i = 0; $i < strlen($text); $i++)
         {
-            $char = $text{$i};
+            $char = $text[$i];
             $r = rand(0, 100);
 
             # roughly 10% raw, 45% hex, 45% dec


### PR DESCRIPTION
Add a config variable to allow more shifts
Add a config variable to retrict the extra shifts to the next X days

Implémentation de la décision du CA :
Les comptes adhérents peuvent faire plus de trois heures par membre sur un cycle (déplafonnement). Les créneaux supplémentaires aux 3h de base ne peuvent être réservées que 72 heures à l’avance. Ces créneaux ne sont pas capitalisés : à chaque début de cycle, le compteur temps est remis à 0. Le nombre maximum de créneaux par cycle n’est pas limité.