### PR TITLE
Refactoring de l'affichage des créneaux

### DIFF
--- a/app/Resources/views/booking/_partial/home_shift_card.html.twig
+++ b/app/Resources/views/booking/_partial/home_shift_card.html.twig
@@ -1,4 +1,4 @@
-<div class="card sticky-action {% if (shift.isDismissed) %}orange lighten-2{% elseif (shift.isCurrent) %}deep-purple white-text{% elseif (shift.isPast) %}grey lighten-2{% else %}cyan darken-4 white-text{% endif %}">
+<div class="card center sticky-action {% if (shift.isDismissed) %}orange darken-4 white-text{% elseif (shift.isCurrent) %}deep-purple white-text{% elseif (shift.isPast) %}grey lighten-2{% else %}cyan darken-4 white-text{% endif %}">
     <div class="card-content">
         {% include "user/_partial/shift_card_header.html.twig" with { shift: shift } %}
     </div>
@@ -23,13 +23,11 @@
                 </div>
                 <div class="modal-footer">
                     <a href="#!" class="modal-action modal-close waves-effect waves-green btn-flat red-text">Retour</a>
-                    <a href="#"
-                       class="modal-action modal-close waves-effect waves-green btn teal"
+                    <a href="#" class="modal-action modal-close waves-effect waves-green btn teal"
                        onclick="$('#form_shift_id').val({{ shift.id }});$('#undismiss_shift').submit();">Oui, je reprends<span class="hide-on-med-and-down"> mon créneau</span></a>
                 </div>
             </div>
-
-            {{ form_start(undismiss_shift_form,{ 'attr' : { 'id' : 'undismiss_shift'}}) }}
+            {{ form_start(undismiss_shift_form,{ 'attr' : { 'id' : 'undismiss_shift' } }) }}
             {{ form_widget(undismiss_shift_form) }}
             {{ form_end(undismiss_shift_form) }}
         {% else %}

--- a/app/Resources/views/booking/_partial/home_shift_card.html.twig
+++ b/app/Resources/views/booking/_partial/home_shift_card.html.twig
@@ -1,6 +1,6 @@
 <div class="card sticky-action {% if (shift.isDismissed) %}orange lighten-2{% elseif (shift.isCurrent) %}deep-purple white-text{% elseif (shift.isPast) %}grey lighten-2{% else %}cyan darken-4 white-text{% endif %}">
     <div class="card-content">
-        <span class="card-title">{{ shift.start|date_fr_long }} de {{ shift.start|date('H:i') }} à {{ shift.end|date('H:i') }}</span>
+        <span class="card-title">{{ shift.start | date_fr_long }} de {{ shift.start | date('H:i') }} à {{ shift.end | date('H:i') }}</span>
         <p>
             <i class="material-icons">person</i>{{ shift.shifter.firstname }} / <b class="{{ shift.job.color }}-text">{{ shift.job.name }}</b>
             {% if use_fly_and_fixed %}
@@ -17,21 +17,14 @@
             <b class="red-text text-darken-4">Créneau en attente d'être repris par un autre bénévole</b>
         {% endif %}
     </div>
-    {% if shift.isCurrent %}
-        <div class="card-action">
-            <a href="#contact{{ shift.id }}" id="more{{ shift.id }}" class="modal-trigger"><i class="material-icons right">more</i></a><span>créneau en cours</span>
-        </div>
-    {% elseif shift.isPast %}
-        {% if use_card_reader_to_validate_shifts %}
+    {% if shift.isPastOrCurrent %}
+        {% if shift.isCurrent %}
             <div class="card-action">
-                {% if (shift.wasCarriedOut) %}
-                    <i class="material-icons tiny">check</i>
-                    <span>effectué</span>
-                {% else %}
-                    <i class="material-icons tiny">close</i>
-                    <span>non effectué</span>
-                {% endif %}
+                <a href="#contact{{ shift.id }}" id="more{{ shift.id }}" class="modal-trigger"><i class="material-icons right">more</i></a><span>créneau en cours</span>
             </div>
