### PR TITLE
Add option to validate shifts with the card reader

### DIFF
--- a/app/DoctrineMigrations/Version20211107094111.php
+++ b/app/DoctrineMigrations/Version20211107094111.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20211107094111 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE shift ADD was_carried_out TINYINT(1) DEFAULT \'0\' NOT NULL');
+        $this->addSql('UPDATE shift SET was_carried_out = 1 WHERE end < NOW()');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE shift DROP was_carried_out');
+    }
+}

--- a/app/Resources/views/admin/booking/_partial/shift.html.twig
+++ b/app/Resources/views/admin/booking/_partial/shift.html.twig
@@ -85,6 +85,17 @@
                                         <button type="submit" class="btn orange"><i class="material-icons left">lock_open</i>Libérer</button>
                                     {% endif %}
                                 </form>
+                                {% if  use_card_reader_to_validate_shifts %}
+                                    {% if shift.wasCarriedOut %}
+                                        <form action="{{ path('invalidate_shift', {'id' : shift.id }) }}" method="post" id="invalidate_shift_{{ shift.id }}">
+                                            <button type="submit" class="btn red"><i class="material-icons left">highlight_off</i>Invalider la participation</button>
+                                        </form>
+                                    {% else %}
+                                        <form action="{{ path('validate_shift', {'id' : shift.id }) }}" method="post" id="validate_shift_{{ shift.id }}">
+                                            <button type="submit" class="btn green"><i class="material-icons left">check_circle</i>Valider la participation</button>
+                                        </form>
+                                    {% endif %}
+                                {% endif %}
                             {% endif %}
                         </div>
                     </li>

--- a/app/Resources/views/default/card_reader.html.twig
+++ b/app/Resources/views/default/card_reader.html.twig
@@ -30,6 +30,14 @@
                                 <li style="height: 30px">
                                     <div>
                                         {% if shift.shifter %}
+                                            {% if use_card_reader_to_validate_shifts %}
+                                                {% if shift.wasCarriedOut %}
+                                                    &#128994;
+                                                {% else %}
+                                                    &#9899;
+                                                {% endif %}
+                                                &nbsp;
+                                            {% endif %}
                                             <span style="margin-right: 5px; font-size: 16px">{{ shift.shifter.publicDisplayName }}</span>
                                             {% if shift.formation %}
                                                 <span class="chip" style="margin-left: 5px"><b>{{ shift.formation }}</b></span>

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -68,6 +68,7 @@ twig:
     display_freeze_account: '%display_freeze_account%'
     display_keys_shop: '%display_keys_shop%'
     display_name_shifters: '%display_name_shifters%'
+    use_card_reader_to_validate_shifts: '%use_card_reader_to_validate_shifts%'
 
 # Doctrine Configuration
 doctrine:

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -101,6 +101,7 @@ parameters:
     reserve_new_shift_to_prior_shifter: true
     forbid_shift_overlap_time: 30
     display_name_shifters: false
+    use_card_reader_to_validate_shifts: false
 
     # Swipe card configuration
     swipe_card_logging: true

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -110,6 +110,8 @@ services:
                 - { name: kernel.event_listener, event: shift.dismissed, method: onShiftDismissed }
                 - { name: kernel.event_listener, event: shift.freed, method: onShiftFreed }
                 - { name: kernel.event_listener, event: shift.deleted, method: onShiftDeleted }
+                - { name: kernel.event_listener, event: shift.validated, method: onShiftValidated }
+                - { name: kernel.event_listener, event: shift.invalidated, method: onShiftInvalidated }
                 - { name: kernel.event_listener, event: member.cycle.end, method: onMemberCycleEnd }
     emailing_event_listener:
             class:  AppBundle\EventListener\EmailingEventListener

--- a/src/AppBundle/Entity/Shift.php
+++ b/src/AppBundle/Entity/Shift.php
@@ -64,6 +64,13 @@ class Shift
     private $dismissedReason;
 
     /**
+     * @var bool
+     *
+     * @ORM\Column(name="was_carried_out", type="boolean", options={"default" : 0})
+     */
+    private $wasCarriedOut;
+
+    /**
      * @ORM\ManyToOne(targetEntity="Beneficiary", inversedBy="shifts")
      * @ORM\JoinColumn(name="shifter_id", referencedColumnName="id")
      */
@@ -117,6 +124,7 @@ class Shift
     public function __construct()
     {
         $this->isDismissed = false;
+        $this->wasCarriedOut = false;
     }
 
     public function __toString()
