### PR TITLE
Bugfix : last_shift_date peut être null

### DIFF
--- a/app/Resources/views/emails/shift_reminder.html.twig
+++ b/app/Resources/views/emails/shift_reminder.html.twig
@@ -6,14 +6,16 @@ Ceci est juste un petit message pour te rappeler que tu as réservé un créneau
 
 {{ dynamicContent | markdown | raw }}
 
-{% if (shift.shifter | last_shift_date | updates_list_from_date | length) %}
-Voici la liste des nouveautés à {{ project_name }} depuis ton dernier créneau le {{ shift.shifter | last_shift_date | date_fr_with_time  }}
+{% if shift.shifter | last_shift_date %}
+{% if shift.shifter | last_shift_date | updates_list_from_date | length %}
+Voici la liste des nouveautés à {{ project_name }} depuis ton dernier créneau le {{ shift.shifter | last_shift_date | date_fr_with_time }}
 <ul>
     {% for update in (shift.shifter | last_shift_date | updates_list_from_date) %}
         <li>{{ update.date | date_fr_long }} - <a href="{{ update.link }}">{{ update.title }}</a> : {{ update.description }}</a></li>
     {% endfor %}
 </ul>
-{%endif%}
+{% endif %}
+{% endif %}
 
 Belle journée à toi.<br >
 Céleste, la petite fée des créneaux :)

--- a/src/AppBundle/Twig/Extension/ProcessUpdateExtension.php
+++ b/src/AppBundle/Twig/Extension/ProcessUpdateExtension.php
@@ -28,7 +28,8 @@ class ProcessUpdateExtension extends AbstractExtension
         );
     }
 
-    public function last_shift_date(Beneficiary $beneficiary){
+    // can return null in sore rare cases
+    public function last_shift_date(Beneficiary $beneficiary) {
         $lastShifted = $this->container->get('doctrine')->getManager()->getRepository(Shift::class)->findLastShifted($beneficiary);
         if ($lastShifted)
             return $lastShifted->getStart();
@@ -36,15 +37,15 @@ class ProcessUpdateExtension extends AbstractExtension
             return $beneficiary->getUser()->getLastLogin();
     }
 
-    public function updates_list_from_date(\DateTime $date){
+    public function updates_list_from_date(\DateTime $date) {
         return $this->container->get('doctrine')->getManager()->getRepository(ProcessUpdate::class)->findFrom($date);
     }
 
-    public function count_updates_list_from_date(\DateTime $date){
+    public function count_updates_list_from_date(\DateTime $date) {
         return $this->container->get('doctrine')->getManager()->getRepository(ProcessUpdate::class)->countFrom($date);
     }
 
-    public function w3c_to_date($w3c){
+    public function w3c_to_date($w3c) {
         return \DateTime::createFromFormat(\DateTimeInterface::W3C,$w3c);
     }
 }


### PR DESCRIPTION
### Quoi ?

Répare une erreur qui survient parfois lors de l'envoi de l'email de rappel du créneau. Le template suppose que le filtre `last_shift_date` renvoie toujours une date, alors qu'il peut être `null`.

Dans quel cas pourrait-il être `null` ?
Si le `shift.shifter` correspond à un bénéficiaire qui fait son premier créneau + qui n'a pas activé son compte (ca arrive lorsqu'un Membership a plusieurs beneficiaries, que le 2e est nouveau, et que son premier créneau a été reservé par le mainBeneficiary (ou un admin))

```
{
    "exception": {
        "class": "Symfony\\Component\\Debug\\Exception\\FatalThrowableError",
        "message": "Type error: Argument 1 passed to AppBundle\\Twig\\Extension\\ProcessUpdateExtension::updates_list_from_date() must be an instance of DateTime, null given, called in /var/www/membres/var/cache/prod/twig/43/4326e64c2557d7c26725046d52fd20ec4cc8ffe997e16c89b1268b61b88f0b9b.php on line 66",
        "code": 0,
        "file": "/var/www/membres/src/AppBundle/Twig/Extension/ProcessUpdateExtension.php:39",
        "trace": [
            "/var/www/membres/var/cache/prod/twig/43/4326e64c2557d7c26725046d52fd20ec4cc8ffe997e16c89b1268b61b88f0b9b.php:66",
            "/var/www/membres/vendor/twig/twig/src/Template.php:405",
            "/var/www/membres/vendor/twig/twig/src/Template.php:378",
            "/var/www/membres/vendor/twig/twig/src/Template.php:390",
            "/var/www/membres/vendor/twig/twig/src/TemplateWrapper.php:45",
            "/var/www/membres/vendor/twig/twig/src/Environment.php:318",
            "/var/www/membres/src/AppBundle/Command/ShiftReminderCommand.php:66",
            "/var/www/membres/vendor/symfony/symfony/src/Symfony/Component/Console/Command/Command.php:255",
            "/var/www/membres/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:1010",
            "/var/www/membres/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Console/Application.php:86",
            "/var/www/membres/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:255",
            "/var/www/membres/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Console/Application.php:74",
            "/var/www/membres/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:148",
            "/var/www/membres/bin/console:27"
        ]
    }
}
```