### PR TITLE
SwipeCardLog : pouvoir les rattacher à SwipeCard

### DIFF
--- a/app/DoctrineMigrations/Version20221027201240.php
+++ b/app/DoctrineMigrations/Version20221027201240.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20221027201240 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE swipe_card_log ADD swipe_card_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE swipe_card_log ADD CONSTRAINT FK_EB23E311C81A7349 FOREIGN KEY (swipe_card_id) REFERENCES swipe_card (id)');
+        $this->addSql('CREATE INDEX IDX_EB23E311C81A7349 ON swipe_card_log (swipe_card_id)');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE swipe_card_log DROP FOREIGN KEY FK_EB23E311C81A7349');
+        $this->addSql('DROP INDEX IDX_EB23E311C81A7349 ON swipe_card_log');
+        $this->addSql('ALTER TABLE swipe_card_log DROP swipe_card_id');
+    }
+}

--- a/app/Resources/views/Profile/show_content.html.twig
+++ b/app/Resources/views/Profile/show_content.html.twig
@@ -34,14 +34,16 @@
             </div>
         </li>
 
-        <li>
-            <div class="collapsible-header">
-                <i class="material-icons">credit_card</i>Badge{% if beneficiary.swipeCards | length > 1%}s{% endif %}
-            </div>
-            <div class="collapsible-body">
-                {% include "member/_partial/swipe_card.html.twig" with { member: member, showBadgeImage: true } %}
-            </div>
-        </li>
+        {% if display_swipe_cards_settings %}
+            <li>
+                <div class="collapsible-header">
+                    <i class="material-icons">credit_card</i>Badge{% if beneficiary.swipeCards | length > 1%}s{% endif %}
+                </div>
+                <div class="collapsible-body">
+                    {% include "member/_partial/swipe_card.html.twig" with { member: member, showBadgeImage: true } %}
+                </div>
+            </li>
+        {% endif %}
 
         {% if app.user.clients | length %}
             <li>

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -107,6 +107,7 @@ parameters:
 
     # Swipe card configuration
     swipe_card_logging: true
+    swipe_card_logging_anonymous: true
     display_swipe_cards_settings: true
 
     logging.mattermost.enabled: false

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -33,6 +33,7 @@ services:
     AppBundle\Controller\DefaultController:
         arguments:
             - '%swipe_card_logging%'
+            - '%swipe_card_logging_anonymous%'
     AppBundle\Controller\AmbassadorController:
         arguments:
             - "%time_after_which_members_are_late_with_shifts%"

--- a/src/AppBundle/Controller/DefaultController.php
+++ b/src/AppBundle/Controller/DefaultController.php
@@ -40,10 +40,12 @@ class DefaultController extends Controller
      * @var boolean
      */
     private $swipeCardLogging;
+    private $swipeCardLoggingAnonymous;
 
-    public function __construct(string $swipeCardLogging)
+    public function __construct(string $swipeCardLogging, string $swipeCardLoggingAnonymous)
     {
         $this->swipeCardLogging = $swipeCardLogging;
+        $this->swipeCardLoggingAnonymous = $swipeCardLoggingAnonymous;
     }
 
     /**
@@ -230,6 +232,9 @@ class DefaultController extends Controller
             $counter = $beneficiary->getMembership()->getTimeCount($beneficiary->getMembership()->endOfCycle(0));
             if ($this->swipeCardLogging) {
                 $dispatcher = $this->get('event_dispatcher');
+                if ($this->$swipeCardLoggingAnonymous) {
+                    $card = null;
+                }
                 $dispatcher->dispatch(SwipeCardEvent::SWIPE_CARD_SCANNED, new SwipeCardEvent($card, $counter));
             }
             $shifts = $em->getRepository('AppBundle:Shift')->getOnGoingShifts($beneficiary);

--- a/src/AppBundle/Controller/DefaultController.php
+++ b/src/AppBundle/Controller/DefaultController.php
@@ -230,7 +230,7 @@ class DefaultController extends Controller
             $counter = $beneficiary->getMembership()->getTimeCount($beneficiary->getMembership()->endOfCycle(0));
             if ($this->swipeCardLogging) {
                 $dispatcher = $this->get('event_dispatcher');
-                $dispatcher->dispatch(SwipeCardEvent::SWIPE_CARD_SCANNED, new SwipeCardEvent($counter));
+                $dispatcher->dispatch(SwipeCardEvent::SWIPE_CARD_SCANNED, new SwipeCardEvent($card, $counter));
             }
             $shifts = $em->getRepository('AppBundle:Shift')->getOnGoingShifts($beneficiary);
             $dispatcher = $this->get('event_dispatcher');

--- a/src/AppBundle/Entity/SwipeCardLog.php
+++ b/src/AppBundle/Entity/SwipeCardLog.php
@@ -22,6 +22,12 @@ class SwipeCardLog
     private $id;
 
     /**
+     * @ORM\ManyToOne(targetEntity="SwipeCard", inversedBy="logs")
+     * @ORM\JoinColumn(name="swipe_card_id", referencedColumnName="id", nullable=true)
+     */
+    private $swipeCard;
+
+    /**
      * @var int
      * @ORM\Column(name="counter", type="integer")
      */
