### PR TITLE
Rôles : permettre à un ROLE_ADMIN de supprimer un événement

### DIFF
--- a/src/AppBundle/Controller/EventController.php
+++ b/src/AppBundle/Controller/EventController.php
@@ -148,7 +148,7 @@ class EventController extends Controller
      *
      * @Route("/{id}", name="event_delete")
      * @Method({"DELETE"})
-     * @Security("has_role('ROLE_SUPER_ADMIN')")
+     * @Security("has_role('ROLE_ADMIN')")
      */
     public function removeAction(Request $request,Event $event)
     {


### PR DESCRIPTION
Avant : 
- le bouton "Supprimer" apparaît déjà pour les ROLE_ADMIN (url `/event/<id>/edit`)
- mais l'action n'est pas possible pour un ROLE_ADMIN

Après : 
- l'action est maintenant possible pour un ROLE_ADMIN