### PR TITLE
Ajustements suite à la mise à jour de Materialize CSS

### DIFF
--- a/src/AppBundle/Resources/public/js/datepicker.js
+++ b/src/AppBundle/Resources/public/js/datepicker.js
@@ -40,10 +40,11 @@ timepickerSettings = {
 }
 
 jQuery(function() {
+    // Note: preventDefault? to avoid having the native date/time picker to popup (happens on some browsers...)
     // Date only datepicker
-    $('input.datepicker').datepicker(datepickerSettings);
-    $('input.timepicker').timepicker(timepickerSettings);
+    $('input.datepicker').on('click', function(e) { e.preventDefault(); }).datepicker(datepickerSettings);
+    $('input.timepicker').on('click', function(e) { e.preventDefault(); }).timepicker(timepickerSettings);
     // Splitted DateTime datepicker
-    $('div.datepicker > input[type=date]').datepicker(datepickerSettings);
-    $('div.datepicker > input[type=time]').timepicker(timepickerSettings);
+    $('div.datepicker > input[type=date]').on('click', function(e) {e.preventDefault(); }).datepicker(datepickerSettings);
+    $('div.datepicker > input[type=time]').on('click', function(e) { e.preventDefault(); }).timepicker(timepickerSettings);
 });


### PR DESCRIPTION
### Quoi ?

Suite de https://github.com/elefan-grenoble/gestion-compte/pull/515

- [x] répare le double popup du date (ou time) picker sur certains navigateurs
-> retirer materialize du composer.json (dans une autre PR)

### Captures d'écran

Exemple de double popup sur Firefox (ne se produit pas sur Chrome) : 

Avant | Après
--------| ---------
![Screenshot from 2022-09-29 17-03-09](https://user-images.githubusercontent.com/7147385/193068109-317b802d-0b1a-482d-9fe9-f836ba1953ce.png) | ![Screenshot from 2022-09-29 17-03-22](https://user-images.githubusercontent.com/7147385/193068348-cf8be0d4-4173-41c4-b9d4-ae0e8a7e1f2f.png)