@@ -277,6 +285,52 @@ class Shift
     public function getDismissedReason()
     {
         return $this->dismissedReason;
+    }
+
+    /**
+     * Set wasCarriedOut
+     *
+     * @param boolean $wasCarriedOut
+     *
+     * @return BookedShift
+     */
+    public function setWasCarriedOut($wasCarriedOut)
+    {
+        $this->wasCarriedOut = $wasCarriedOut;
+
+        return $this;
+    }
+
+    /**
+     * Validate shift participation
+     *
+     * @return BookedShift
+     */
+    public function validateShiftParticipation()
+    {
+        $this->wasCarriedOut = 1;
+        return $this;
+    }
+
+    /**
+     * Invalidate shift participation
+     *
+     * @return BookedShift
+     */
+    public function invalidateShiftParticipation()
+    {
+        $this->wasCarriedOut = 0;
+        return $this;
+    }
+
+    /**
+     * Get wasCarriedOut
+     *
+     * @return bool
+     */
+    public function getWasCarriedOut()
+    {
+        return $this->wasCarriedOut;
     }
 
     /**

--- a/src/AppBundle/Event/ShiftInvalidatedEvent.php
+++ b/src/AppBundle/Event/ShiftInvalidatedEvent.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace AppBundle\Event;
+
+use AppBundle\Entity\Membership;
+use AppBundle\Entity\Shift;
+use Symfony\Component\EventDispatcher\Event;
+
+class ShiftInvalidatedEvent extends Event
+{
+    const NAME = 'shift.invalidated';
+
+    private $shift;
+    private $membership;
+
+    public function __construct(Shift $shift, Membership $membership)
+    {
+        $this->shift = $shift;
+        $this->membership = $membership;
+    }
+
+    /**
+     * @return Membership
+     */
+    public function getMembership()
+    {
+        return $this->membership;
+    }
+
+    /**
+     * @return Shift
+     */
+    public function getShift()
+    {
+        return $this->shift;
+    }
+
+}

--- a/src/AppBundle/Event/ShiftValidatedEvent.php
+++ b/src/AppBundle/Event/ShiftValidatedEvent.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace AppBundle\Event;
+
+use AppBundle\Entity\Shift;
+use Symfony\Component\EventDispatcher\Event;
+
+class ShiftValidatedEvent extends Event
+{
+    const NAME = 'shift.validated';
+
+    private $shift;
+
+    public function __construct(Shift $shift)
+    {
+        $this->shift = $shift;
+    }
+
+    public function getShift()
+    {
+        return $this->shift;
+    }
+
+}

--- a/src/AppBundle/Repository/ShiftRepository.php
+++ b/src/AppBundle/Repository/ShiftRepository.php
@@ -248,4 +248,19 @@ class ShiftRepository extends \Doctrine\ORM\EntityRepository
             ->getResult();
     }
 
+    public function getOnGoingShifts($beneficiary)
+    {
+        $qb = $this->createQueryBuilder('s')
+                    ->where('s.end > :now')
+                    ->andwhere('s.start < :now_plus_ten')
+                    ->andwhere('s.shifter = :sid')
+                    ->setParameter('now', new \Datetime('now'))
+                    ->setParameter('now_plus_ten', new \Datetime('now +10 minutes'))
+                    ->setParameter('sid', $beneficiary->getId());
+
+        return $qb
+            ->getQuery()
+            ->getResult();
+    }
+
 }

--- a/src/AppBundle/Security/ShiftVoter.php
+++ b/src/AppBundle/Security/ShiftVoter.php
@@ -19,6 +19,8 @@ class ShiftVoter extends Voter
     const REJECT = 'reject';
     const ACCEPT = 'accept';
     const LOCK = 'lock';
+    const VALIDATE = 'validate';
+    const INVALIDATE = "invalidate";
     private $decisionManager;
     private $container;
 
@@ -37,7 +39,7 @@ class ShiftVoter extends Voter
     protected function supports($attribute, $subject)
     {
         // if the attribute isn't one we support, return false
-        if (!in_array($attribute, array(self::BOOK, self::DISMISS, self::REJECT, self::FREE, self::ACCEPT, self::LOCK))) {
+        if (!in_array($attribute, array(self::BOOK, self::DISMISS, self::REJECT, self::FREE, self::ACCEPT, self::LOCK, self::VALIDATE, self::INVALIDATE))) {
             return false;
         }
 
@@ -97,6 +99,12 @@ class ShiftVoter extends Voter
                     return true;
                 }
                 return $this->canAccept($shift, $user);
+            case self::VALIDATE:
+            case self::INVALIDATE:
+                if ($this->decisionManager->decide($token, array('ROLE_ADMIN','ROLE_SHIFT_MANAGER'))) {
+                    return true;
+                }
+                return false;
         }
 
         throw new \LogicException('This code should not be reached!');


### PR DESCRIPTION
The shifts are counted to the used as soon as she register for a shift.

This PR add an option to use the card reader to validate a shift. As such, when the member enters the shop, she scan her card on the card reader, then her shift is validated and her shift counter incremented. If the card reader is not working and/or the member forgot her card, it is possible to manually validate the shift.