### PR TITLE
Rendre la réservation de créneau optionnelle

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -98,6 +98,7 @@ parameters:
     display_gauge: true
     use_fly_and_fixed: false
     time_after_which_members_are_late_with_shifts: -9
+    reserve_shift: true
 
     # Swipe card configuration
     swipe_card_logging: true

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -98,7 +98,7 @@ parameters:
     display_gauge: true
     use_fly_and_fixed: false
     time_after_which_members_are_late_with_shifts: -9
-    reserve_shift: true
+    reserve_new_shift_to_prior_shifter: true
 
     # Swipe card configuration
     swipe_card_logging: true

--- a/src/AppBundle/Command/ShiftGenerateCommand.php
+++ b/src/AppBundle/Command/ShiftGenerateCommand.php
@@ -97,6 +97,8 @@ class ShiftGenerateCommand extends ContainerAwareCommand
                         if (!isset($last_cycle_shifters_array[$i])
                             // ou que c'est un shift qui ne doit pas être repris
                             || ($use_fly_and_fixed && !$last_cycle_shifters_array[$i]->isFixe())
+                            // ou qu'on ne reserve pas les shifts
+                            || !$this->getContainer()->getParameter('reserve_shift')
                         ) {
                             $current_shift->setShifter(null);
                             $current_shift->setBookedTime(null);

--- a/src/AppBundle/Command/ShiftGenerateCommand.php
+++ b/src/AppBundle/Command/ShiftGenerateCommand.php
@@ -98,7 +98,7 @@ class ShiftGenerateCommand extends ContainerAwareCommand
                             // ou que c'est un shift qui ne doit pas être repris
                             || ($use_fly_and_fixed && !$last_cycle_shifters_array[$i]->isFixe())
                             // ou qu'on ne reserve pas les shifts
-                            || !$this->getContainer()->getParameter('reserve_shift')
+                            || !$this->getContainer()->getParameter('reserve_new_shift_to_prior_shifter')
                         ) {
                             $current_shift->setShifter(null);
                             $current_shift->setBookedTime(null);


### PR DESCRIPTION
Bonjour,

Au sein de la frenchCoop, nous aimerions ne pas utiliser la notion de réservation de créneaux lors de la génération.
On pourrait imaginer la possibilité d'avoir un paramètre reserve_shift = (postionné à true par défaut pour maintenir une comptabilité descendante)