### PR TITLE
Orienter les membres qui souhaitent geler leur compte

### DIFF
--- a/app/Resources/views/Profile/show_content.html.twig
+++ b/app/Resources/views/Profile/show_content.html.twig
@@ -24,7 +24,13 @@
                 <i class="material-icons">ac_unit</i>Gel du compte
             </div>
             <div class="collapsible-body">
-                {% include "member/_partial/frozen.html.twig" with { member: member } %}
+                {% if display_freeze_account %}
+                    {% include "member/_partial/frozen.html.twig" with { member: member } %}
+                {% else %}
+                    <p class="red-text">
+                        {{ display_freeze_account_false_message }}
+                    </p>
+                {% endif %}
             </div>
         </li>
 

--- a/app/Resources/views/Profile/show_content.html.twig
+++ b/app/Resources/views/Profile/show_content.html.twig
@@ -10,7 +10,9 @@
     </h5>
     <ul class="collapsible">
         <li>
-            <div class="collapsible-header"><i class="material-icons">person</i>Mes informations</div>
+            <div class="collapsible-header">
+                <i class="material-icons">person</i>Mes informations
+            </div>
             <div class="collapsible-body">
                 {% include "beneficiary/_partial/info.html.twig" with { beneficiary: beneficiary } %}
                 <a href="{{ path('fos_user_profile_edit') }}" class="btn waves-effect waves-light"><i class="material-icons left">mode_edit</i>Editer</a>
@@ -18,14 +20,18 @@
         </li>
 
         <li>
-            <div class="collapsible-header"><i class="material-icons">ac_unit</i>Gel du compte</div>
+            <div class="collapsible-header">
+                <i class="material-icons">ac_unit</i>Gel du compte
+            </div>
             <div class="collapsible-body">
                 {% include "member/_partial/frozen.html.twig" with { member: member } %}
             </div>
         </li>
 
         <li>
-            <div class="collapsible-header"><i class="material-icons">credit_card</i>Badge{% if beneficiary.swipeCards | length > 1%}s{% endif %}</div>
+            <div class="collapsible-header">
+                <i class="material-icons">credit_card</i>Badge{% if beneficiary.swipeCards | length > 1%}s{% endif %}
+            </div>
             <div class="collapsible-body">
                 {% include "member/_partial/swipe_card.html.twig" with { member: member, showBadgeImage: true } %}
             </div>
@@ -33,7 +39,9 @@
 
         {% if app.user.clients | length %}
             <li>
-                <div class="collapsible-header"><i class="material-icons">extension</i>Services</div>
+                <div class="collapsible-header">
+                    <i class="material-icons">extension</i>Services
+                </div>
                 <div class="collapsible-body">
                     <table>
                         <thead>

--- a/app/Resources/views/member/_partial/frozen.html.twig
+++ b/app/Resources/views/member/_partial/frozen.html.twig
@@ -1,46 +1,53 @@
 {% if not member.frozen %}
     {% if member.frozenChange %}
-        <br>
+        <br />
         Comme demandé, mon compte sera gelé à la fin de mon cycle courant. soit le
         <strong>{{ member.endOfCycle | date_modify('+1 day') |date_fr_long }}</strong>
-        <br>
-        <a class="btn-large waves-effect waves-light btn orange"
-           href="{{ path('member_freeze_change',{ 'id' : member.id }) }}">
-            <i class="material-icons left">cancel</i>
-            Annuler le gel de mon compte</a>
+        <br />
+        <a class="btn-large waves-effect waves-light btn orange" href="{{ path('member_freeze_change',{ 'id' : member.id }) }}">
+            <i class="material-icons left">cancel</i>Annuler le gel de mon compte
+        </a>
     {% else %}
+        <a class="waves-effect waves-light btn modal-trigger blue" href="#pause">
+            <i class="material-icons left">ac_unit</i>Geler mon compte
+        </a>
 
-        <a class="waves-effect waves-light btn modal-trigger blue" href="#pause"><i class="material-icons left">ac_unit</i>Geler
-            mon compte</a>
         <!-- Modal Structure -->
-        <div id="pause" class="modal">
+        <div class="modal" id="pause">
             <div class="modal-content">
-                <h5><i class="material-icons left small">ac_unit</i>Gel de compte</h5>
-                <p>Besoin de faire une pause ? demande le gel de ton compte ! <br> Pendant le gel, tu n'as plus accès au
-                    magasin, mais tu n'es pas engagé par le bénévolat.
-                    <br>Le gel sera effectif dès le début de ton prochain cycle, soit le
+                <h5>
+                    <i class="material-icons small">ac_unit</i>&nbsp;Gel de compte
+                </h5>
+                <p>
+                    Besoin de faire une pause ? demande le gel de ton compte !
+                    <br />
+                    Pendant le gel, tu n'as plus accès au magasin, mais tu n'es pas engagé par le bénévolat.
+                    <br />
+                    Le gel sera effectif dès le début de ton prochain cycle, soit le
                     <strong>{{ member.endOfCycle | date_modify("+1 day") | date_fr_long }}</strong> et
                     reste actif pour <strong>au minimum un cycle complet</strong>.
-                    <br>Tu peux demander le dégel à tout moment.</p>
+                    <br />
+                    Tu peux demander le dégel à tout moment.
+                </p>
             </div>
             <div class="modal-footer">
                 <a href="#!" class="modal-action modal-close waves-effect waves-green btn-flat red-text">Retour</a>
