### PR TITLE
Ajustements supplémentaires suite à la mise à jour de Materialize CSS

### DIFF
--- a/app/Resources/views/admin/booking/_partial/bucket_modal.html.twig
+++ b/app/Resources/views/admin/booking/_partial/bucket_modal.html.twig
@@ -94,7 +94,7 @@ It use the materialize modal class https://materializecss.com/modals.html
                         </div>
                         <div class="collapsible-body">
                             <div class="row">
-                                <div class="col {% if use_fly_and_fixed %}s7{% else %}s9{% endif %}">
+                                <div class="col {% if use_fly_and_fixed %}s7{% else %}s9{% endif %} input-field">
                                     <input id="benef{{ shift.id }}" type="text" class="autocomplete" name="beneficiary" placeholder="Beneficiaire" />
                                 </div>
                                 {% if use_fly_and_fixed %}

--- a/app/Resources/views/admin/booking/_partial/bucket_modal.html.twig
+++ b/app/Resources/views/admin/booking/_partial/bucket_modal.html.twig
@@ -95,7 +95,7 @@ It use the materialize modal class https://materializecss.com/modals.html
                         <div class="collapsible-body">
                             <div class="row">
                                 <div class="col {% if use_fly_and_fixed %}s7{% else %}s9{% endif %}">
-                                    <input id="benef{{ shift.id }}" type="text" class="empty-shift" name="beneficiary" placeholder="Beneficiaire" />
+                                    <input id="benef{{ shift.id }}" type="text" class="autocomplete" name="beneficiary" placeholder="Beneficiaire" />
                                 </div>
                                 {% if use_fly_and_fixed %}
                                     <div class="col s2">

--- a/app/Resources/views/admin/booking/_partial/bucket_modal.html.twig
+++ b/app/Resources/views/admin/booking/_partial/bucket_modal.html.twig
@@ -95,17 +95,21 @@ It use the materialize modal class https://materializecss.com/modals.html
                         <div class="collapsible-body">
                             <div class="row">
                                 <div class="col {% if use_fly_and_fixed %}s7{% else %}s9{% endif %}">
-                                    <input id ="benef{{ shift.id }}" type="text" class="empty-shift" name="beneficiary" placeholder="Beneficiaire">
+                                    <input id="benef{{ shift.id }}" type="text" class="empty-shift" name="beneficiary" placeholder="Beneficiaire" />
                                 </div>
                                 {% if use_fly_and_fixed %}
                                     <div class="col s2">
                                         <div>
-                                            <input type="radio" id="volant{{ shift.id }}" class="checkedTypeService{{ shift.id }}" name="typeService{{ shift.id }}" checked value=0>
-                                            <label for="volant{{ shift.id }}" style="color: #5f5a5a; font-weight: 600;">volant</label>
+                                            <label for="volant{{ shift.id }}" style="color: #5f5a5a; font-weight: 600;">
+                                                <input type="radio" id="volant{{ shift.id }}" class="checkedTypeService{{ shift.id }}" name="typeService{{ shift.id }}" checked value=0 />
+                                                <span>volant</span>
+                                            </label>
                                         </div>
                                         <div>
-                                            <input type="radio" id="fixe{{ shift.id }}" class="checkedTypeService{{ shift.id }}" name="typeService{{ shift.id }}" value=1>
-                                            <label for="fixe{{ shift.id }}" style="color: #5f5a5a; font-weight: 600;">fixe</label>
+                                            <label for="fixe{{ shift.id }}" style="color: #5f5a5a; font-weight: 600;">
+                                                <input type="radio" id="fixe{{ shift.id }}" class="checkedTypeService{{ shift.id }}" name="typeService{{ shift.id }}" value=1 />
+                                                <span>fixe</span>
+                                            </label>
                                         </div>
                                     </div>
                                     <div class="col s3">
@@ -113,7 +117,7 @@ It use the materialize modal class https://materializecss.com/modals.html
                                     </div>
                                 {% else %}
                                     <div class="col s3">
-                                        <input type="hidden" class="checkedTypeService{{ shift.id }}" name="typeService{{ shift.id }}" value=0>
+                                        <input type="hidden" class="checkedTypeService{{ shift.id }}" name="typeService{{ shift.id }}" value=0 />
                                         <button class="btn add" onclick="postShift({{ shift.id }})">Ajouter</button>
                                     </div>
                                 {% endif %}

--- a/app/Resources/views/admin/booking/index.html.twig
+++ b/app/Resources/views/admin/booking/index.html.twig
@@ -9,7 +9,6 @@
 {% endblock %}
 
 {% block content %}
