### PR TITLE
Afficher le créneau fixe sur son dashboard

### DIFF
--- a/app/Resources/views/admin/booking/_partial/shift.html.twig
+++ b/app/Resources/views/admin/booking/_partial/shift.html.twig
@@ -86,19 +86,27 @@
                                 {% if use_card_reader_to_validate_shifts and shift.isPastOrCurrent %}
                                     {% if shift.wasCarriedOut %}
                                         <form action="{{ path('invalidate_shift', { 'id' : shift.id }) }}" method="POST" id="invalidate_shift_{{ shift.id }}">
-                                            <button type="submit" class="btn red"><i class="material-icons left">highlight_off</i>Invalider la participation</button>
+                                            <button type="submit" class="btn red">
+                                                <i class="material-icons left">highlight_off</i>Invalider la participation
+                                            </button>
                                         </form>
                                     {% else %}
                                         <form action="{{ path('validate_shift', { 'id' : shift.id }) }}" method="POST" id="validate_shift_{{ shift.id }}">
-                                            <button type="submit" class="btn green"><i class="material-icons left">check_circle</i>Valider la participation</button>
+                                            <button type="submit" class="btn green">
+                                                <i class="material-icons left">check_circle</i>Valider la participation
+                                            </button>
                                         </form>
                                     {% endif %}
                                 {% endif %}
                                 <form action="{{ path('free_shift', { 'id' : shift.id }) }}" method="POST" id="free_shift_{{ shift.id }}">
                                     {% if shift.isPast %}
-                                        <button type="submit" class="btn red"><i class="material-icons left">delete</i>Supprimer</button>
+                                        <button type="submit" class="btn red">
+                                            <i class="material-icons left">delete</i>Supprimer
+                                        </button>
                                     {% else %}
-                                        <button type="submit" class="btn orange"><i class="material-icons left">lock_open</i>Libérer</button>
+                                        <button type="submit" class="btn orange">
+                                            <i class="material-icons left">lock_open</i>Libérer
+                                        </button>
                                     {% endif %}
                                 </form>
                             {% endif %}

--- a/app/Resources/views/admin/period/edit.html.twig
+++ b/app/Resources/views/admin/period/edit.html.twig
@@ -48,7 +48,9 @@
                             <div class="collapsible-body">
                                 Créneau fixe réservé le <i>{{ position.bookedTime | date_fr_with_time }}</i> par <a href="{{ path("member_show",{'member_number': position.booker.membership.memberNumber}) }}">{{ position.booker }}</a>.
                                 <form action="{{ path('free_position_from_period', {'id' : position.id }) }}" method="post" id="free_position_{{ position.id }}">
-                                    <button type="submit" class="btn orange"><i class="material-icons left">lock_open</i>Libérer</button>
+                                    <button type="submit" class="btn orange">
+                                        <i class="material-icons left">lock_open</i>Libérer
+                                    </button>
                                 </form>
                             </div>
                         </li>

--- a/app/Resources/views/booking/_partial/home_shift.html.twig
+++ b/app/Resources/views/booking/_partial/home_shift.html.twig
@@ -22,15 +22,17 @@
             <a href="#contact{{ shift.id }}" id="more{{ shift.id }}" class="modal-trigger"><i class="material-icons right">more</i></a><span>créneau en cours</span>
         </div>
     {% elseif (shift.isPast) %}
-        <div class="card-action">
-            {% if (shift.wasCarriedOut) %}
-                <i class="material-icons tiny">check</i>
-                <span>effectué</span>
-            {% else %}
-                <i class="material-icons tiny">close</i>
-                <span>non effectué</span>
-            {% endif %}
-        </div>
+        {% if use_card_reader_to_validate_shifts %}
+            <div class="card-action">
+                {% if (shift.wasCarriedOut) %}
+                    <i class="material-icons tiny">check</i>
+                    <span>effectué</span>
+                {% else %}
+                    <i class="material-icons tiny">close</i>
+                    <span>non effectué</span>
+                {% endif %}
+            </div>
+        {% endif %}
     {% else %}
         {% if (shift.isDismissed) %}
             <div class="card-action">

--- a/app/Resources/views/booking/_partial/home_shift.html.twig
+++ b/app/Resources/views/booking/_partial/home_shift.html.twig
@@ -12,7 +12,7 @@
                 Formation : <b>{{ shift.formation }}</b>
             {% endif %}
         </p>
