### PR TITLE
autoriser_cumul_avance

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -102,6 +102,7 @@ parameters:
     forbid_shift_overlap_time: 30
     display_name_shifters: false
     use_card_reader_to_validate_shifts: false
+    max_time_at_end_of_shift: 0
 
     # Swipe card configuration
     swipe_card_logging: true


### PR DESCRIPTION
pour ne pas que le compteur retombe à 0 lorsqu'un membre a de l'avance (limite max définie en paramètre) 