### PR TITLE
Allow zipcode with leading zero

### DIFF
--- a/app/Resources/views/beneficiary/_partial/info.html.twig
+++ b/app/Resources/views/beneficiary/_partial/info.html.twig
@@ -25,7 +25,7 @@
                 {% if beneficiary.address.street2 %}
                     &nbsp;{{ beneficiary.address.street2 }}
                 {% endif %}
-                &nbsp;{{ beneficiary.address.zipCode }}
+                &nbsp;{{ "%05d"|format(beneficiary.address.zipCode) }}
                 &nbsp;{{ beneficiary.address.city }}
                 </span>
             </div>

--- a/src/AppBundle/Form/AddressType.php
+++ b/src/AppBundle/Form/AddressType.php
@@ -19,7 +19,7 @@ class AddressType extends AbstractType
         $builder
             ->add('street1',TextType::class,array('label'=>'Rue'))
             ->add('street2',TextType::class,array('label'=>'Rue 2','required'=>false))
-            ->add('zipcode',IntegerType::class,array('label'=>'Code postal'))
+            ->add('zipcode',TextType::class,array('label'=>'Code postal'))
             ->add('city',TextType::class,array('label'=>'Ville'));
     }
     


### PR DESCRIPTION
#433 Permet d'avoir un code postal commençant par zéro. Cependant le premier zéro du code postal ne s'affiche pas dans le formulaire d'édition d'adresse.