@@ -44,27 +50,27 @@ class SwipeCardLog
     }
 
     /**
-     * Set date.
+     * Set swipeCard.
      *
-     * @param \DateTime|null $date
+     * @param SwipeCard|null $swipeCard
      *
      * @return SwipeCardLog
      */
-    public function setDate($date = null)
+    public function setSwipeCard(?SwipeCard $swipeCard)
     {
-        $this->date = $date;
+        $this->swipeCard = $swipeCard;
 
         return $this;
     }
 
     /**
-     * Get date.
+     * Get swipeCard.
      *
-     * @return \DateTime|null
+     * @return SwipeCard|null
      */
-    public function getDate()
+    public function getSwipeCard() : ?SwipeCard
     {
-        return $this->date;
+        return $this->swipeCard;
     }
 
     /**
@@ -89,5 +95,29 @@ class SwipeCardLog
     public function getCounter()
     {
         return $this->counter;
+    }
+
+    /**
+     * Set date.
+     *
+     * @param \DateTime|null $date
+     *
+     * @return SwipeCardLog
+     */
+    public function setDate($date = null)
+    {
+        $this->date = $date;
+
+        return $this;
+    }
+
+    /**
+     * Get date.
+     *
+     * @return \DateTime|null
+     */
+    public function getDate()
+    {
+        return $this->date;
     }
 }

--- a/src/AppBundle/Event/SwipeCardEvent.php
+++ b/src/AppBundle/Event/SwipeCardEvent.php
@@ -13,9 +13,18 @@ class SwipeCardEvent extends Event
      */
     private $beneficiaryCounter;
 
-    public function __construct($beneficiaryCounter)
+    public function __construct(SwipeCard $swipeCard, $beneficiaryCounter)
     {
+        $this->swipeCard = $swipeCard;
         $this->beneficiaryCounter = $beneficiaryCounter;
+    }
+
+    /**
+     * @return SwipeCard
+     */
+    public function getSwipeCard(): SwipeCard
+    {
+        return $this->swipeCard;
     }
 
     /**

--- a/src/AppBundle/EventListener/SwipeCardEventListener.php
+++ b/src/AppBundle/EventListener/SwipeCardEventListener.php
@@ -30,6 +30,7 @@ class SwipeCardEventListener implements EventSubscriberInterface
     {
         $log = new SwipeCardLog();
         $log->setDate(new \DateTime());
+        $log->setSwipeCard($event->getSwipeCard());
         $log->setCounter($event->getCounter());
         $this->em->persist($log);;
         $this->em->flush();


### PR DESCRIPTION
Il y a 2 ans, un premier commit (https://github.com/elefan-grenoble/gestion-compte/commit/2f47a5b88274a28d9b8deaf6a918ad4236abb22a) avait rajouté la table `SwipeCardLog` pour avoir un historique de chaque passage de badge. Cet historique était rattaché au badge, donc non anonyme.

Un deuxième commit (https://github.com/elefan-grenoble/gestion-compte/commit/5026ee25f47da309cefc8c95e76402099c201774) à remplacer le lien vers le badge par un `counter`, et ainsi rendre cet historique anonyme. C'était une demande au sein de l'Elefan à l'époque.

La politique au sein de l'Elefan n'a pas changé, mais cette PR permet à la coop de choisir : anonyme ou rattaché au badge.

Un nouveau paramètre `swipe_card_logging_anonymous` a été rajouté