### PR TITLE
Fix recipients array when null

### DIFF
--- a/src/AppBundle/Command/SendShiftAlertsCommand.php
+++ b/src/AppBundle/Command/SendShiftAlertsCommand.php
@@ -87,7 +87,7 @@ class SendShiftAlertsCommand extends ContainerAwareCommand
 
     private function sendAlertsByEmail(InputInterface $input, OutputInterface $output, DateTime $date, $alerts, $template) {
         $mailer = $this->getContainer()->get('mailer');
-        $recipients = explode(',', $input->getOption('emails'));
+        $recipients = $input->getOption('emails') ? explode(',', $input->getOption('emails')) : null;
         if ($recipients) {
             setlocale(LC_TIME, 'fr_FR.UTF8');
             $dateFormatted = strftime("%A %e %B", $date->getTimestamp());


### PR DESCRIPTION
Currently when the emails argument is null, the explode results in an array with an empty element:
```
<?php
$recipients = explode(',', null);
print_r($recipients);
?>
```
result:
```
Array
(
    [0] => 
)
```

This makes the job fail with `Address in mailbox given [] does not comply with RFC 2822, 3.6.2.`

This PR fixes that issue