### PR TITLE
Modèle de données : ajout de champs createdAt

### DIFF
--- a/app/DoctrineMigrations/Version20221028213910_created_at_fields.php
+++ b/app/DoctrineMigrations/Version20221028213910_created_at_fields.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20221028213910 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE commission ADD created_at DATETIME NOT NULL');
+        $this->addSql('ALTER TABLE event ADD created_at DATETIME NOT NULL');
+        $this->addSql('ALTER TABLE formation ADD created_at DATETIME NOT NULL');
+        $this->addSql('ALTER TABLE job ADD created_at DATETIME NOT NULL');
+        $this->addSql('ALTER TABLE shift ADD created_at DATETIME NOT NULL');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE commission DROP created_at');
+        $this->addSql('ALTER TABLE event DROP created_at');
+        $this->addSql('ALTER TABLE formation DROP created_at');
+        $this->addSql('ALTER TABLE job DROP created_at');
+        $this->addSql('ALTER TABLE shift DROP created_at');
+    }
+}

--- a/src/AppBundle/Controller/FormationController.php
+++ b/src/AppBundle/Controller/FormationController.php
@@ -51,14 +51,12 @@ class FormationController extends Controller
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-
             $em->persist($formation);
             $em->flush();
 
             $session->getFlashBag()->add('success', 'La nouvelle formation a bien été créée !');
 
             return $this->redirectToRoute('admin_formations');