+            {% endif %}
+        {% if use_card_reader_to_validate_shifts %}
+            {% include "user/_partial/shift_card_validation_status.html.twig" with { shift: shift } %}
         {% endif %}
     {% else %}
         {% if shift.isDismissed %}
@@ -73,8 +66,7 @@
                             </div>
                         </div>
                         <div class="modal-footer">
-                            <a href="#!"
-                            class="modal-action modal-close waves-effect waves-green btn-flat grey-text ">Retour à la raison</a>
+                            <a href="#!" class="modal-action modal-close waves-effect waves-green btn-flat grey-text ">Retour à la raison</a>
                             <button class="modal-action modal-close waves-effect waves-green btn red ">Oui, je me désiste !</button>
                         </div>
                     </form>
@@ -84,5 +76,5 @@
     {% endif %}
 </div>
 {% if (shift.isUpcoming or shift.isCurrent) %}
-    {{ render(controller("AppBundle:Default:shiftContactForm", { 'shift':shift })) }}
+    {{ render(controller("AppBundle:Default:shiftContactForm", { "shift": shift })) }}
 {% endif %}

--- a/app/Resources/views/booking/_partial/home_shift_card.html.twig
+++ b/app/Resources/views/booking/_partial/home_shift_card.html.twig
@@ -20,7 +20,8 @@
     {% if shift.isPastOrCurrent %}
         {% if shift.isCurrent %}
             <div class="card-action">
-                <a href="#contact{{ shift.id }}" id="more{{ shift.id }}" class="modal-trigger"><i class="material-icons right">more</i></a><span>créneau en cours</span>
+                <a href="#contact{{ shift.id }}" id="more{{ shift.id }}" class="modal-trigger" title="Contacter les bénévoles du créneau"><i class="material-icons right">email</i></a>
+                <span>créneau en cours</span>
             </div>
             {% endif %}
         {% if use_card_reader_to_validate_shifts %}

--- a/app/Resources/views/booking/_partial/home_shift_card.html.twig
+++ b/app/Resources/views/booking/_partial/home_shift_card.html.twig
@@ -1,21 +1,6 @@
 <div class="card sticky-action {% if (shift.isDismissed) %}orange lighten-2{% elseif (shift.isCurrent) %}deep-purple white-text{% elseif (shift.isPast) %}grey lighten-2{% else %}cyan darken-4 white-text{% endif %}">
     <div class="card-content">
-        <span class="card-title">{{ shift.start | date_fr_long }} de {{ shift.start | date('H:i') }} à {{ shift.end | date('H:i') }}</span>
-        <p>
-            <i class="material-icons">person</i>{{ shift.shifter.firstname }} / <b class="{{ shift.job.color }}-text">{{ shift.job.name }}</b>
-            {% if use_fly_and_fixed %}
-                <br>
-                Type : <b>{% if shift.fixe %}Fixe{% else %}Volant{% endif %}</b>
-            {% endif %}
-            {% if shift.formation != null %}
-                <br>
-                Formation : <b>{{ shift.formation }}</b>
-            {% endif %}
-        </p>
-        {% if shift.isDismissed %}
-            <br>
-            <b class="red-text text-darken-4">Créneau en attente d'être repris par un autre bénévole</b>
-        {% endif %}
+        {% include "user/_partial/shift_card_header.html.twig" with { shift: shift } %}
     </div>
     {% if shift.isPastOrCurrent %}
         {% if shift.isCurrent %}

--- a/app/Resources/views/booking/_partial/reserved_shift_card.html.twig
+++ b/app/Resources/views/booking/_partial/reserved_shift_card.html.twig
@@ -1,19 +1,6 @@
 <div class="card cyan lighten-5">
     <div class="card-content">
