### PR TITLE
Admin : permettre à un n'importe quel ROLE_ADMIN_PANEL d'accéder à l'admin

### DIFF
--- a/src/AppBundle/Controller/AdminController.php
+++ b/src/AppBundle/Controller/AdminController.php
@@ -51,7 +51,7 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
  * User controller.
  *
  * @Route("admin")
- * @Security("has_role('ROLE_USER_MANAGER')")
+ * @Security("has_role('ROLE_ADMIN_PANEL')")
  */
 class AdminController extends Controller
 {


### PR DESCRIPTION
Il y a actuellement un "bug" où seuls les `ROLE_USER_MANAGER` peuvent en fait accéder à la page /admin.

Corrigé pour élargir l'accès.