-        {% if (shift.isDismissed ) %}
+        {% if (shift.isDismissed) %}
             <br>
             <b class="red-text text-darken-4">Créneau en attente d'être repris par un autre bénévole</b>
         {% endif %}
@@ -51,11 +51,10 @@
             {{ form_start(undismiss_shift_form,{ 'attr' : { 'id' : 'undismiss_shift'}}) }}
             {{ form_widget(undismiss_shift_form) }}
             {{ form_end(undismiss_shift_form) }}
-
         {% else %}
             <div class="card-action">
                 {% if not shift.fixe %}
-                    <a href="#dismiss{{ shift.id }}" class="modal-trigger btn-flat red white-text">Annuler</a>
+                    <a href="#dismiss{{ shift.id }}" class="modal-trigger btn-flat red white-text" title="Annuler">Annuler</a>
                 {% endif %}
                 {% if (shift.isUpcoming) %}
                     <a href="#contact{{ shift.id }}" class="modal-trigger btn-flat" title="Contacter les bénévoles du créneau"><i class="material-icons">email</i></a>

--- a/app/Resources/views/booking/_partial/home_shift.html.twig
+++ b/app/Resources/views/booking/_partial/home_shift.html.twig
@@ -12,16 +12,16 @@
                 Formation : <b>{{ shift.formation }}</b>
             {% endif %}
         </p>
-        {% if (shift.isDismissed) %}
+        {% if shift.isDismissed %}
             <br>
             <b class="red-text text-darken-4">Créneau en attente d'être repris par un autre bénévole</b>
         {% endif %}
     </div>
-    {% if (shift.isCurrent) %}
+    {% if shift.isCurrent %}
         <div class="card-action">
             <a href="#contact{{ shift.id }}" id="more{{ shift.id }}" class="modal-trigger"><i class="material-icons right">more</i></a><span>créneau en cours</span>
         </div>
-    {% elseif (shift.isPast) %}
+    {% elseif shift.isPast %}
         {% if use_card_reader_to_validate_shifts %}
             <div class="card-action">
                 {% if (shift.wasCarriedOut) %}
@@ -34,7 +34,7 @@
             </div>
         {% endif %}
     {% else %}
-        {% if (shift.isDismissed) %}
+        {% if shift.isDismissed %}
             <div class="card-action">
                 <a href="#undismiss{{ shift.id }}" class="modal-trigger btn-flat green truncate white-text">reprendre<span class="hide-on-med-and-down"> mon créneau</span></a>
             </div>
@@ -54,33 +54,35 @@
             {{ form_widget(undismiss_shift_form) }}
             {{ form_end(undismiss_shift_form) }}
         {% else %}
-            <div class="card-action">
-                {% if not shift.fixe %}
-                    <a href="#dismiss{{ shift.id }}" class="modal-trigger btn-flat red white-text" title="Annuler">Annuler</a>
-                {% endif %}
-                {% if (shift.isUpcoming) %}
-                    <a href="#contact{{ shift.id }}" class="modal-trigger btn-flat" title="Contacter les bénévoles du créneau"><i class="material-icons">email</i></a>
-                {% endif %}
-            </div>
-            <div id="dismiss{{ shift.id }}" class="modal black-text">
-                <form action="{{ path('shift_dismiss',{'id':shift.id}) }}" method="post">
-                    <div class="modal-content">
-                        <h5>Je ne peux pas faire mon créneau</h5>
-                        <div class="input-field">
-                            <textarea id="reason" name="reason" class="materialize-textarea"></textarea>
-                            <label for="reason">Justification éventuelle</label>
+            {% if not shift.fixe or shift.isUpcoming %}
+                <div class="card-action">
+                    {% if not shift.fixe %}
+                        <a href="#dismiss{{ shift.id }}" class="modal-trigger btn-flat red white-text" title="Annuler">Annuler</a>
+                    {% endif %}
+                    {% if shift.isUpcoming %}
+                        <a href="#contact{{ shift.id }}" class="modal-trigger btn-flat" title="Contacter les bénévoles du créneau"><i class="material-icons">email</i></a>
+                    {% endif %}
+                </div>
+                <div id="dismiss{{ shift.id }}" class="modal black-text">
+                    <form action="{{ path('shift_dismiss',{'id':shift.id}) }}" method="post">
+                        <div class="modal-content">
+                            <h5>Je ne peux pas faire mon créneau</h5>
+                            <div class="input-field">
+                                <textarea id="reason" name="reason" class="materialize-textarea"></textarea>
+                                <label for="reason">Justification éventuelle</label>
+                            </div>
                         </div>