-        <span class="card-title">{{ shift.start|date_fr_long }}</span>
-        <p>
-            De {{ shift.start|date('H:i') }} à {{ shift.end|date('H:i') }}
-            <br />
-            <i class="material-icons">person</i>{{ shift.lastShifter.firstname }} / <b class="{{ shift.job.color }}-text">{{ shift.job.name }}</b>
-            {% if use_fly_and_fixed %}
-                <br />
-                Type : <b>{% if shift.fixe %}Fixe{% else %}Volant{% endif %}</b>
-            {% endif %}
-            {% if shift.formation != null %}
-                <br />
-                Formation : <b>{{ shift.formation }}</b>
-            {% endif %}
-        </p>
+        {% include "user/_partial/shift_card_header.html.twig" with { shift: shift } %}
     </div>
     <div class="card-action">
         <a href="#accept{{ shift.id }}" class="modal-trigger btn waves-effect waves-green green">J'accepte</a>

--- a/app/Resources/views/booking/_partial/reserved_shift_card.html.twig
+++ b/app/Resources/views/booking/_partial/reserved_shift_card.html.twig
@@ -1,4 +1,4 @@
-<div class="card cyan lighten-5">
+<div class="card center cyan lighten-5">
     <div class="card-content">
         {% include "user/_partial/shift_card_header.html.twig" with { shift: shift } %}
     </div>

--- a/app/Resources/views/user/_partial/mini_shift_card.html.twig
+++ b/app/Resources/views/user/_partial/mini_shift_card.html.twig
@@ -1,6 +1,6 @@
 <div class="card mini-shift {% if (shift.isDismissed) %}orange darken-4{% elseif shift.isPast %}grey lighten-2{% else %}cyan darken-4{% endif %}">
     <div class="card-content{% if not shift.isPast %} white-text{% endif %}">
-        <span class="card-title">{{ shift.start|date_fr_long }} de {{ shift.start|date('H:i') }} à {{ shift.end|date('H:i') }}</span>
+        <span class="card-title">{{ shift.start | date_fr_long }} de {{ shift.start | date('H:i') }} à {{ shift.end | date('H:i') }}</span>
         <p>
             {{ shift.shifter.firstname }} / <b class="{{ shift.job.color }}-text">{{ shift.job.name }}</b>
         </p>
@@ -9,17 +9,6 @@
         {% endif %}
     </div>
     {% if use_card_reader_to_validate_shifts and shift.isPastOrCurrent %}
-        <div class="card-action center">
-            {% if (shift.wasCarriedOut) %}
-                <i class="material-icons tiny">check</i>
-                <span>effectué</span>
-            {% else %}
-                <i class="material-icons tiny">close</i>
-                <span>non effectué</span>
-            {% endif %}
-            {% if shift.isCurrent %}
-                <span>(créneau en cours)</span>
-            {% endif %}
-        </div>
+        {% include "user/_partial/shift_card_validation_status.html.twig" with { shift: shift } %}
     {% endif %}
 </div>

--- a/app/Resources/views/user/_partial/mini_shift_card.html.twig
+++ b/app/Resources/views/user/_partial/mini_shift_card.html.twig
@@ -1,12 +1,6 @@
 <div class="card mini-shift {% if (shift.isDismissed) %}orange darken-4{% elseif shift.isPast %}grey lighten-2{% else %}cyan darken-4{% endif %}">
     <div class="card-content{% if not shift.isPast %} white-text{% endif %}">
-        <span class="card-title">{{ shift.start | date_fr_long }} de {{ shift.start | date('H:i') }} à {{ shift.end | date('H:i') }}</span>
-        <p>
-            {{ shift.shifter.firstname }} / <b class="{{ shift.job.color }}-text">{{ shift.job.name }}</b>
-        </p>
-        {% if (shift.isDismissed) %}
-            <p>Créneau annulé, en attente de repreneur</p>
-        {% endif %}
+        {% include "user/_partial/shift_card_header.html.twig" with { shift: shift } %}
     </div>
     {% if use_card_reader_to_validate_shifts and shift.isPastOrCurrent %}
         {% include "user/_partial/shift_card_validation_status.html.twig" with { shift: shift } %}