-{# Title --------- #}
 <div class="row center">
     <h4 class="header">Administration des créneaux</h4>
 </div>
@@ -58,8 +57,8 @@
                     {{ form_label(filterForm.filling) }}
                 </div>
             </div>
-
             {{ form_widget(filterForm.filter) }}
+        </div>
     </li>
 </ul>
 {{ form_end(filterForm) }}
@@ -93,48 +92,43 @@
 
 {% block javascripts %}
     <script>
-
         $(document).ready(function ($) {
             // for the filter form ------------------
-            $('#SelectionTypeDropBox')
-                .on('change', function () {
-
-                    if (this.value === "0") {
-                        $('#weekSelectionType').show();
-                        $('#dateSelectionType').hide();
-                    } else {
-                        $('#weekSelectionType').hide();
-                        $('#dateSelectionType').show();
-                    }
-                })
-                .trigger('change');
+            $('#SelectionTypeDropBox').on('change', function () {
+                if (this.value === "0") {
+                    $('#weekSelectionType').show();
+                    $('#dateSelectionType').hide();
+                } else {
+                    $('#weekSelectionType').hide();
+                    $('#dateSelectionType').show();
+                }
+            })
+            .trigger('change');
 
             // for the bucket modification popup----------------
-            $('input.empty-shift')
-                .autocomplete({
-                    data: {
-                        {% for beneficiary in beneficiaries %}
+            $('input.autocomplete').autocomplete({
+                data: {
+                    {% for beneficiary in beneficiaries %}
                         "{{ beneficiary.autocompleteLabel }}": null,
-                        {% endfor %}
-                    },
-                    // The max amount of results that
-                    // can be shown at once. Default: Infinity.
-                    limit: 10,
-                    onAutocomplete: function (val) {
-                        // Callback function when value is autocomplete.
-                        $('button.add').removeAttr('disabled');
-                    },
-                    // The minimum length of the input for
-                    // the autocomplete to start. Default: 1.
-                    minLength: 2,
-                })
-                .keydown(function () {
-                    $('button.add:not(:disabled)').attr('disabled', 'disabled');
-                });
+                    {% endfor %}
+                },
+                // The max amount of results that
+                // can be shown at once. Default: Infinity.
+                limit: 10,
+                onAutocomplete: function (val) {
+                    // Callback function when value is autocomplete.
+                    $('button.add').removeAttr('disabled');
+                },
+                // The minimum length of the input for
+                // the autocomplete to start. Default: 1.
+                minLength: 2,
+            })
+            .keydown(function () {
+                $('button.add:not(:disabled)').attr('disabled', 'disabled');
+            });
         })
 
         function postShift(shiftId) {
-
             {% if use_fly_and_fixed %}
             let selectedTypeService = document.querySelector('.checkedTypeService'+shiftId+':checked');
             {% else %}

--- a/app/Resources/views/admin/member/join.html.twig
+++ b/app/Resources/views/admin/member/join.html.twig
@@ -18,19 +18,15 @@
 
     {{ form_start(form) }}
         <div class="row">
-            <div class="col s12">
-                <div class="row">
-                    <div class="input-field col m6 s12">
-                        <i class="material-icons prefix">person</i>
-                        {{ form_widget(form.from_text) }}
-                        {{ form_label(form.from_text) }}
-                    </div>
-                    <div class="input-field col m6 s12">
-                        <i class="material-icons prefix">person</i>
-                        {{ form_widget(form.dest_text) }}
-                        {{ form_label(form.dest_text) }}
-                    </div>
-                </div>
+            <div class="input-field col m6 s12">
+                <i class="material-icons prefix">person</i>
+                {{ form_widget(form.from_text) }}
+                {{ form_label(form.from_text) }}
+            </div>
+            <div class="input-field col m6 s12">
+                <i class="material-icons prefix">person</i>
+                {{ form_widget(form.dest_text) }}
+                {{ form_label(form.dest_text) }}
             </div>
         </div>
         {{ form_widget(form.join) }}
@@ -39,14 +35,14 @@
 
 {% block javascripts %}
     <script>
-        jQuery(function ($) {
-            $('input[name="form[from_text]"],input[name="form[dest_text]"]').autocomplete({
+        $(document).ready(function() {
+            $('input.autocomplete').autocomplete({
                 data: {
-            {% for member in members %}
-                {% if member.mainBeneficiary %}
-                    "#{{ member.memberNumber }} {{ member.mainBeneficiary.firstname }} {{ member.mainBeneficiary.lastname }}" : null,
-                {% endif %}
-            {% endfor %}
+                    {% for member in members %}
+                        {% if member.mainBeneficiary %}
+                            "#{{ member.memberNumber }} {{ member.mainBeneficiary.firstname }} {{ member.mainBeneficiary.lastname }}": null,
+                        {% endif %}
+                    {% endfor %}
                 },
                 limit: 10, // The max amount of results that can be shown at once. Default: Infinity.
                 onAutocomplete: function(val) {

--- a/app/Resources/views/admin/period/edit.html.twig
+++ b/app/Resources/views/admin/period/edit.html.twig
@@ -82,10 +82,10 @@
                             <div class="collapsible-body">
                                 <div class="row">
                                     <div class="col {% if use_fly_and_fixed %}s7{% else %}s9{% endif %}">
-                                        <input id ="benef{{ position.id }}" type="text" class="empty-position" name="beneficiary" placeholder="Beneficiaire">
+                                        <input id ="benef{{ position.id }}" type="text" class="autocomplete" name="beneficiary" placeholder="Beneficiaire" />
                                     </div>
                                     <div class="col s3">
-                                        <input type="hidden" class="checkedTypeService{{ position.id }}" name="typeService{{ position.id }}" value=0>
+                                        <input type="hidden" class="checkedTypeService{{ position.id }}" name="typeService{{ position.id }}" value=0 />
                                         <button type="button" class="btn add" onclick="postPosition({{ position.id }})">Ajouter</button>
                                     </div>
                                 </div>
@@ -134,8 +134,8 @@
 
 {% block javascripts %}
     <script>
-        jQuery(function ($) {
-            $('input.empty-position').autocomplete({
+        $(document).ready(function ($) {
+            $('input.autocomplete').autocomplete({
                 data: {
                     {% for beneficiary in beneficiaries %}
                         "{{ beneficiary.autocompleteLabel }}" : null,

--- a/app/Resources/views/admin/period/edit.html.twig
+++ b/app/Resources/views/admin/period/edit.html.twig
@@ -81,7 +81,7 @@
                             </div>
                             <div class="collapsible-body">
                                 <div class="row">
-                                    <div class="col {% if use_fly_and_fixed %}s7{% else %}s9{% endif %}">
+                                    <div class="col {% if use_fly_and_fixed %}s7{% else %}s9{% endif %} input-field">
                                         <input id ="benef{{ position.id }}" type="text" class="autocomplete" name="beneficiary" placeholder="Beneficiaire" />
                                     </div>
                                     <div class="col s3">
@@ -154,7 +154,6 @@
         })
 
         function postPosition(positionId) {
-
             let selectedBenef = document.getElementById('benef'+positionId);
 
             if (selectedBenef != null) {

--- a/app/Resources/views/booking/_partial/modal.html.twig
+++ b/app/Resources/views/booking/_partial/modal.html.twig
@@ -66,13 +66,12 @@
             <p>Nombre de places restantes : {{ nbBookableShifts }}/{{ nbShifts }}</p>
             {% for availableShift in availableShifts %}
                 <div>
-                    <input type="radio" id="{{ availableShift.id }}" class="checkedFormation" name="formation"
-                           value="{{ availableShift.id }}">
                     <label for="{{ availableShift.id }}" style="color: #5f5a5a; font-weight: 600;">
+                        <input type="radio" id="{{ availableShift.id }}" class="checkedFormation" name="formation" value="{{ availableShift.id }}" />
                         {% if availableShift.formation %}
-                            {{ availableShift.formation.name }}
+                            <span>{{ availableShift.formation.name }}</span>
                         {% else %}
-                            sans formation particulière
+                            <span>sans formation particulière</span>
                         {% endif %}
                     </label>
                 </div>
@@ -80,15 +79,19 @@
             {% if use_fly_and_fixed %}
                 <p>Ce créneau sera fait en tant que :</p>
                 <div>
-                    <input type="radio" id="volant{{ firstBookable.id }}" class="checkedTypeService" name="typeService" value=0>
-                    <label for="volant{{ firstBookable.id }}" style="color: #5f5a5a; font-weight: 600;">volant (une seule fois)</label>
+                    <label for="volant{{ firstBookable.id }}" style="color: #5f5a5a; font-weight: 600;">
+                        <input type="radio" id="volant{{ firstBookable.id }}" class="checkedTypeService" name="typeService" value=0 />
+                        <span>volant (une seule fois)</span>
+                    </label>
                 </div>
                 <div>
-                    <input type="radio" id="fixe{{ firstBookable.id }}" class="checkedTypeService" name="typeService" value=1>
-                    <label for="fixe{{ firstBookable.id }}" style="color: #5f5a5a; font-weight: 600;">fixe (reporté à chaque cycle)</label>
+                    <label for="fixe{{ firstBookable.id }}" style="color: #5f5a5a; font-weight: 600;">
+                        <input type="radio" id="fixe{{ firstBookable.id }}" class="checkedTypeService" name="typeService" value=1 />
+                        <span>fixe (reporté à chaque cycle)</span>
+                    </label>
                 </div>
             {% else %}
-                <input type="hidden" name="typeService" value=0>
+                <input type="hidden" name="typeService" value=0 />
             {% endif %}
             <div class="" style="position: fixed;top:0;width: 100%;left: 0;">
                 {% if nbBookableShifts < nbShifts %}

--- a/app/Resources/views/booking/index.html.twig
+++ b/app/Resources/views/booking/index.html.twig
@@ -130,7 +130,6 @@
     <script>
         jQuery(function () {
             $('.collapsible li').click();
-            $('.modal').modal();
             $('#legend .collapsible-header').on('click',function () {
                 var data_raw = Cookies.get("frontend");
                 var data = undefined;

--- a/src/AppBundle/Controller/MembershipController.php
+++ b/src/AppBundle/Controller/MembershipController.php
@@ -840,8 +840,8 @@ class MembershipController extends Controller
     public function joinAction(Request $request)
     {
         $form = $this->createFormBuilder()
-            ->add('from_text', TextType::class, array('label' => 'Adhérent a joindre'))
-            ->add('dest_text', TextType::class, array('label' => 'au compte de l\'adhérent'))
+            ->add('from_text', TextType::class, array('label' => 'Adhérent a joindre', 'attr' => array('class' => 'autocomplete')))
+            ->add('dest_text', TextType::class, array('label' => 'au compte de l\'adhérent', 'attr' => array('class' => 'autocomplete')))
             ->add('join', SubmitType::class, array('label' => 'Joindre les deux comptes', 'attr' => array('class' => 'btn')))
             ->getForm();
         $form->handleRequest($request);

--- a/src/AppBundle/Resources/public/js/app.js
+++ b/src/AppBundle/Resources/public/js/app.js
@@ -12,11 +12,12 @@ $(document).ready(function() {
     $('.modal').modal({
         ready: function (modal) {
             $(modal).find('.simplemde-container').trigger('modalOpen'); //tell markdown editor to refresh
-            },
+        },
     });
     $('.collapsible').collapsible();
     $('.tooltipped').tooltip();
     $(".dropdown-button").dropdown();
+    // $('input.autocomplete').autocomplete({});  // see specific files
 });
 
 function myCookieInit(defaultData){

--- a/src/AppBundle/Resources/public/js/app.js
+++ b/src/AppBundle/Resources/public/js/app.js
@@ -1,23 +1,22 @@
 $(document).ready(function() {
+    // initialize Materialize behavior - https://materializecss.com/
     $('select').formSelect();
     // $('datepicker').datepicker();  // see datepicker.js
     $('.sidenav').sidenav({
         menuWidth: 300, // Default is 300
         edge: 'left', // Choose the horizontal origin
         closeOnClick: true, // Closes side-nav on <a> clicks, useful for Angular/Meteor
-        draggable: true, // Choose whether you can drag to open on touch screens,
-        onOpen: function(el) { /* Do Stuff */ }, // A function to be called when sideNav is opened
-        onClose: function(el) { /* Do Stuff */ }, // A function to be called when sideNav is closed
+        draggable: true, // Choose whether you can drag to open on touch screens
     });
     $('.modal').modal({
         ready: function (modal) {
-            $(modal).find('.simplemde-container').trigger('modalOpen'); //tell markdown editor to refresh
+            $(modal).find('.simplemde-container').trigger('modalOpen'); // tell markdown editor to refresh
         },
     });
     $('.collapsible').collapsible();
     $('.tooltipped').tooltip();
-    $(".dropdown-button").dropdown();
-    // $('input.autocomplete').autocomplete({});  // see specific files
+    $(".dropdown-trigger").dropdown();
+    // $('input.autocomplete').autocomplete();  // see specific files for initialization & configuration
 });
 
 function myCookieInit(defaultData){


### PR DESCRIPTION
### Quoi ?

Suite de https://github.com/elefan-grenoble/gestion-compte/pull/515

- [x] répare l'affichage des input radio
- [x] répare l'autocomplete sur les pages `/booking/admin` & `/period/edit`
  - ajout de `input-field` à l'élément parent
  - homogénéisation des selectors en `input.autocomplete`