-                    </div>
-                    <div class="modal-footer">
-                        <a href="#!"
-                           class="modal-action modal-close waves-effect waves-green btn-flat grey-text ">Retour à la raison</a>
-                        <button class="modal-action modal-close waves-effect waves-green btn red ">Oui, je me désiste !</button>
-                    </div>
-                </form>
-            </div>
+                        <div class="modal-footer">
+                            <a href="#!"
+                            class="modal-action modal-close waves-effect waves-green btn-flat grey-text ">Retour à la raison</a>
+                            <button class="modal-action modal-close waves-effect waves-green btn red ">Oui, je me désiste !</button>
+                        </div>
+                    </form>
+                </div>
+            {% endif %}
         {% endif %}
     {% endif %}
 </div>
 {% if (shift.isUpcoming or shift.isCurrent) %}
-    {{ render(controller("AppBundle:Default:shiftContactForm",{'shift':shift})) }}
+    {{ render(controller("AppBundle:Default:shiftContactForm", { 'shift':shift })) }}
 {% endif %}

--- a/app/Resources/views/booking/_partial/reserved_shift.html.twig
+++ b/app/Resources/views/booking/_partial/reserved_shift.html.twig
@@ -37,6 +37,4 @@
                class="modal-action modal-close waves-effect waves-green btn teal">Oui, Je ne reprends pas ce créneau</a>
         </div>
     </div>
-
-
 </div>

--- a/app/Resources/views/booking/home_booked_shifts.html.twig
+++ b/app/Resources/views/booking/home_booked_shifts.html.twig
@@ -9,7 +9,7 @@
                 {% if period_positions %}
                     <div class="row">
                         {% for period_position in period_positions %}
-                            <div class="col m4 s6">
+                            <div class="col s12 m6 l4">
                                 {% include "user/_partial/period_position.html.twig" with { period_position: period_position } %}
                             </div>
                         {% endfor %}
@@ -24,7 +24,7 @@
                 <div class="collapsible-header active"><i class="material-icons">event_note</i>Mes créneaux à accepter</div>
                 <div class="collapsible-body">
                     {% for shift in member.reservedShifts %}
-                        {% include "booking/_partial/reserved_shift.html.twig" with { shift: shift  } %}
+                        {% include "booking/_partial/reserved_shift.html.twig" with { shift: shift } %}
                     {% endfor %}
                 </div>
             </li>
@@ -37,7 +37,7 @@
                     <div class="collapsible-body">
                         <div class="row">
                             {% for shift in shiftsOfCycle %}
-                                <div class="col m6 s12 {% if shiftsOfCycle | length == 1 %}push-m3{% endif %}">
+                                <div class="col s12 m6 l4 {% if shiftsOfCycle | length == 1 %}push-m3{% endif %}">
                                     {% include "booking/_partial/home_shift.html.twig" with { shift: shift } %}
                                 </div>
                             {% endfor %}
@@ -52,7 +52,7 @@
                 <div class="collapsible-body">
                     <div class="row">
                         {% for bookedshift in member.getFutureRebookedShifts() %}
-                            <div class="col m6 s12 {% if (member.getFutureRebookedShifts() | length) < 2 %}push-m3{% endif %}">
+                            <div class="col s12 m6 l4 {% if (member.getFutureRebookedShifts() | length) < 2 %}push-m3{% endif %}">
                                 <div class="card green lighten-5">
                                     <div class="card-content green-text">
                                         <span class="card-title">{{ bookedshift.start|date_fr_long }} de {{ bookedshift.start|date('H:i') }} à {{ bookedshift.end|date('H:i') }}</span>
@@ -82,15 +82,15 @@
                     <div class="row">
                         {% for cycle in -1..-2 %}
                             {% if shift_service.hasCycle(member, cycle) %}
-                                <div class="col m6 s12">
+                                <div class="col s12 m6 l4">
                                     {% set previousShifts = member.getShiftsOfCycle(cycle) %}
                                     <h6>Cycle précédent (du {{ member.startOfCycle(cycle) | date('d/m/y') }} au {{ member.endOfCycle(cycle) | date('d/m/y') }})</h6>
                                     {% if previousShifts|length == 0 %}
                                         Pas de créneau
                                     {% endif %}
                                     {% for shift in previousShifts %}