-                <a class="waves-effect waves-light btn green"
-                   href="{{ path('member_freeze_change',{ 'id' : member.id }) }}"><i
-                            class="material-icons left">check</i>Ok, je gèle mon compte</a>
+                <a class="waves-effect waves-light btn green" href="{{ path('member_freeze_change',{ 'id' : member.id }) }}">
+                    <i class="material-icons left">check</i>Ok, je gèle mon compte
+                </a>
             </div>
         </div>
     {% endif %}
 {% else %}
     {% if member.frozenChange %}
         Mon compte sera degelé à la fin de mon cycle courrant qui termine le {{ member.endOfCycle |date_fr_long }}<br>
-        <a class="btn-large waves-effect waves-light btn orange"
-           href="{{ path('member_freeze_change',{ 'id' : member.id }) }}"><i class="material-icons left">cancel</i>Annuler
-            la demande de degel de mon compte</a>
+        <a class="btn-large waves-effect waves-light btn orange" href="{{ path('member_freeze_change',{ 'id' : member.id }) }}">
+            <i class="material-icons left">cancel</i>Annuler la demande de degel de mon compte
+        </a>
     {% else %}
         Mon compte est gelé
-        <a class="btn-large waves-effect waves-light btn green"
-           href="{{ path('member_freeze_change',{ 'id' : member.id }) }}"><i class="material-icons left">play_circle_filled</i>Demander
-            le dégèle de mon compte</a>
+        <a class="btn-large waves-effect waves-light btn green" href="{{ path('member_freeze_change',{ 'id' : member.id }) }}">
+            <i class="material-icons left">play_circle_filled</i>Demander le dégèle de mon compte
+        </a>
     {% endif %}
 {% endif %}

--- a/app/Resources/views/member/show.html.twig
+++ b/app/Resources/views/member/show.html.twig
@@ -225,8 +225,7 @@
                                     <i class="material-icons left">cancel</i>Annuler la demande de dégel du compte
                                 </a>
                             {% else %}
-                                <a href="{{ path("member_freeze_change",{"id":member.id}) }}"
-                                   class="waves-effect waves-light btn waves-purple purple lighten-2">
+                                <a href="{{ path("member_freeze_change",{"id":member.id}) }}" class="waves-effect waves-light btn waves-purple purple lighten-2">
                                     <i class="material-icons left">play_arrow</i>Dégeler le compte à la fin du cycle
                                 </a>
                             {% endif %}
@@ -239,7 +238,9 @@
                             </a>
                             <div id="pause" class="modal">
                                 <div class="modal-content">
-                                    <h5><i class="material-icons left small">pause_circle_filled</i>Gel immédiat du compte</h5>
+                                    <h5>
+                                        <i class="material-icons left small">pause_circle_filled</i>Gel immédiat du compte
+                                    </h5>
                                     <p>Attention, le gel immédiat sera effectif dés aujourd'hui, interdisant l'accès au magasin</p>
                                     <p>De plus, à la fin du cycle, les heures effectuées ne seront pas décomptées.</p>
                                 </div>
@@ -256,7 +257,9 @@
                             </a>
                             <div id="unpause" class="modal">
                                 <div class="modal-content">
-                                    <h5><i class="material-icons left small">play_arrow</i>Dégel immédiat du compte</h5>
+                                    <h5>
+                                        <i class="material-icons left small">play_arrow</i>Dégel immédiat du compte
+                                    </h5>
                                     <p>Attention, le dégel immédiat sera effectif dés aujourd'hui, réautorisant l'accès au magasin</p>
                                     <p>De plus, les heures de bénévolat sont dues pour ce cycle.</p>
                                 </div>
@@ -285,7 +288,9 @@
                         </a>
                         <div id="close-member" class="modal">
                             <div class="modal-content">
-                                <h5><i class="material-icons left small">remove_circle_outline</i>Fermeture du compte membre</h5>
+                                <h5>
+                                    <i class="material-icons left small">remove_circle_outline</i>Fermeture du compte membre
+                                </h5>
                                 <p>Attention, vous êtes sur le point de fermer le compte du membre.</p>
                             </div>
                             <div class="modal-footer">
@@ -301,7 +306,9 @@
                         </a>
                         <div id="reopen-member" class="modal">
                             <div class="modal-content">
-                                <h5><i class="material-icons left small">info_outline</i>Ré-ouverture du compte membre</h5>
+                                <h5>
+                                    <i class="material-icons left small">info_outline</i>Ré-ouverture du compte membre
+                                </h5>
                                 <p>Attention, vous êtes sur le point de ré-ouvrir le compte du membre.</p>
                             </div>
                             <div class="modal-footer">

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -66,6 +66,7 @@ twig:
     display_gauge: '%display_gauge%'
     display_swipe_cards_settings: '%display_swipe_cards_settings%'
     display_freeze_account: '%display_freeze_account%'
+    display_freeze_account_false_message: '%display_freeze_account_false_message%'
     display_keys_shop: '%display_keys_shop%'
     display_name_shifters: '%display_name_shifters%'
     use_card_reader_to_validate_shifts: '%use_card_reader_to_validate_shifts%'

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -120,4 +120,5 @@ parameters:
 
     code_generation_enabled: true
     display_freeze_account: true
+    display_freeze_account_false_message: "Le gel de compte n'est pas autorisé."
     display_keys_shop: true


### PR DESCRIPTION
Il existe déjà un paramètre `display_freeze_account` pour autoriser les membres à geler eux-même leur compte.

Ajout d'un nouveau paramètre `display_freeze_account_false_message`, qui s'affiche lorsque le premier paramètre est `false`.

(ce paramètre est configurable et modifiable en fonction des besoins de la coop, permettant de détailler/orienter le membre)

### Capture d'écran

Home > Gérer mon compte
![Screenshot from 2022-10-08 16-03-41](https://user-images.githubusercontent.com/7147385/194711469-d75160fa-4a18-41d3-b59f-095ef967d53c.png)
