### PR TITLE
Améliore l'affichage du header sur les écrans "medium-size"

### DIFF
--- a/app/Resources/views/admin/service/navlist.html.twig
+++ b/app/Resources/views/admin/service/navlist.html.twig
@@ -1,5 +1,8 @@
 {% for service in services %}
     <li>
-        <a href="{{ service.url }}"><i class="material-icons small left">{{ service.Icon }}</i>{{ service.slug }}</a>
+        <a href="{{ service.url }}" title="{{ service.slug }}">
+            <i class="material-icons small left">{{ service.Icon }}</i>
+            <span class="show-on-xl-only">{{ service.slug }}</span>
+        </a>
     </li>
 {% endfor %}

--- a/app/Resources/views/layout.html.twig
+++ b/app/Resources/views/layout.html.twig
@@ -41,8 +41,9 @@
                     <ul id="nav-desktop" class="right hide-on-med-and-down">
                         {% if is_granted("ROLE_ADMIN_PANEL") %}
                             <li class="highlight">
-                                <a href="{{ path("admin") }}" class="">
-                                    <i class="material-icons left">build</i><span class="show-on-xl-only">Administration</span>
+                                <a href="{{ path("admin") }}" title="Administration">
+                                    <i class="material-icons left">build</i>
+                                    <span class="show-on-xl-only">Administration</span>
                                 </a>
                             </li>
                         {% endif %}
@@ -50,18 +51,22 @@
                             {{ render(controller("AppBundle:Service:navlist")) }}
                             {% if app.user.beneficiary %}
                                 <li>
-                                    <a href="{{ path('fos_user_profile_show') }}">
+                                    <a href="{{ path('fos_user_profile_show') }}" title="{{ app.user.firstname }}">
                                         <i class="material-icons small left">settings</i>
-                                        <small class="show-on-xl-only">{{ app.user.firstname }}</small>
+                                        <span class="show-on-xl-only">{{ app.user.firstname }}</span>
                                     </a>
                                 </li>
                             {% endif %}
                             <li>
-                                <a href="{{ path('fos_user_security_logout') }}"><i class="material-icons small right">exit_to_app</i></a>
+                                <a href="{{ path('fos_user_security_logout') }}">
+                                    <i class="material-icons small right">exit_to_app</i>
+                                </a>
                             </li>
                         {% else %}
                             <li>
-                                <a href="{{ path('fos_user_security_login') }}">{{ 'layout.login'|trans({}, 'FOSUserBundle') }}</a>
+                                <a href="{{ path('fos_user_security_login') }}">
+                                    {{ 'layout.login'|trans({}, 'FOSUserBundle') }}
+                                </a>
                             </li>
                         {% endif %}
                     </ul>


### PR DESCRIPTION
### Quoi ?

Petits ajustements d'affichage du header
- mettre le nom du bénéficiaire à la même taille que les autres texte
- cacher le texte (et garder seulement les icones) à des tailles intermédiaires
- mettre des `title` pour avoir du texte qui apparait lorsqu'on passe la souris sur les icones

### Pourquoi ?

Meilleur lisibilité sur les écrans de taille moyenne.
Permettre aussi de rajouter des services supplémentaires dans le futur

### Captures d'écran

Avant

![Screenshot from 2022-09-28 00-04-33](https://user-images.githubusercontent.com/7147385/192646016-e0f7bbf3-6092-46ea-80f4-5c8657509c66.png)
![Screenshot from 2022-09-28 00-04-53](https://user-images.githubusercontent.com/7147385/192646037-bfee7e93-f05e-406a-a688-96f98f2d70df.png)

Après

![Screenshot from 2022-09-28 00-06-27](https://user-images.githubusercontent.com/7147385/192646146-17b1b4a5-117c-4cc9-b844-f1c88cf777e1.png)
![Screenshot from 2022-09-28 00-06-13](https://user-images.githubusercontent.com/7147385/192646199-5df4de7b-b61d-4c37-b4c2-06e08bc86f7e.png)