-
         }
 
         return $this->render('admin/formation/new.html.twig', array(
@@ -74,7 +72,7 @@ class FormationController extends Controller
      * @Method({"GET", "POST"})
      * @Security("has_role('ROLE_ADMIN')")
      */
-    public function editAction(Request $request,Formation $formation)
+    public function editAction(Request $request, Formation $formation)
     {
         $session = new Session();
 
@@ -82,7 +80,6 @@ class FormationController extends Controller
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-
             $em = $this->getDoctrine()->getManager();
             $em->persist($formation);
             $em->flush();
@@ -90,7 +87,6 @@ class FormationController extends Controller
             $session->getFlashBag()->add('success', 'La formation a bien été éditée !');
 
             return $this->redirectToRoute('admin_formations');
-
         }
 
         return $this->render('admin/formation/edit.html.twig', array(
@@ -107,7 +103,7 @@ class FormationController extends Controller
      * @Method({"DELETE"})
      * @Security("has_role('ROLE_SUPER_ADMIN')")
      */
-    public function removeAction(Request $request,Formation $formation)
+    public function removeAction(Request $request, Formation $formation)
     {
         $session = new Session();
         $form = $this->getDeleteForm($formation);
@@ -125,7 +121,8 @@ class FormationController extends Controller
      * @param Formation $formation
      * @return \Symfony\Component\Form\FormInterface
      */
-    protected function getDeleteForm(Formation $formation){
+    protected function getDeleteForm(Formation $formation)
+    {
         return $this->createFormBuilder()
             ->setAction($this->generateUrl('formation_delete', array('id' => $formation->getId())))
             ->setMethod('DELETE')

--- a/src/AppBundle/Controller/NoteController.php
+++ b/src/AppBundle/Controller/NoteController.php
@@ -54,7 +54,6 @@ class NoteController extends Controller
         $new_note = new Note();
         $new_note->setParent($note);
         $new_note->setAuthor($this->getCurrentAppUser());
-        $new_note->setCreatedAt(new \DateTime());
         $new_note->setSubject($note->getSubject());
 
         $note_form = $this->createForm(NoteType::class, $new_note);

--- a/src/AppBundle/Controller/TaskController.php
+++ b/src/AppBundle/Controller/TaskController.php
@@ -28,8 +28,8 @@ class TaskController extends Controller
      * @Route("/", name="tasks_list")
      * @Method("GET")
      */
-    public function listAction(Request $request){
-
+    public function listAction(Request $request)
+    {
         $this->denyAccessUnlessGranted('view', new Task());
 
         $em = $this->getDoctrine()->getManager();
@@ -46,7 +46,8 @@ class TaskController extends Controller
      * @Route("/new", name="task_new")
      * @Method({"GET","POST"})
      */
-    public function newAction(Request $request){
+    public function newAction(Request $request)
+    {
         $session = new Session();
         $current_app_user = $this->get('security.token_storage')->getToken()->getUser();
 
@@ -57,7 +58,6 @@ class TaskController extends Controller
         $em = $this->getDoctrine()->getManager();
 
         $task->setRegistrar($current_app_user);
-        $task->setCreatedAt(new \DateTime('now'));
 
         $form = $this->createForm(TaskType::class, $task);
         $form->handleRequest($request);
@@ -75,7 +75,7 @@ class TaskController extends Controller
 
             return $this->redirectToRoute('task_edit',array('id'=>$task->getId()));
 
-        }elseif ($form->isSubmitted()){
+        } elseif ($form->isSubmitted()){
             foreach ($this->getErrorMessages($form) as $key => $errors){
                 foreach ($errors as $error)
                     $session->getFlashBag()->add('error', $key." : ".$error);
@@ -84,7 +84,6 @@ class TaskController extends Controller
         return $this->render('default/task/new.html.twig', array(
             'form' => $form->createView()
         ));
-
     }
 
     /**
@@ -93,7 +92,8 @@ class TaskController extends Controller
      * @Route("/edit/{id}", name="task_edit")
      * @Method({"GET","POST"})
      */
-    public function editAction(Request $request,Task $task){
+    public function editAction(Request $request,Task $task)
+    {
         $session = new Session();
 
         $this->denyAccessUnlessGranted('edit',$task);
@@ -122,7 +122,7 @@ class TaskController extends Controller
 
             return $this->redirectToRoute('tasks_list');
 
-        }elseif ($form->isSubmitted()){
+        } elseif ($form->isSubmitted()){
             foreach ($this->getErrorMessages($form) as $key => $errors){
                 foreach ($errors as $error)
                     $session->getFlashBag()->add('error', $key." : ".$error);

--- a/src/AppBundle/Entity/AnonymousBeneficiary.php
+++ b/src/AppBundle/Entity/AnonymousBeneficiary.php
@@ -80,7 +80,6 @@ class AnonymousBeneficiary
      */
     private $created_at;
 
-
     /**
      * @var \DateTime
      *
@@ -193,7 +192,8 @@ class AnonymousBeneficiary
      *
      * @return \DateTime
      */
-    public function getCreatedAt(){
+    public function getCreatedAt()
+    {
         return $this->created_at;
     }
 

--- a/src/AppBundle/Entity/Commission.php
+++ b/src/AppBundle/Entity/Commission.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Mapping\OrderBy;
  * Commission
  *
  * @ORM\Table(name="commission")
+ * @ORM\HasLifecycleCallbacks()
  * @ORM\Entity(repositoryClass="AppBundle\Repository\CommissionRepository")
  */
 class Commission
@@ -58,7 +59,7 @@ class Commission
     private $next_meeting_date = null;
 
     /**
-     * Many Commissions have Many Beneficiary.
+     * Many Commissions have Many Beneficiaries.
      * @ORM\ManyToMany(targetEntity="Beneficiary", mappedBy="commissions")
      */
     private $beneficiaries;
@@ -71,10 +72,41 @@ class Commission
     private $tasks;
 
     /**
-     * One Commission have Many Owners (Beneficiary).
+     * One Commission has Many Owners (Beneficiary).
      * @ORM\OneToMany(targetEntity="Beneficiary", mappedBy="own",cascade={"persist"})
      */
     private $owners;
+
+    /**
+     * @var \DateTime
+     *
+     * @ORM\Column(name="created_at", type="datetime")
+     */
+    private $createdAt;
+
+    /**
+     * Constructor
+     */
+    public function __construct()
+    {
+        $this->beneficiaries = new \Doctrine\Common\Collections\ArrayCollection();
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->getName();
+    }
+
+    /**
+     * @ORM\PrePersist
+     */
+    public function setCreatedAtValue()
+    {
+        $this->createdAt = new \DateTime();
+    }
 
     /**
      * Get id
@@ -108,14 +140,6 @@ class Commission
     public function getName()
     {
         return $this->name;
-    }
-
-    /**
-     * Constructor
-     */
-    public function __construct()
-    {
-        $this->beneficiaries = new \Doctrine\Common\Collections\ArrayCollection();
     }
 
     /**
@@ -314,5 +338,15 @@ class Commission
     public function getNextMeetingDate()
     {
         return $this->next_meeting_date;
+    }
+
+    /**
+     * Get createdAt
+     *
+     * @return \DateTime
+     */
+    public function getCreatedAt()
+    {
+        return $this->createdAt;
     }
 }

--- a/src/AppBundle/Entity/Event.php
+++ b/src/AppBundle/Entity/Event.php
@@ -26,13 +26,6 @@ class Event
     private $id;
 
     /**
-     * @ORM\Column(type="datetime")
-     *
-     * @var \DateTime
-     */
-    private $updatedAt;
-
-    /**
      * @var string
      *
      * @Assert\NotBlank()
@@ -113,11 +106,33 @@ class Event
     private $proxies;
 
     /**
+     * @var \DateTime
+     *
+     * @ORM\Column(name="created_at", type="datetime")
+     */
+    private $createdAt;
+
+    /**
+     * @ORM\Column(type="datetime")
+     *
+     * @var \DateTime
+     */
+    private $updatedAt;
+
+    /**
      * Constructor
      */
     public function __construct()
     {
         $this->proxies = new \Doctrine\Common\Collections\ArrayCollection();
+    }
+
+    /**
+     * @ORM\PrePersist
+     */
+    public function setCreatedAtValue()
+    {
+        $this->createdAt = new \DateTime();
     }
 
     /**
@@ -137,7 +152,6 @@ class Event
     {
         return $this->id;
     }
-
 
     /**
      * If manually uploading a file (i.e. not using Symfony Form) ensure an instance
@@ -245,7 +259,6 @@ class Event
     {
         $this->proxys->removeElement($proxy);
     }
-
 
     public function getProxiesByOwner(Beneficiary $beneficiary)
     {
@@ -459,17 +472,13 @@ class Event
     }
 
     /**
-     * Set updatedAt.
+     * Get createdAt
      *
-     * @param \DateTime $updatedAt
-     *
-     * @return Event
+     * @return \DateTime
      */
-    public function setUpdatedAt($updatedAt)
+    public function getCreatedAt()
     {
-        $this->updatedAt = $updatedAt;
-
-        return $this;
+        return $this->createdAt;
     }
 
     /**

--- a/src/AppBundle/Entity/Formation.php
+++ b/src/AppBundle/Entity/Formation.php
@@ -84,7 +84,7 @@ class Formation extends Group
     }
 
     /**
-     * Get created_at
+     * Get createdAt
      *
      * @return \DateTime
      */

--- a/src/AppBundle/Entity/Formation.php
+++ b/src/AppBundle/Entity/Formation.php
@@ -10,6 +10,7 @@ use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
  * Formation
  *
  * @ORM\Table(name="formation")
+ * @ORM\HasLifecycleCallbacks()
  * @ORM\Entity(repositoryClass="AppBundle\Repository\FormationRepository")
  * @UniqueEntity(fields={"name"}, message="Ce nom est déjà utilisé par une autre formation")
  */
@@ -31,6 +32,38 @@ class Formation extends Group
     private $beneficiaries;
 
     /**
+     * @var \DateTime
+     *
+     * @ORM\Column(name="created_at", type="datetime")
+     */
+    private $createdAt;
+
+    /**
+     * Constructor
+     */
+    public function __construct()
+    {
+        parent::__construct(null);
+        $this->beneficiaries = new \Doctrine\Common\Collections\ArrayCollection();
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->getName();
+    }
+
+    /**
+     * @ORM\PrePersist
+     */
+    public function setCreatedAtValue()
+    {
+        $this->createdAt = new \DateTime();
+    }
+
+    /**
      * Get id
      *
      * @return int
@@ -40,17 +73,24 @@ class Formation extends Group
         return $this->id;
     }
 
-    public function __toString()
-    {
-        return $this->getName();
-    }
     /**
-     * Constructor
+     * Get roles
+     *
+     * @return array
      */
-    public function __construct()
+    public function getRoles()
     {
-        parent::__construct(null);
-        $this->beneficiaries = new \Doctrine\Common\Collections\ArrayCollection();
+        return $this->roles;
+    }
+
+    /**
+     * Get created_at
+     *
+     * @return \DateTime
+     */
+    public function getCreatedAt()
+    {
+        return $this->createdAt;
     }
 
     /**

--- a/src/AppBundle/Entity/HelloassoPayment.php
+++ b/src/AppBundle/Entity/HelloassoPayment.php
@@ -92,13 +92,14 @@ class HelloassoPayment
      */
     private $registration;
 
-
-    /***
+    /**
      * @return string
      */
-    public function __toString(){
+    public function __toString()
+    {
         return '#'.$this->getId().' de '.$this->getEmail().' le '. $this->getCreatedAt()->format('d-M-Y à H:i').' '.$this->getAmount().' €';
     }
+
     /**
      * @ORM\PrePersist
      */

--- a/src/AppBundle/Entity/Job.php
+++ b/src/AppBundle/Entity/Job.php
@@ -9,6 +9,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  * Job
  *
  * @ORM\Table(name="job")
+ * @ORM\HasLifecycleCallbacks()
  * @ORM\Entity(repositoryClass="AppBundle\Repository\JobRepository")
  */
 class Job
@@ -40,12 +41,14 @@ class Job
 
     /**
      * @var string
+     * 
      * @ORM\Column(name="description", type="text", nullable=true)
      */
     private $description;
 
     /**
      * @var int
+     * 
      * @ORM\Column(name="min_shifter_alert", type="integer", options={"default" : 2})
      */
     private $min_shifter_alert;
@@ -67,6 +70,36 @@ class Job
      */
     private $enabled;
 
+    /**
+     * @var \DateTime
+     *
+     * @ORM\Column(name="created_at", type="datetime")
+     */
+    private $createdAt;
+
+    /**
+     * Constructor
+     */
+    public function __construct()
+    {
+        $this->shifts = new \Doctrine\Common\Collections\ArrayCollection();
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->getName();
+    }
+
+    /**
+     * @ORM\PrePersist
+     */
+    public function setCreatedAtValue()
+    {
+        $this->createdAt = new \DateTime();
+    }
 
     /**
      * Get id
@@ -137,24 +170,19 @@ class Job
     }
 
     /**
+     * Set min_shifter_alert
+     * 
      * @param int $min_shifter_alert
      * @return Job
      */
-    public function setMinShifterAlert(int $min_shifter_alert): Job {
+    public function setMinShifterAlert(int $min_shifter_alert): Job
+    {
         $this->min_shifter_alert = $min_shifter_alert;
         return $this;
     }
 
     /**
-     * Constructor
-     */
-    public function __construct()
-    {
-        $this->shifts = new \Doctrine\Common\Collections\ArrayCollection();
-    }
-
-    /**
-     * Add shift.
+     * Add shift
      *
      * @param \AppBundle\Entity\Shift $shift
      *
@@ -168,7 +196,7 @@ class Job
     }
 
     /**
-     * Remove shift.
+     * Remove shift
      *
      * @param \AppBundle\Entity\Shift $shift
      *
@@ -180,7 +208,7 @@ class Job
     }
 
     /**
-     * Get shifts.
+     * Get shifts
      *
      * @return \Doctrine\Common\Collections\Collection
      */
@@ -190,7 +218,7 @@ class Job
     }
 
     /**
-     * Add period.
+     * Add period
      *
      * @param \AppBundle\Entity\Period $period
      *
@@ -204,7 +232,7 @@ class Job
     }
 
     /**
-     * Remove period.
+     * Remove period
      *
      * @param \AppBundle\Entity\Period $period
      *
@@ -216,7 +244,7 @@ class Job
     }
 
     /**
-     * Get periods.
+     * Get periods
      *
      * @return \Doctrine\Common\Collections\Collection
      */
@@ -242,19 +270,34 @@ class Job
     }
 
     /**
+     * Get description
+     * 
      * @return string
      */
-    public function getDescription(): string {
+    public function getDescription(): string
+    {
         return $this->description ? $this->description : '';
     }
 
     /**
+     * Set description
+     * 
      * @param string $description
      * @return Job
      */
-    public function setDescription(string $description): Job {
+    public function setDescription(string $description): Job
+    {
         $this->description = $description;
         return $this;
     }
 
+    /**
+     * Get created_at
+     *
+     * @return \DateTime
+     */
+    public function getCreatedAt()
+    {
+        return $this->createdAt;
+    }
 }

--- a/src/AppBundle/Entity/Job.php
+++ b/src/AppBundle/Entity/Job.php
@@ -292,7 +292,7 @@ class Job
     }
 
     /**
-     * Get created_at
+     * Get createdAt
      *
      * @return \DateTime
      */

--- a/src/AppBundle/Entity/Note.php
+++ b/src/AppBundle/Entity/Note.php
@@ -32,13 +32,6 @@ class Note
     private $text;
 
     /**
-     * @var \DateTime
-     *
-     * @ORM\Column(name="created_at", type="datetime")
-     */
-    private $created_at;
-
-    /**
      * @ORM\ManyToOne(targetEntity="User", inversedBy="annotations")
      * @ORM\JoinColumn(name="author_id", referencedColumnName="id")
      */
@@ -62,11 +55,26 @@ class Note
     private $children;
 
     /**
+     * @var \DateTime
+     *
+     * @ORM\Column(name="created_at", type="datetime")
+     */
+    private $createdAt;
+
+    /**
+     * Constructor
+     */
+    public function __construct()
+    {
+        $this->children = new \Doctrine\Common\Collections\ArrayCollection();
+    }
+
+    /**
      * @ORM\PrePersist
      */
     public function setCreatedAtValue()
     {
-        $this->created_at = new \DateTime();
+        $this->createdAt = new \DateTime();
     }
 
     /**
@@ -109,27 +117,13 @@ class Note
     }
 
     /**
-     * Set createdAt
-     *
-     * @param \DateTime $created_at
-     *
-     * @return Note
-     */
-    public function setCreatedAt($created_at)
-    {
-        $this->created_at = $created_at;
-
-        return $this;
-    }
-
-    /**
      * Get createdAt
      *
      * @return \DateTime
      */
     public function getCreatedAt()
     {
-        return $this->created_at;
+        return $this->createdAt;
     }
 
     /**
@@ -201,13 +195,6 @@ class Note
     public function getParent()
     {
         return $this->parent;
-    }
-    /**
-     * Constructor
-     */
-    public function __construct()
-    {
-        $this->children = new \Doctrine\Common\Collections\ArrayCollection();
     }
 
     /**

--- a/src/AppBundle/Entity/Shift.php
+++ b/src/AppBundle/Entity/Shift.php
@@ -8,6 +8,7 @@ use Doctrine\ORM\Mapping as ORM;
  * Shift
  *
  * @ORM\Table(name="shift")
+ * @ORM\HasLifecycleCallbacks()
  * @ORM\Entity(repositoryClass="AppBundle\Repository\ShiftRepository")
  */
 class Shift
@@ -89,21 +90,21 @@ class Shift
     private $lastShifter;
 
     /**
-     * One Period has One Formation.
+     * One Shift has one Formation.
      * @ORM\ManyToOne(targetEntity="Formation")
      * @ORM\JoinColumn(name="formation_id", referencedColumnName="id", onDelete="SET NULL")
      */
     private $formation;
 
     /**
-     * One Period has One Job.
+     * One Shift has One Job.
      * @ORM\ManyToOne(targetEntity="Job", inversedBy="shifts")
      * @ORM\JoinColumn(name="job_id", referencedColumnName="id", nullable=false)
      */
     private $job;
 
     /**
-     * One shift may have been created from One PeriodPosition.
+     * One Shift may have been created from One PeriodPosition.
      * @ORM\ManyToOne(targetEntity="PeriodPosition")
      * @ORM\JoinColumn(name="position_id", referencedColumnName="id", onDelete="SET NULL")
      */
@@ -128,6 +129,13 @@ class Shift
      */
     private $fixe = false;
 
+    /**
+     * @var \DateTime
+     *
+     * @ORM\Column(name="created_at", type="datetime")
+     */
+    private $createdAt;
+
     public function __construct()
     {
         $this->isDismissed = false;
@@ -138,6 +146,14 @@ class Shift
     {
         setlocale(LC_TIME, 'fr_FR.UTF8');
         return strftime("%A %e %B de %R", $this->getStart()->getTimestamp()).' à '.strftime("%R", $this->getEnd()->getTimestamp()).' ['.$this->getShifter().']';
+    }
+
+    /**
+     * @ORM\PrePersist
+     */
+    public function setCreatedAtValue()
+    {
+        $this->createdAt = new \DateTime();
     }
 
     /**
@@ -614,7 +630,7 @@ class Shift
     }
 
     /**
-     * Set job
+     * Set position
      *
      * @param \AppBundle\Entity\PeriodPosition $position
      *
@@ -627,4 +643,13 @@ class Shift
         return $this;
     }
 
+    /**
+     * Get createdAt
+     *
+     * @return \DateTime
+     */
+    public function getCreatedAt()
+    {
+        return $this->createdAt;
+    }
 }

--- a/src/AppBundle/Entity/SwipeCard.php
+++ b/src/AppBundle/Entity/SwipeCard.php
@@ -27,13 +27,6 @@ class SwipeCard
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="created_at", type="datetime")
-     */
-    private $created_at;
-
-    /**
-     * @var \DateTime
-     *
      * @ORM\Column(name="disabled_at", type="datetime", nullable=true)
      */
     private $disabled_at;
@@ -71,11 +64,18 @@ class SwipeCard
     private $logs;
 
     /**
+     * @var \DateTime
+     *
+     * @ORM\Column(name="created_at", type="datetime")
+     */
+    private $createdAt;
+
+    /**
      * @ORM\PrePersist
      */
     public function setCreatedAtValue()
     {
-        $this->created_at = new \DateTime();
+        $this->createdAt = new \DateTime();
         $this->disabled_at = null;
     }
 
@@ -203,7 +203,7 @@ class SwipeCard
      */
     public function setCreatedAt($createdAt)
     {
-        $this->created_at = $createdAt;
+        $this->createdAt = $createdAt;
 
         return $this;
     }
@@ -215,7 +215,7 @@ class SwipeCard
      */
     public function getCreatedAt()
     {
-        return $this->created_at;
+        return $this->createdAt;
     }
 
     /**

--- a/src/AppBundle/Entity/Task.php
+++ b/src/AppBundle/Entity/Task.php
@@ -40,13 +40,6 @@ class Task
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="created_at", type="datetime")
-     */
-    private $createdAt;
-
-    /**
-     * @var \DateTime
-     *
      * @ORM\Column(name="due_date", type="date", nullable=true)
      */
     private $dueDate;
@@ -92,6 +85,22 @@ class Task
      */
     private $status;
 
+    /**
+     * @var \DateTime
+     *
+     * Used as start date...
+     * @ORM\Column(name="created_at", type="datetime")
+     */
+    private $createdAt;
+
+    /**
+     * Constructor
+     */
+    public function __construct()
+    {
+        $this->commissions = new \Doctrine\Common\Collections\ArrayCollection();
+        $this->owners = new \Doctrine\Common\Collections\ArrayCollection();
+    }
 
     /**
      * Get id
@@ -197,14 +206,6 @@ class Task
     public function getStatus()
     {
         return $this->status;
-    }
-    /**
-     * Constructor
-     */
-    public function __construct()
-    {
-        $this->commissions = new \Doctrine\Common\Collections\ArrayCollection();
-        $this->owners = new \Doctrine\Common\Collections\ArrayCollection();
     }
 
     /**

--- a/src/AppBundle/Form/NoteType.php
+++ b/src/AppBundle/Form/NoteType.php
@@ -37,6 +37,4 @@ class NoteType extends AbstractType
     {
         return 'appbundle_note';
     }
-
-
 }


### PR DESCRIPTION
Nice to have : un champ pour savoir à quelle date l'objet a été créé - `createdAt`

Ca permet ensuite : 
- d'ordonner une liste d'objets par date de création
- de filtrer par date
- de visualiser le nombre occurrences par échelle de temps donnée

Pour cela on peut utiliser les outils mis à disposition par Symfony / Doctrine
https://symfony.com/doc/3.4/doctrine/lifecycle_callbacks.html
```
@ORM\HasLifecycleCallbacks()
@ORM\PrePersist
```

Actions effectuées : 
- j'ai ajouté un champ `createdAt` aux modèles suivants : `Formation`, `Job`, `Shift`, `Commission` et `Event`
- le modèle `Task` a déjà le champ, et il est utilisé "autrement"...
- les modèles `Note`, `SwipeCard` avaient déjà le champ (renommé `created_at` en `createdAt`)

Todo ?
- j'ai préféré ne pas toucher aux modèles `AnonymousBeneficiary`, `HelloassoPayment` et `Registration` (il faudrait renommer `created_at` en `createdAt`)