-                                        <div class="col m12 s12">
-                                            {% include "user/_partial/mini_shift.html.twig" with { shift: shift  } %}
+                                        <div class="col s12 m12">
+                                            {% include "user/_partial/mini_shift.html.twig" with { shift: shift } %}
                                         </div>
                                     {% endfor %}
                                 </div>

--- a/app/Resources/views/booking/home_booked_shifts.html.twig
+++ b/app/Resources/views/booking/home_booked_shifts.html.twig
@@ -33,7 +33,7 @@
             {% set shiftsOfCycle = member.getShiftsOfCycle(cycle) %}
             {% if shiftsOfCycle | length > 0 %}
                 <li class="active">
-                    <div class="collapsible-header active"><i class="material-icons">date_range</i>Mes créneaux pour le cycle {% if cycle == 0 %}courant{% else %}suivant{% endif %}  (du {{ member.startOfCycle(cycle) | date_fr_long }} au {{ member.endOfCycle(cycle) | date_fr_long }})</div>
+                    <div class="collapsible-header active"><i class="material-icons">date_range</i>Mes créneaux pour le cycle {% if cycle == 0 %}courant{% else %}suivant{% endif %} (du {{ member.startOfCycle(cycle) | date_fr_long }} au {{ member.endOfCycle(cycle) | date_fr_long }})</div>
                     <div class="collapsible-body">
                         <div class="row">
                             {% for shift in shiftsOfCycle %}

--- a/app/Resources/views/booking/home_booked_shifts.html.twig
+++ b/app/Resources/views/booking/home_booked_shifts.html.twig
@@ -2,6 +2,23 @@
     {% set beneficiary = app.user.beneficiary %}
     {% set member = beneficiary.membership %}
     <ul class="collapsible expandable">
+        {% if use_fly_and_fixed %}
+            <li class="active">
+                <div class="collapsible-header"><i class="material-icons">event</i>Créneau fixe</div>
+                <div class="collapsible-body">
+                {% if period_positions %}
+                    <div class="row">
+                        {% for period_position in period_positions %}
+                            <div class="col m4 s6">
+                                {% include "user/_partial/period_position.html.twig" with { period_position: period_position } %}
+                            </div>
+                        {% endfor %}
+                    </div>
+                    {% else %}
+                        <p>Pas de créneau fixe</p>
+                    {% endif %}
+            </li>
+        {% endif %}
         {% if (member.reservedShifts | length) > 0 %}
             <li class="active">
                 <div class="collapsible-header active"><i class="material-icons">event_note</i>Mes créneaux à accepter</div>

--- a/app/Resources/views/booking/home_dashboard.html.twig
+++ b/app/Resources/views/booking/home_dashboard.html.twig
@@ -49,7 +49,7 @@
                 <p>
                     <i class="material-icons">warning</i> Pense à réserver tes créneaux.
                     <br>
-                    Tu as encore {{ remaining | duration_from_minutes }} à réserver.
+                    Tu as encore {{ remaining | duration_from_minutes }} à effectuer.
                 </p>
             {% else %}
                 {% set duration_to_book = (shift_service.shiftTimeByCycle(member) - member.timeCount(member.endOfCycle)) %}
@@ -85,13 +85,11 @@
         {% endif %}
     {% endif %}
 
-    <a href="{{ path("booking") }}" class="btn teal hide-on-small-only"
-        {% if beneficiariesWhoCanBook | length == 0 %}disabled{% endif %}>
+    <a href="{{ path("booking") }}" class="btn teal hide-on-small-only" title="Je réserve un créneau{% if use_fly_and_fixed %} volant{% endif %}" {% if beneficiariesWhoCanBook | length == 0 %}disabled{% endif %}>
         <i class="material-icons left">schedule</i>
-        Je réserve un créneau
+        Je réserve un créneau{% if use_fly_and_fixed %} volant{% endif %}
     </a>
