### PR TITLE
Mise à jour du composer.lock suite à la PR #465

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,62 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ffa6976e1e2a48789fed85cf6021b78b",
+    "content-hash": "936ef7735c175e434b54ba92a322ffdf",
     "packages": [
+        {
+            "name": "asmshaon/easy-barcode-generator",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/asmshaon/easy-barcode-generator.git",
+                "reference": "44c08da6f8ee1585d41f71ebd48b9b920031b22e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/asmshaon/easy-barcode-generator/zipball/44c08da6f8ee1585d41f71ebd48b9b920031b22e",
+                "reference": "44c08da6f8ee1585d41f71ebd48b9b920031b22e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-gd": "*",
+                "php": ">=5.3.2"
+            },
+            "default-branch": true,
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "CodeItNow\\": "CodeItNow/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Akhtar Khan",
+                    "email": "er.akhtarkhan@gmail.com"
+                }
+            ],
+            "description": "Barcode & Qr Code generator library by http://www.codeitnow.in. You can use it with Custom PHP application or any PHP Framework such as Laravel, Cakephp, Yii, Codeigneter etc.",
+            "homepage": "http://www.codeitnow.in",
+            "keywords": [
+                "Symfony2",
+                "barcode",
+                "cakephp",
+                "code",
+                "generator",
+                "laravel",
+                "qr",
+                "qrcode",
+                "symfony"
+            ],
+            "support": {
+                "issues": "https://github.com/asmshaon/easy-barcode-generator/issues",
+                "source": "https://github.com/asmshaon/easy-barcode-generator/tree/master"
+            },
+            "time": "2022-04-22T10:13:03+00:00"
+        },
         {
             "name": "behat/transliterator",
             "version": "v1.3.0",
@@ -54,59 +108,6 @@
                 "source": "https://github.com/Behat/Transliterator/tree/v1.3.0"
             },
             "time": "2020-01-14T16:39:13+00:00"
-        },
-        {
-            "name": "codeitnowin/barcode",
-            "version": "3.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/codeitnowin/barcode-generator.git",
-                "reference": "6325a15ae904ec401b947e1a3e868de1c2cc80b0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/codeitnowin/barcode-generator/zipball/6325a15ae904ec401b947e1a3e868de1c2cc80b0",
-                "reference": "6325a15ae904ec401b947e1a3e868de1c2cc80b0",
-                "shasum": ""
-            },
-            "require": {
-                "ext-gd": "*",
-                "php": ">=5.3.2"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "CodeItNow\\": "CodeItNow/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Akhtar Khan",
-                    "email": "er.akhtarkhan@gmail.com"
-                }
-            ],
-            "description": "Barcode & Qr Code generator library by http://www.codeitnow.in. You can use it with Custom PHP application or any PHP Framework such as Laravel, Cakephp, Yii, Codeigneter etc.",
-            "homepage": "http://www.codeitnow.in",
-            "keywords": [
-                "Symfony2",
-                "barcode",
-                "cakephp",
-                "code",
-                "generator",
-                "laravel",
-                "qr",
-                "qrcode",
-                "symfony"
-            ],
-            "support": {
-                "issues": "https://github.com/codeitnowin/barcode-generator/issues",
-                "source": "https://github.com/codeitnowin/barcode-generator/tree/master"
-            },
-            "time": "2018-10-25T18:32:10+00:00"
         },
         {
             "name": "components/jquery",
@@ -7099,7 +7100,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "asmshaon/easy-barcode-generator": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
@@ -7110,5 +7113,5 @@
     "platform-overrides": {
         "php": "7.3"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.2.0"
 }


### PR DESCRIPTION
Dans la PR précédente (#465), un packet a été remplacé, mais en oubliant de mettre à jour le `composer.lock`

Cette PR met le `composer.lock` à jour (seulement le nouveau packet)

Commande lancée :
```
php composer.phar update asmshaon/easy-barcode-generator
```