--- a/app/Resources/views/user/_partial/mini_shift_card.html.twig
+++ b/app/Resources/views/user/_partial/mini_shift_card.html.twig
@@ -1,5 +1,5 @@
-<div class="card mini-shift {% if (shift.isDismissed) %}orange darken-4{% elseif shift.isPast %}grey lighten-2{% else %}cyan darken-4{% endif %}">
-    <div class="card-content{% if not shift.isPast %} white-text{% endif %}">
+<div class="card center mini-shift {% if (shift.isDismissed) %}orange darken-4 white-text{% elseif (shift.isPast) %}grey lighten-2{% else %}cyan darken-4 white-text{% endif %}">
+    <div class="card-content">
         {% include "user/_partial/shift_card_header.html.twig" with { shift: shift } %}
     </div>
     {% if use_card_reader_to_validate_shifts and shift.isPastOrCurrent %}

--- a/app/Resources/views/user/_partial/period_position_card.html.twig
+++ b/app/Resources/views/user/_partial/period_position_card.html.twig
@@ -1,19 +1,18 @@
-<div class="card">
+<div class="card center">
     <div class="card-content">
         <span class="card-title">
             {{ period_position.period.getDayOfWeekString() }} de {{ period_position.period.start | date('H:i') }} à {{ period_position.period.end | date('H:i') }}
             <small>(Semaine {{ period_position.weekCycle }})</small>
         </span>
         <p>
+            <i class="material-icons">person</i>{{ period_position.shifter.firstname }}
+            <br />
             <b class="{{ period_position.period.job.color }}-text">{{ period_position.period.job.name }}</b>
             {% if period_position.formation != null %}
                 <br />
                 Formation : <b>{{ period_position.formation }}</b>
             {% endif %}
         </p>
-    </div>
-    <div class="card-action center">
-        <i class="material-icons">person</i>{{ period_position.shifter.firstname }}
     </div>
     {% if show_actions is defined and show_actions and is_granted("ROLE_SHIFT_MANAGER") %}
         <div class="card-action">

--- a/app/Resources/views/user/_partial/shift_card.html.twig
+++ b/app/Resources/views/user/_partial/shift_card.html.twig
@@ -1,20 +1,6 @@
 <div class="card {% if (shift.isDismissed) %}orange darken-4{% elseif shift.isPast %}grey lighten-2{% else %}cyan darken-4{% endif %}">
     <div class="card-content{% if not shift.isPast %} white-text{% endif %}">
-        <span class="card-title">{{ shift.start | date_fr_long }} de {{ shift.start | date('H:i') }} à {{ shift.end | date('H:i') }}</span>
-        <p>
-            <i class="material-icons">person</i>{{ shift.shifter.firstname }} / <b class="{{ shift.job.color }}-text">{{ shift.job.name }}</b>
-            {% if use_fly_and_fixed %}
-                <br />
-                Type : <b>{% if shift.fixe %}Fixe{% else %}Volant{% endif %}</b>
-            {% endif %}
-            {% if shift.formation != null %}
-                <br />
-                Formation : <b>{{ shift.formation }}</b>
-            {% endif %}
-        </p>
-        {% if (shift.isDismissed) %}
-            <p>Créneau annulé, en attente de repreneur</p>
-        {% endif %}
+        {% include "user/_partial/shift_card_header.html.twig" with { shift: shift } %}
     </div>
     {% if use_card_reader_to_validate_shifts and shift.isPastOrCurrent %}
         {% include "user/_partial/shift_card_validation_status.html.twig" with { shift: shift } %}

--- a/app/Resources/views/user/_partial/shift_card.html.twig
+++ b/app/Resources/views/user/_partial/shift_card.html.twig
@@ -1,5 +1,5 @@
-<div class="card {% if (shift.isDismissed) %}orange darken-4{% elseif shift.isPast %}grey lighten-2{% else %}cyan darken-4{% endif %}">
-    <div class="card-content{% if not shift.isPast %} white-text{% endif %}">
+<div class="card center {% if (shift.isDismissed) %}orange darken-4 white-text{% elseif (shift.isCurrent) %}deep-purple white-text{% elseif (shift.isPast) %}grey lighten-2{% else %}cyan darken-4 white-text{% endif %}">
+    <div class="card-content">
         {% include "user/_partial/shift_card_header.html.twig" with { shift: shift } %}
     </div>
     {% if use_card_reader_to_validate_shifts and shift.isPastOrCurrent %}