-    <a href="{{ path("booking") }}" class="btn teal hide-on-med-and-up"
-        {% if beneficiariesWhoCanBook | length == 0 %}disabled{% endif %}>
+    <a href="{{ path("booking") }}" class="btn teal hide-on-med-and-up" title="Je réserve un créneau{% if use_fly_and_fixed %} volant{% endif %}" {% if beneficiariesWhoCanBook | length == 0 %}disabled{% endif %}>
         Réserver
     </a>
 

--- a/app/Resources/views/default/index.html.twig
+++ b/app/Resources/views/default/index.html.twig
@@ -70,7 +70,7 @@
                                 {% if (app.user.beneficiary.membership.registrations | length) and not app.user.beneficiary.membership | uptodate %}
                                     <p>
                                         <i class="material-icons">warning</i>
-                                        Ton adhésion a expirée le {{ "now"|date_modify((app.user.beneficiary.membership | remainder | date("%R%a"))~" days")| date_fr_long }}
+                                        Ton adhésion a expirée le {{ "now" | date_modify((app.user.beneficiary.membership | remainder | date("%R%a"))~" days")| date_fr_long }}
                                     </p>
                                     <a href="{{ path("user_self_register") }}" class="waves-effect waves-light light-green btn">
                                         <i class="material-icons left">card_membership</i>Je ré-adhère en ligne

--- a/app/Resources/views/member/_partial/shifts.html.twig
+++ b/app/Resources/views/member/_partial/shifts.html.twig
@@ -4,18 +4,18 @@
 {% set nextShifts = member.getShiftsOfCycle(1) %}
 
 {% if use_fly_and_fixed %}
-<div class="row">
-    <h6>Créneau fixe</h6>
-    {% if period_positions %}
-        {% for period_position in period_positions %}
-            <div class="col m4 s6">
-                {% include "user/_partial/period_position.html.twig" with { period_position: period_position } %}
-            </div>
-        {% endfor %}
-    {% else %}
-        <p>Pas de créneau fixe</p>
-    {% endif %}
-</div>
+    <div class="row">
+        <h6>Créneau fixe</h6>
+        {% if period_positions %}
+            {% for period_position in period_positions %}
+                <div class="col m4 s6">
+                    {% include "user/_partial/period_position.html.twig" with { period_position: period_position, show_actions: true } %}
+                </div>
+            {% endfor %}
+        {% else %}
+            <p>Pas de créneau fixe</p>
+        {% endif %}
+    </div>
 {% endif %}
 
 <div class="row">

--- a/app/Resources/views/member/_partial/shifts.html.twig
+++ b/app/Resources/views/member/_partial/shifts.html.twig
@@ -8,7 +8,7 @@
         <h6>Créneau fixe</h6>
         {% if period_positions %}
             {% for period_position in period_positions %}
-                <div class="col m4 s6">
+                <div class="col s12 m6 l4">
                     {% include "user/_partial/period_position.html.twig" with { period_position: period_position, show_actions: true } %}
                 </div>
             {% endfor %}
@@ -20,11 +20,11 @@
 
 <div class="row">
     <h6>Cycle précédent (du {{ member.startOfCycle(-1) | date_fr_long }} au {{ member.endOfCycle(-1) | date_fr_long }})</h6>
-    {% if previousShifts|length == 0 %}
+    {% if previousShifts | length == 0 %}
         Pas de créneau
     {% endif %}
     {% for shift in previousShifts %}
-        <div class="col m4 s6">
+        <div class="col s12 m6 l4">
             {% include "user/_partial/shift.html.twig" with { shift: shift } %}
         </div>
     {% endfor %}
@@ -32,11 +32,11 @@
 
 <div class="row">
     <h6>Cycle en cours (du {{ member.startOfCycle | date_fr_long }} au {{ member.endOfCycle | date_fr_long }})</h6>
-    {% if currentShifts|length == 0 %}
+    {% if currentShifts | length == 0 %}
         Pas de créneau
     {% endif %}
     {% for shift in currentShifts %}
-        <div class="col m4 s6">
+        <div class="col s12 m6 l4">
             {% include "user/_partial/shift.html.twig" with { shift: shift } %}
         </div>
     {% endfor %}
@@ -44,11 +44,11 @@
 
 <div class="row">
     <h6>Prochain cycle (du {{ member.startOfCycle(1) | date_fr_long }} au {{ member.endOfCycle(1) | date_fr_long }})</h6>
-    {% if nextShifts|length == 0 %}
+    {% if nextShifts | length == 0 %}
         Pas de créneau
     {% endif %}
     {% for shift in nextShifts %}
