### PR TITLE
Sort upcoming shifts by date ascending

### DIFF
--- a/app/Resources/views/booking/home_booked_shifts.html.twig
+++ b/app/Resources/views/booking/home_booked_shifts.html.twig
@@ -13,7 +13,7 @@
             </li>
         {% endif %}
         {% for cycle in 0..1 %}
-            {% set shiftsOfCycle = member.getShiftsOfCycle(cycle) %}
+            {% set shiftsOfCycle = member.getShiftsOfCycle(cycle, false, true) %}
             {% if shiftsOfCycle | length > 0 %}
                 <li class="active">
                     <div class="collapsible-header active"><i class="material-icons">date_range</i>Mes créneaux pour le cycle {% if cycle == 0 %}courant{% else %}suivant{% endif %}  (du {{ member.startOfCycle(cycle) | date_fr_long }} au {{ member.endOfCycle(cycle) | date_fr_long }})</div>

--- a/src/AppBundle/Entity/Membership.php
+++ b/src/AppBundle/Entity/Membership.php
@@ -395,7 +395,7 @@ class Membership
     /**
      * Get all shifts for all beneficiaries
      */
-    public function getAllShifts($excludeDismissed = false)
+    public function getAllShifts($excludeDismissed = false, $orderByAscending = false)
     {
         $shifts = new ArrayCollection();
         foreach ($this->getBeneficiaries() as $beneficiary) {
@@ -404,12 +404,16 @@ class Membership
             }
         }
         if ($excludeDismissed) {
-            return $shifts->filter(function($shift) {
+            $shifts = $shifts->filter(function($shift) {
                 return !$shift->getIsDismissed();
             });
-        } else {
-            return $shifts;
         }
+        if ($orderByAscending) {
+            usort($shifts, function($shift1, $shift2) {
+                return $shift1.start - $shift2.start;
+            })
+        }
+        return $shifts;
     }
 
     /**
@@ -447,9 +451,9 @@ class Membership
      * @param bool $excludeDismissed
      * @return ArrayCollection|\Doctrine\Common\Collections\Collection
      */
-    public function getShiftsOfCycle($cycleOffset = 0, $excludeDismissed = false)
+    public function getShiftsOfCycle($cycleOffset = 0, $excludeDismissed = false, $orderByAscending = false)
     {
-        return $this->getAllShifts($excludeDismissed)->filter(function($shift) use ($cycleOffset) {
+        return $this->getAllShifts($excludeDismissed, $orderByAscending)->filter(function($shift) use ($cycleOffset) {
             return $shift->getStart() > $this->startOfCycle($cycleOffset) &&
                 $shift->getEnd() < $this->endOfCycle($cycleOffset);
         });


### PR DESCRIPTION
Order upcoming shifts by date ascending instead of date descending (default)

Current display :point_down: 
![Screenshot from 2021-12-06 22-24-44](https://user-images.githubusercontent.com/7147385/144925107-e5be1962-b1ae-4cc4-a723-350c0ecd8cd9.png)