--- a/app/Resources/views/user/_partial/shift_card.html.twig
+++ b/app/Resources/views/user/_partial/shift_card.html.twig
@@ -1,6 +1,6 @@
 <div class="card {% if (shift.isDismissed) %}orange darken-4{% elseif shift.isPast %}grey lighten-2{% else %}cyan darken-4{% endif %}">
     <div class="card-content{% if not shift.isPast %} white-text{% endif %}">
-        <span class="card-title">{{ shift.start|date_fr_long }} de {{ shift.start|date('H:i') }} à {{ shift.end|date('H:i') }}</span>
+        <span class="card-title">{{ shift.start | date_fr_long }} de {{ shift.start | date('H:i') }} à {{ shift.end | date('H:i') }}</span>
         <p>
             <i class="material-icons">person</i>{{ shift.shifter.firstname }} / <b class="{{ shift.job.color }}-text">{{ shift.job.name }}</b>
             {% if use_fly_and_fixed %}
@@ -17,18 +17,7 @@
         {% endif %}
     </div>
     {% if use_card_reader_to_validate_shifts and shift.isPastOrCurrent %}
-        <div class="card-action center">
-            {% if (shift.wasCarriedOut) %}
-                <i class="material-icons tiny">check</i>
-                <span>effectué</span>
-            {% else %}
-                <i class="material-icons tiny">close</i>
-                <span>non effectué</span>
-            {% endif %}
-            {% if shift.isCurrent %}
-                <span>(créneau en cours)</span>
-            {% endif %}
-        </div>
+        {% include "user/_partial/shift_card_validation_status.html.twig" with { shift: shift } %}
     {% endif %}
     <div class="card-action">
         {% if use_card_reader_to_validate_shifts and shift.isPastOrCurrent %}

--- a/app/Resources/views/user/_partial/shift_card_header.html.twig
+++ b/app/Resources/views/user/_partial/shift_card_header.html.twig
@@ -1,0 +1,18 @@
+<span class="card-title">{{ shift.start | date_fr_long }} de {{ shift.start | date('H:i') }} à {{ shift.end | date('H:i') }}</span>
+<p>
+    <i class="material-icons">person</i>{{ shift.shifter.firstname }}
+    <br />
+    <b class="{{ shift.job.color }}-text">{{ shift.job.name }}</b>
+    {% if use_fly_and_fixed %}
+        <br />
+        Type : <b>{% if shift.fixe %}Fixe{% else %}Volant{% endif %}</b>
+    {% endif %}
+    {% if shift.formation != null %}
+        <br />
+        Formation : <b>{{ shift.formation }}</b>
+    {% endif %}
+</p>
+{% if (shift.isDismissed) %}
+    <br>
+    <b class="red-text text-darken-4">Créneau annulé, en attente d'être repris par un autre bénévole</b>
+{% endif %}

--- a/app/Resources/views/user/_partial/shift_card_validation_status.html.twig
+++ b/app/Resources/views/user/_partial/shift_card_validation_status.html.twig
@@ -1,0 +1,12 @@
+<div class="card-action center">
+    {% if (shift.wasCarriedOut) %}
+        <i class="material-icons tiny">check</i>
+        <span>effectué</span>
+    {% else %}
+        <i class="material-icons tiny">close</i>
+        <span>non effectué</span>
+    {% endif %}
+    {% if shift.isCurrent %}
+        <strong>(créneau en cours)</strong>
+    {% endif %}
+</div>


### PR DESCRIPTION
Les "card" créneau sont visibles à plusieurs endroits, et avec des formats légèrement différents : 
- `booking/_partial/home_shift_card.html.twig`
- `booking/_partial/reserved_shift_card.html.twig`
- `user/_partial/mini_shift_card.html.twig`

à défaut de pouvoir utiliser un seul et même template pour toutes ces "card" (spécificités d'affichage, de bouton admin supplémentaires, etc), on refactore seulement certains morceaux des templates : 
- créé `shift_card_validation_status.html.twig`
- créé `shift_card_header.html.twig`
- centrer les cartes
- homogéniser la couleur (background, texte) en fonction du statut