-        <div class="col m4 s6">
+        <div class="col s12 m6 l4">
             {% include "user/_partial/shift.html.twig" with { shift: shift } %}
         </div>
     {% endfor %}

--- a/app/Resources/views/user/_partial/mini_shift.html.twig
+++ b/app/Resources/views/user/_partial/mini_shift.html.twig
@@ -1,9 +1,25 @@
 <div class="card mini-shift {% if (shift.isDismissed) %}orange darken-4{% elseif shift.isPast %}grey lighten-2{% else %}cyan darken-4{% endif %}">
     <div class="card-content{% if not shift.isPast %} white-text{% endif %}">
         <span class="card-title">{{ shift.start|date_fr_long }} de {{ shift.start|date('H:i') }} à {{ shift.end|date('H:i') }}</span>
-        <p>{{ shift.shifter.firstname }} / <b class="{{ shift.job.color }}-text">{{ shift.job.name }}</b> </p>
+        <p>
+            {{ shift.shifter.firstname }} / <b class="{{ shift.job.color }}-text">{{ shift.job.name }}</b>
+        </p>
         {% if (shift.isDismissed) %}
             <p>Créneau annulé, en attente de repreneur</p>
         {% endif %}
     </div>
+    {% if use_card_reader_to_validate_shifts and shift.isPastOrCurrent %}
+        <div class="card-action center">
+            {% if (shift.wasCarriedOut) %}
+                <i class="material-icons tiny">check</i>
+                <span>effectué</span>
+            {% else %}
+                <i class="material-icons tiny">close</i>
+                <span>non effectué</span>
+            {% endif %}
+            {% if shift.isCurrent %}
+                <span>(créneau en cours)</span>
+            {% endif %}
+        </div>
+    {% endif %}
 </div>

--- a/app/Resources/views/user/_partial/period_position.html.twig
+++ b/app/Resources/views/user/_partial/period_position.html.twig
@@ -15,7 +15,7 @@
     <div class="card-action center">
         <i class="material-icons">person</i>{{ period_position.shifter.firstname }}
     </div>
-    {% if is_granted("ROLE_SHIFT_MANAGER") %}
+    {% if show_actions is defined and show_actions and is_granted("ROLE_SHIFT_MANAGER") %}
         <div class="card-action">
             <a href="{{ path("period_edit", { 'id': period_position.period.id }) }}" class="waves-effect waves-light btn white black-text" target="_blank">
                 <i class="material-icons left orange-text">date_range</i>Voir le créneau

--- a/app/Resources/views/user/_partial/period_position.html.twig
+++ b/app/Resources/views/user/_partial/period_position.html.twig
@@ -17,7 +17,7 @@
     </div>
     {% if show_actions is defined and show_actions and is_granted("ROLE_SHIFT_MANAGER") %}
         <div class="card-action">
-            <a href="{{ path("period_edit", { 'id': period_position.period.id }) }}" class="waves-effect waves-light btn white black-text" target="_blank">
+            <a href="{{ path("period_edit", { 'id': period_position.period.id }) }}" class="waves-effect waves-light btn white black-text" target="_blank" title="Voir le créneau">
                 <i class="material-icons left orange-text">date_range</i>Voir le créneau
             </a>
         </div>

--- a/app/Resources/views/user/_partial/shift.html.twig
+++ b/app/Resources/views/user/_partial/shift.html.twig
@@ -33,21 +33,29 @@
     <div class="card-action">
         {% if use_card_reader_to_validate_shifts and shift.isPastOrCurrent %}
             {% if shift.wasCarriedOut %}
-                <form action="{{ path('invalidate_shift', {'id' : shift.id }) }}" method="post" id="invalidate_shift_{{ shift.id }}">
-                    <button type="submit" class="btn red"><i class="material-icons left">highlight_off</i>Invalider la participation</button>
+                <form action="{{ path('invalidate_shift', {'id' : shift.id }) }}" method="POST" id="invalidate_shift_{{ shift.id }}">
+                    <button type="submit" class="btn red" title="Invalider la participation">
+                        <i class="material-icons left">highlight_off</i>Invalider la participation
+                    </button>
                 </form>
             {% else %}
