### PR TITLE
Répare l'affichage du header sur les petits écrans

### DIFF
--- a/app/Resources/views/admin/service/navlist.html.twig
+++ b/app/Resources/views/admin/service/navlist.html.twig
@@ -2,7 +2,7 @@
     <li>
         <a href="{{ service.url }}" title="{{ service.slug }}">
             <i class="material-icons small left">{{ service.Icon }}</i>
-            <span class="show-on-xl-only">{{ service.slug }}</span>
+            <span class="show-on-medium-and-down show-on-xl-only">{{ service.slug }}</span>
         </a>
     </li>
 {% endfor %}

--- a/app/Resources/views/layout.html.twig
+++ b/app/Resources/views/layout.html.twig
@@ -71,7 +71,10 @@
                         {% endif %}
                     </ul>
 
-                    <ul id="nav-mobile" class="sidenav">
+                    <a href="#" data-target="nav-mobile" class="sidenav-trigger show-on-medium-and-down">
+                        <i class="material-icons">menu</i>
+                    </a>
+                    <ul id="nav-mobile" class="sidenav show-on-medium-and-down">
                         {% if is_granted("IS_AUTHENTICATED_REMEMBERED") %}
                             {% set frozen = app.user.beneficiary and app.user.beneficiary.membership.frozen %}
                             <li>
@@ -87,34 +90,47 @@
                                         {% endimage %}
                                         {% endif %}
                                     </div>
-                                    <a href="#user"><img class="circle" src="{{ gravatar(app.user.email) }}"></a>
-                                    <a href="#name"><span class="{% if not frozen %}white-text{% else %}black-text{% endif %} name">{{ app.user }}</span></a>
+                                    <a href="#user">
+                                        <img class="circle" src="{{ gravatar(app.user.email) }}">
+                                    </a>
+                                    <a href="#name">
+                                        <span class="{% if not frozen %}white-text{% else %}black-text{% endif %} name">{{ app.user }}</span>
+                                    </a>
                                 </div>
                             </li>
                             <li>
-                                <a href="{{ path('homepage') }}"><i class="material-icons small">home</i>Accueil</a>
+                                <a href="{{ path('homepage') }}">
+                                    <i class="material-icons small">home</i>Accueil
+                                </a>
                             </li>
                             {% if app.user.beneficiary %}
                                 <li>
-                                    <a href="{{ path('fos_user_profile_show') }}"><i class="material-icons">settings</i>Mon profil ({{ app.user.username}})</a>
+                                    <a href="{{ path('fos_user_profile_show') }}">
+                                        <i class="material-icons">settings</i>Mon profil ({{ app.user.username}})
+                                    </a>
                                 </li>
                             {% endif %}
                             {% if is_granted("ROLE_ADMIN_PANEL") %}
                                 <li class="indigo lighten-5">
-                                    <a href="{{ path("admin") }}" class=""><i class="material-icons left indigo-text darken-4">build</i>Administration</a>
+                                    <a href="{{ path("admin") }}" class="">
+                                        <i class="material-icons left indigo-text darken-4">build</i>Administration
+                                    </a>
                                 </li>
                             {% endif %}
                             {{ render(controller("AppBundle:Service:navlist")) }}
                             <li>
-                                <a href="{{ path('fos_user_security_logout') }}"><i class="material-icons small">exit_to_app</i>{{ 'layout.logout'|trans({}, 'FOSUserBundle') }}</a>
+                                <a href="{{ path('fos_user_security_logout') }}">
+                                    <i class="material-icons small">exit_to_app</i>{{ 'layout.logout'|trans({}, 'FOSUserBundle') }}
+                                </a>
                             </li>
                         {% else %}
                             <li>
-                                <a href="{{ path('fos_user_security_login') }}"><span class="glyphicon glyphicon-log-in"></span> {{ 'layout.login'|trans({}, 'FOSUserBundle') }}</a>
+                                <a href="{{ path('fos_user_security_login') }}">
+                                    <span class="glyphicon glyphicon-log-in"></span> {{ 'layout.login'|trans({}, 'FOSUserBundle') }}
+                                </a>
                             </li>
                         {% endif %}
                     </ul>
-                    <a href="#" data-target="nav-mobile" class="sidenav-trigger hide-on-large-and-up"><i class="material-icons">menu</i></a>
                 </div>
             </nav>
         </header>


### PR DESCRIPTION
Suite à la PR https://github.com/elefan-grenoble/gestion-compte/pull/517 je suis allé un peu vite, et je n'ai pas pris en compte l'affichage mobile (menu + sidebar).
Réparé :pray: 

Avant | Après
--- | ---
![Screenshot from 2022-10-11 21-30-53](https://user-images.githubusercontent.com/7147385/195212404-3d88e8d1-e8a8-4601-858b-ec1f64ef26a4.png) | ![Screenshot from 2022-10-12 00-48-35](https://user-images.githubusercontent.com/7147385/195212419-9abfb017-18f3-490d-a998-f2b6deed994b.png)
