### PR TITLE
Créneau fixe : répare l'affichage du jour de la semaine

### DIFF
--- a/src/AppBundle/Entity/Period.php
+++ b/src/AppBundle/Entity/Period.php
@@ -105,8 +105,8 @@ class Period
      */
     public function getDayOfWeekString()
     {
-        // return jddayofweek($this->dayOfWeek, CAL_DOW_LONG);  # in english...
-        return date('l', strtotime("Monday + {$this->dayOfWeek} days"));
+        setlocale(LC_TIME, 'fr_FR.UTF8');
+        return strftime("%A", strtotime("Monday + {$this->dayOfWeek} days"));
     }
 
     /**


### PR DESCRIPTION
Avant : jour de la semaine en anglais | Après : jour de la semaine en français
--- | ---
![Screenshot from 2022-10-07 15-19-44](https://user-images.githubusercontent.com/7147385/194564619-70b484fa-0d0a-4213-b861-7e7339967519.png) | ![Screenshot from 2022-10-07 15-19-56](https://user-images.githubusercontent.com/7147385/194564622-bda7cf76-b4c3-4e97-8dae-246cc116739a.png)