-                <form action="{{ path('validate_shift', {'id' : shift.id }) }}" method="post" id="validate_shift_{{ shift.id }}">
-                    <button type="submit" class="btn green"><i class="material-icons left">check_circle</i>Valider la participation</button>
+                <form action="{{ path('validate_shift', {'id' : shift.id }) }}" method="POST" id="validate_shift_{{ shift.id }}">
+                    <button type="submit" class="btn green" title="Valider la participation">
+                        <i class="material-icons left">check_circle</i>Valider la participation
+                    </button>
                 </form>
             {% endif %}
         {% endif %}
         {% if is_granted('free',shift) %}
             <form action="{{ path('free_shift', { 'id' : shift.id }) }}" method="POST">
                 {% if shift.isPast %}
-                    <button type="submit" class="btn red"><i class="material-icons left">delete</i>Supprimer</button>
+                    <button type="submit" class="btn red" title="Supprimer">
+                        <i class="material-icons left">delete</i>Supprimer
+                    </button>
                 {% else %}
-                    <button type="submit" class="btn orange"><i class="material-icons left">lock_open</i>Libérer</button>
+                    <button type="submit" class="btn orange" title="Libérer">
+                        <i class="material-icons left">lock_open</i>Libérer
+                    </button>
                 {% endif %}
             </form>
         {% endif %}

--- a/src/AppBundle/Controller/BookingController.php
+++ b/src/AppBundle/Controller/BookingController.php
@@ -48,9 +48,15 @@ class BookingController extends Controller
             ->add('shift_id', HiddenType::class)
             ->getForm();
 
-        return $this->render('booking/home_booked_shifts.html.twig', [
-            'undismiss_shift_form' => $undismissShiftForm->createView()
-        ]);
+        $beneficiaries = $this->getUser()->getBeneficiary()->getMembership()->getBeneficiaries();
+
+        $em = $this->getDoctrine()->getManager();
+        $period_positions = $em->getRepository('AppBundle:PeriodPosition')->findByBeneficiaries($beneficiaries);
+
+        return $this->render('booking/home_booked_shifts.html.twig', array(
+            'undismiss_shift_form' => $undismissShiftForm->createView(),
+            'period_positions' => $period_positions,
+        ));
     }
 
 

--- a/src/AppBundle/Resources/public/css/custom.css
+++ b/src/AppBundle/Resources/public/css/custom.css
@@ -126,7 +126,15 @@ footer.page-footer {
 }
 /* Links */
 .card .card-action a.btn {
+  overflow: hidden;
+  white-space: nowrap;
+  width: 100%;
   color: white;
+}
+.card .card-action button.btn {
+  overflow: hidden;
+  white-space: nowrap;
+  width: 100%;
 }
 .btn,
 .btn-large {

--- a/src/AppBundle/Resources/public/css/custom.less
+++ b/src/AppBundle/Resources/public/css/custom.less
@@ -53,8 +53,18 @@ footer.page-footer{
 }
 
 /* Links */
-.card .card-action a.btn{
-  color: white;
+.card .card-action {
+  a.btn {
+    color: white;
+    overflow: hidden;
+    white-space: nowrap;
+    width: 100%;
+  }
+  button.btn {
+    overflow: hidden;
+    white-space: nowrap;
+    width: 100%;
+  }
 }
 .btn, .btn-large {
   color: #fff;


### PR DESCRIPTION
à la suite de https://github.com/elefan-grenoble/gestion-compte/pull/480

### Modifications apportées

- dans `views/booking/home_booked_shifts.html.twig` : nouvelle section qui affiche le/les créneau fixe du membre (généré depuis `BookingController.php`)
- ne pas afficher les `card-actions` dans `period_position.html.twig` si le créneau fixe est affiché depuis le dashboard (les actions admin se font coté admin)
- bien utiliser `{% if use_card_reader_to_validate_shifts %}` si l'on manipule `shift.wasCarriedOut`
- petits ajustements sur le CTA "Je réserve un créneau" avec l'ajout du mot "volant"
- améliorations du responsive en modifiant le nombre de cartes affichés par taille d'écran
- améliorations sur l'accessibilité en ajoutant le `title=` à certains boutons (le texte ne s'affiche pas nécessairement en entier sur les petits écrans)

### Capture d'écran

![Screenshot from 2022-08-24 00-55-26](https://user-images.githubusercontent.com/7147385/186283331-1d9165bd-47f9-4bb4-9e34-00a8ad255fde.png)

