### PR TITLE
Rôles : permettre à un ROLE_ADMIN de créer un événement

### DIFF
--- a/app/Resources/views/admin/event/list.html.twig
+++ b/app/Resources/views/admin/event/list.html.twig
@@ -63,8 +63,6 @@
     </div>
     {% if is_granted("ROLE_ADMIN") %}
         <a href="{{ path("proxies_list") }}" class="btn"><i class="material-icons left">list</i>Toutes les procurations</a>
-    {% endif %}
-    {% if is_granted("ROLE_SUPER_ADMIN") %}
         <a href="{{ path('event_new') }}" class="btn"><i class="material-icons left">add</i>Ajouter un événement</a>
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
Avant : 
- action déjà possible pour un ROLE_ADMIN (en connaissant l'url `/event/new`)
- mais le bouton n'apparaissait que pour les ROLE_SUPER_ADMIN

Après : 
- le bouton apparaît aussi pour les ROLE_ADMIN