### PR TITLE
UI : petites améliorations suite aux dernières PR

### DIFF
--- a/app/Resources/views/admin/booking/_partial/bucket_modal.html.twig
+++ b/app/Resources/views/admin/booking/_partial/bucket_modal.html.twig
@@ -11,7 +11,7 @@ It use the materialize modal class https://materializecss.com/modals.html
         {% endif %}
         <h4>Créneaux / <span class="{{ bucket.first.job.color }}-text">{{ bucket.first.job.name }}</span></h4>
         <h5>{{ bucket.start|date_fr_long }} de {{ bucket.start|date('G\\hi') }} à {{ bucket.end|date('G\\hi') }}</h5>
-        <span>remplissage : {{ nbShifts-nbBookableShifts }}/{{ nbShifts }} ({{ ((nbShifts-nbBookableShifts) / nbShifts)*100 }}%)</span>
+        <span>remplissage : {{ nbShifts-nbBookableShifts }}/{{ nbShifts }} ({{ (((nbShifts-nbBookableShifts) / nbShifts)*100) | round }}%)</span>
         <ul class="collapsible" data-collapsible="accordion">
             {% for shift in bucket.sortedShifts() %}
                 {% if shift.shifter %}{# is booked #}

--- a/app/Resources/views/admin/booking/index.html.twig
+++ b/app/Resources/views/admin/booking/index.html.twig
@@ -14,14 +14,16 @@
 </div>
 
 {# Filter form  --------- #}
-{{ form_start(filterForm) }}
 <ul class="collapsible" data-collapsible="accordion">
     <li>
-        <div class="collapsible-header"><i class="material-icons">tune</i>Filtres</div>
+        <div class="collapsible-header">
+            <i class="material-icons">tune</i>Filtres
+        </div>
         <div class="collapsible-body">
+            {{ form_start(filterForm) }}
             <div class="row">
                 <div class="input-field col m3">
-                    {{ form_widget(filterForm.type, { 'id': 'SelectionTypeDropBox'}) }}
+                    {{ form_widget(filterForm.type, { 'id': 'SelectionTypeDropBox' }) }}
                     {{ form_label(filterForm.type) }}
                 </div>
                 <div id="dateSelectionType">
@@ -45,14 +47,12 @@
                     </div>
                 </div>
             </div>
-            <div>
-                <div class="input-field col m3">
+            <div class="row">
+                <div class="input-field col m6">
                     {{ form_widget(filterForm.job) }}
                     {{ form_label(filterForm.job) }}
                 </div>
-            </div>
-            <div>
-                <div class="input-field col m3">
+                <div class="input-field col m6">
                     {{ form_widget(filterForm.filling) }}
                     {{ form_label(filterForm.filling) }}
                 </div>

--- a/app/Resources/views/admin/index.html.twig
+++ b/app/Resources/views/admin/index.html.twig
@@ -9,8 +9,7 @@
         <div class="container">
         {% if is_granted("ROLE_ADMIN_PANEL") %}
             <h4 class="row center">
-                <i class="material-icons large">build</i><br />
-                Admin
+                <i class="material-icons">build</i>&nbsp;Administration
             </h4>
 
             {% if is_granted("ROLE_USER_MANAGER") %}

--- a/app/Resources/views/admin/period/index.html.twig
+++ b/app/Resources/views/admin/period/index.html.twig
@@ -162,7 +162,7 @@
                 {# Actions ----------------------------------- #}
                 <li>
                     <div class="collapsible-header">
-                        <i class="material-icons">build</i>Action
+                        <i class="material-icons">build</i>Actions
                     </div>
                     <div class="collapsible-body">
                         <div class="row">

--- a/app/Resources/views/admin/period/index.html.twig
+++ b/app/Resources/views/admin/period/index.html.twig
@@ -145,7 +145,9 @@
             <ul class="collapsible" data-collapsible="accordion">
                 {# Filters  ---------------------------------- #}
                 <li>
-                    <div class="collapsible-header"><i class="material-icons">tune</i>Filtres</div>
+                    <div class="collapsible-header">
+                        <i class="material-icons">tune</i>Filtres
+                    </div>
                     <div class="collapsible-body">
                         {{ form_start(filter_form) }}
                         <div class="row">
@@ -153,15 +155,15 @@
                             {{ _self.input(filter_form.week) }}
                             {{ _self.input(filter_form.filling, not use_fly_and_fixed) }}
                         </div>
-                        <div class="row">
-                            {{ form_widget(filter_form.filter) }}
-                        </div>
+                        {{ form_widget(filter_form.filter) }}
                         {{ form_end(filter_form) }}
                     </div>
                 </li>
                 {# Actions ----------------------------------- #}
                 <li>
-                    <div class="collapsible-header"><i class="material-icons">build</i>Action</div>
+                    <div class="collapsible-header">
+                        <i class="material-icons">build</i>Action
+                    </div>
                     <div class="collapsible-body">
                         <div class="row">
                             <a href="{{ path("period_new") }}"

--- a/app/Resources/views/admin/period/index.html.twig
+++ b/app/Resources/views/admin/period/index.html.twig
@@ -170,51 +170,46 @@
                                class="btn col m4 waves-effect waves-light tooltipped"
                                data-position="bottom" data-html="true"
                                data-tooltip="Créer un groupe de créneaux type <br/> à une heure et un jour donné">
-                                <i class="material-icons left">note_add</i>Nouveau créneau type</a>
+                                <i class="material-icons left">note_add</i>Nouveau créneau type
+                            </a>
                         </div>
 
                         {% if is_granted("ROLE_ADMIN") %}
                             <div class="row">
                                 <a href="{{ path("period_copy") }}"
-                                   class="btn col m4 offset-m1 waves-effect waves-light tooltipped"
+                                   class="btn col m4 waves-effect waves-light tooltipped"
                                    data-position="bottom" data-html="true"
-                                   data-tooltip="<b>Admin :</b>Dupliquer Des créneaux types d'un jour vers un autre">
+                                   data-tooltip="<b>Admin :</b> Dupliquer des créneaux types d'un jour vers un autre">
                                     <i class="material-icons left">content_copy</i>Dupliquer des créneaux
                                 </a>
                             </div>
                             <div class="row">
                                 <a href="{{ path("shifts_generation") }}"
-                                   class="btn col m4 offset-m1 waves-effect waves-light tooltipped"
+                                   class="btn col m4 waves-effect waves-light tooltipped"
                                    data-position="bottom" data-html="true"
                                    data-tooltip="<b>Admin :</b> Générer automatiquement des créneaux à partir de la semaine type">
-                                    <i class="material-icons left">date_range</i> <i
-                                            class="material-icons left">build</i>
-                                    Générer des créneaux
+                                    <i class="material-icons left">date_range</i> <i class="material-icons left">build</i>Générer des créneaux
                                 </a>
                             </div>
                         {% endif %}
 
-
-                        <div class="row">
-                            {% if use_fly_and_fixed %}
-                            <a id="shifter" style="display: None;" onClick="showShifters()"
-                               class="btn col m4 waves-effect waves-light purple tooltipped"
-                               data-position="bottom" data-html="true"
-                               data-tooltip="Afficher le nom des membres inscrits en créneaux fix">
-                                <i class="material-icons left">accessibility</i>Afficher les membres
-                            </a>
-
-                            <a id="training" onClick="showTraining()"
-                               class="btn col m4 waves-effect waves-light purple tooltipped"
-                               data-position="bottom" data-html="true"
-                               data-tooltip="Afficher la formation demandée pour étre inscrit à un créneaux">
-                                <i class="material-icons left">accessibility</i>Afficher les formations
-                            </a>
-                        </div>
+                        {% if use_fly_and_fixed %}
+                            <div class="row">
+                                <a id="shifter" style="display: None;" onClick="showShifters()"
+                                class="btn col m4 waves-effect waves-light purple tooltipped"
+                                data-position="bottom" data-html="true"
+                                data-tooltip="Afficher le nom des membres inscrits en créneaux fixes">
+                                    <i class="material-icons left">accessibility</i>Afficher les membres
+                                </a>
+                                <a id="training" onClick="showTraining()"
+                                class="btn col m4 waves-effect waves-light purple tooltipped"
+                                data-position="bottom" data-html="true"
+                                data-tooltip="Afficher la formation demandée pour étre inscrit à un créneau">
+                                    <i class="material-icons left">accessibility</i>Afficher les formations
+                                </a>
+                            </div>
                         {% endif %}
-
                     </div>
-
                 </li>
             </ul>
         </div>

--- a/src/AppBundle/Controller/BookingController.php
+++ b/src/AppBundle/Controller/BookingController.php
@@ -225,7 +225,7 @@ class BookingController extends Controller
                 ],
             ])
             ->add('job', EntityType::class, array(
-                'label' => 'Type',
+                'label' => 'Type de créneau',
                 'class' => 'AppBundle:Job',
                 'choice_label' => 'name',
                 'multiple' => false,

--- a/src/AppBundle/Controller/PeriodController.php
+++ b/src/AppBundle/Controller/PeriodController.php
@@ -57,7 +57,7 @@ class PeriodController extends Controller
         $res["form"] = $this->createFormBuilder()
             ->setAction($this->generateUrl('period'))
             ->add('job', EntityType::class, array(
-                'label' => 'Type',
+                'label' => 'Type de créneau',
                 'class' => 'AppBundle:Job',
                 'choice_label' => 'name',
                 'multiple' => false,


### PR DESCRIPTION
Liste des améliorations
- renommer le filtre "Type" en "Type de créneau"
- améliorer l'affichage des boutons action sur la page "Semaine type"
- éviter d'afficher 33.3333% (utiliser `| round`)
- renommer le titre de la page Admin en "Administration"