### PR TITLE
Pouvoir définir le nombre maximal de procurations

### DIFF
--- a/app/Resources/views/admin/event/proxy/list.html.twig
+++ b/app/Resources/views/admin/event/proxy/list.html.twig
@@ -6,11 +6,16 @@
 <a href="{{ path('homepage') }}"><i class="material-icons">home</i></a><i class="material-icons">chevron_right</i>
 <a href="{{ path('admin') }}"><i class="material-icons">build</i>&nbsp;Administration</a><i class="material-icons">chevron_right</i>
 <a href="{{ path('event_list') }}"><i class="material-icons">list</i>&nbsp;Liste des événements</a><i class="material-icons">chevron_right</i>
+<i class="material-icons">event</i>&nbsp;{{ event.title }}<i class="material-icons">chevron_right</i>
 <i class="material-icons">list</i>&nbsp;Procurations
 {% endblock %}
 
 {% block content %}
     <h4>Liste des procurations en cours <small>({{ proxies | length }})</small></h4>
+
+    <p class="red-text">
+        Rappel : chaque membre peut porter au maximum <strong>{{ max_event_proxy_per_member }} procuration{% if max_event_proxy_per_member > 1 %}s{% endif %}</strong>
+    </p>
 
     {% if event %}
         <h5>{{ event.title }}</h5>

--- a/app/Resources/views/beneficiary/find_member_number.html.twig
+++ b/app/Resources/views/beneficiary/find_member_number.html.twig
@@ -1,13 +1,12 @@
 {% extends 'layout.html.twig' %}
 
+{% block title %}Recherche numéro d'adhérent - {{ site_name }}{% endblock %}
+
 {% block breadcrumbs %}
 {% if is_granted("IS_AUTHENTICATED_REMEMBERED") %}
     <a href="{{ path('homepage') }}"><i class="material-icons">home</i></a><i class="material-icons">chevron_right</i>
     <i class="material-icons">search</i>&nbsp;Recherche numéro d'adhérent
 {% endif %}
-{% endblock %}
-
-{% block aftercontainer %}
 {% endblock %}
 
 {% block content %}
@@ -48,7 +47,6 @@
                 <p class=" col s12 light">Déjà un compte ? <a href="{{ path('fos_user_security_login') }}">identifiez-vous</a></p>
             </div>
             {% endif %}
-
         </div>
     </div>
 {% endblock %}

--- a/app/Resources/views/beneficiary/find_member_number.html.twig
+++ b/app/Resources/views/beneficiary/find_member_number.html.twig
@@ -3,8 +3,6 @@
 {% block breadcrumbs %}
 {% if is_granted("IS_AUTHENTICATED_REMEMBERED") %}
     <a href="{{ path('homepage') }}"><i class="material-icons">home</i></a><i class="material-icons">chevron_right</i>
-    <a href="{{ path('admin') }}"><i class="material-icons">build</i>&nbsp;Administration</a><i class="material-icons">chevron_right</i>
-    <a href="{{ path('user_office_tools') }}"><i class="material-icons">folder_shared</i>&nbsp;Adhésion et ré-adhésion</a><i class="material-icons">chevron_right</i>
     <i class="material-icons">search</i>&nbsp;Recherche numéro d'adhérent
 {% endif %}
 {% endblock %}

--- a/app/Resources/views/default/event/_event.html.twig
+++ b/app/Resources/views/default/event/_event.html.twig
@@ -24,21 +24,19 @@
                             <span>Procuration donnée à &nbsp;<b>{{ proxy_given.owner.user.firstname }} {{ proxy_given.owner.user.lastname }}</b></span>
                         {% endif %}
                     {% endif %}
-                    {% if proxy_received|length > 0 %}
-                        {% for proxy_received_item in proxy_received %}
-                            {% if proxy_received_item.giver %}
-                                <div>Procuration portée par <b>{{ proxy_received_item.owner.user.firstname }}</b> de la part de&nbsp;<b>{{ proxy_received_item.giver.mainBeneficiary.user.firstname }} {{ proxy_received_item.giver.mainBeneficiary.user.lastname }}</b></div>
-                            {% else %}
-                                <div><b>{{ proxy_received_item.owner.user.firstname }}</b> accepte une procuration. <a href="{{ path("event_proxy_lite_remove",{'event':event.id,'proxy':proxy_received_item.id}) }}" class="red-text">X</a></div>
-                            {% endif %}
-                        {% endfor %}
-                    {% endif %}
+                    {% for proxy_received_item in proxy_received %}
+                        {% if proxy_received_item.giver %}
+                            <div>Procuration portée par <b>{{ proxy_received_item.owner.user.firstname }}</b> de la part de&nbsp;<b>{{ proxy_received_item.giver.mainBeneficiary.user.firstname }} {{ proxy_received_item.giver.mainBeneficiary.user.lastname }}</b></div>
+                        {% else %}
+                            <div><b>{{ proxy_received_item.owner.user.firstname }}</b> accepte une procuration. <a href="{{ path("event_proxy_lite_remove",{'event':event.id,'proxy':proxy_received_item.id}) }}" class="red-text">X</a></div>
+                        {% endif %}
+                    {% endfor %}
                     {% if proxy_given is null and proxy_received|length == 0 %}
                         <a class="activator waves-effect waves-light btn orange hide-on-small-only" href="#" onclick="return false;"><i class="material-icons">list</i>
                             {% if event.anonymousProxy %}
-                            Donner / recevoir une procuration
+                                <span>Donner / recevoir une procuration</span>
                             {% else %}
-                            Donner procuration
+                                <span>Donner procuration</span>
                             {% endif %}
                         </a>
                         <a class="activator waves-effect waves-light btn orange hide-on-med-and-up" href="#" onclick="return false;"><i class="material-icons">list</i>Procurations</a>
@@ -68,10 +66,12 @@
                     {% endif %}
                     {% if (minDateOfLastRegistration is not null and app.user.beneficiary.membership.lastRegistration.date < minDateOfLastRegistration) %}
                         <b>Oups</b>, seuls les membres qui ont adhéré ou ré-adhéré <b>après le {{ minDateOfLastRegistration | date('d M Y') }}</b> peuvent voter à cet événement.
-                        <br>Pense à mettre à jour ton adhésion pour participer ! :)
+                        <br />
+                        Pense à mettre à jour ton adhésion pour participer ! :)
                     {% elseif (app.user.beneficiary.membership.getTimeCount(event.maxDateOfLastRegistration) < time_after_which_members_are_late_with_shifts * 60) %}
-                        <b>Oups</b>, seuls les membres avec un compteur de créneaux supérieur à {{ time_after_which_members_are_late_with_shifts }} à la date du {{ event.maxDateOfLastRegistration | date('d M Y') }}</b> peuvent voter à cet événement.
-                        <br>Pense à rattraper tes créneaux pour la prochaine fois ! :)
+                        <b>Oups</b>, seuls les membres avec un compteur de créneaux supérieur à <b>{{ time_after_which_members_are_late_with_shifts }} à la date du {{ event.maxDateOfLastRegistration | date('d M Y') }}</b> peuvent voter à cet événement.
+                        <br />
+                        Pense à rattraper tes créneaux pour la prochaine fois ! :)
                     {% else %}
                         <ul>
                             {% if proxy_given is not null %}
@@ -81,16 +81,13 @@
                                     <li>Procuration donnée à &nbsp;<b>{{ proxy_given.owner.user.firstname }} {{ proxy_given.owner.user.lastname }}</b></li>
                                 {% endif %}
                             {% endif %}
-
-                            {% if proxy_received|length > 0 %}
-                                {% for proxy_received_item in proxy_received %}
-                                    {% if proxy_received_item.giver %}
-                                        <li>Procuration portée par <b>{{ proxy_received_item.owner.user.firstname }}</b> de la part de&nbsp;<b>{{ proxy_received_item.giver.mainBeneficiary.user.firstname }} {{ proxy_received_item.giver.mainBeneficiary.user.lastname }}</b></li>
-                                    {% else %}
-                                        <li><b>{{ proxy_received_item.owner.user.firstname }}</b> accepte une procuration. <a href="{{ path("event_proxy_lite_remove",{'event':event.id,'proxy':proxy_received_item.id}) }}" class="red-text">X</a></li>
-                                    {% endif %}
-                                {% endfor %}
-                            {% endif %}
+                            {% for proxy_received_item in proxy_received %}
+                                {% if proxy_received_item.giver %}
+                                    <li>Procuration portée par <b>{{ proxy_received_item.owner.user.firstname }}</b> de la part de&nbsp;<b>{{ proxy_received_item.giver.mainBeneficiary.user.firstname }} {{ proxy_received_item.giver.mainBeneficiary.user.lastname }}</b></li>
+                                {% else %}
+                                    <li><b>{{ proxy_received_item.owner.user.firstname }}</b> accepte une procuration. <a href="{{ path("event_proxy_lite_remove",{'event':event.id,'proxy':proxy_received_item.id}) }}" class="red-text">X</a></li>
+                                {% endif %}
+                            {% endfor %}
                         </ul>
                         {% if proxy_given is null and (proxy_received|length == 0) %}
                             <a href="{{ path("event_proxy_give",{'id':event.id}) }}" class="waves-effect waves-light btn purple hide-on-small-only" title="Je ne peux pas venir, je fais une procuration">Je ne peux pas venir, je fais une procuration</a>

--- a/app/Resources/views/default/event/_event.html.twig
+++ b/app/Resources/views/default/event/_event.html.twig
@@ -21,30 +21,36 @@
                         {% if proxy_given.owner is null %}
                             <span>Procuration donnée au premier membre volontaire</span>
                         {% else %}
-                            <span>Procuration donnée à &nbsp;<b>{{ proxy_given.owner.user.firstname }} {{ proxy_given.owner.user.lastname }}</b></span>
+                            <span>Procuration donnée à &nbsp;<b>{{ proxy_given.owner }}</b></span>
                         {% endif %}
                     {% endif %}
                     {% for proxy_received_item in proxy_received %}
                         {% if proxy_received_item.giver %}
-                            <div>Procuration portée par <b>{{ proxy_received_item.owner.user.firstname }}</b> de la part de&nbsp;<b>{{ proxy_received_item.giver.mainBeneficiary.user.firstname }} {{ proxy_received_item.giver.mainBeneficiary.user.lastname }}</b></div>
+                            <div>Procuration portée par <b>{{ proxy_received_item.owner.user.firstname }}</b> de la part de&nbsp;<b>{{ proxy_received_item.giver.mainBeneficiary }}</b></div>
                         {% else %}
                             <div><b>{{ proxy_received_item.owner.user.firstname }}</b> accepte une procuration. <a href="{{ path("event_proxy_lite_remove",{'event':event.id,'proxy':proxy_received_item.id}) }}" class="red-text">X</a></div>
                         {% endif %}
                     {% endfor %}
-                    {% if proxy_given is null and proxy_received|length == 0 %}
-                        <a class="activator waves-effect waves-light btn orange hide-on-small-only" href="#" onclick="return false;"><i class="material-icons">list</i>
+                    {% if (proxy_given is null) and (proxy_received|length == 0) %}
+                        <button class="activator waves-effect waves-light btn orange hide-on-small-only">
+                            <i class="material-icons">list</i>
                             {% if event.anonymousProxy %}
-                                <span>Donner / recevoir une procuration</span>
+                                <span class="activator">Donner / recevoir une procuration</span>
                             {% else %}
-                                <span>Donner procuration</span>
+                                <span class="activator">Donner procuration</span>
                             {% endif %}
-                        </a>
-                        <a class="activator waves-effect waves-light btn orange hide-on-med-and-up" href="#" onclick="return false;"><i class="material-icons">list</i>Procurations</a>
+                        </button>
+                        <button class="activator waves-effect waves-light btn orange hide-on-med-and-up">
+                            <i class="material-icons">list</i>
+                            <span class="activator">Procurations</span>
+                        </button>
                     {% endif %}
                 {% endif %}
             {% endif %}
             {% if is_granted("ROLE_SUPER_ADMIN") %}
-                <a href="{{ path("event_edit",{'id':event.id}) }}" class="btn"><i class="material-icons">edit</i> Editer</a>
+                <a href="{{ path("event_edit",{'id':event.id}) }}" class="btn">
+                    <i class="material-icons">edit</i> Editer
+                </a>
             {% endif %}
         </div>
         <div class="card-reveal">
@@ -78,23 +84,31 @@
                                 {% if proxy_given.owner is null %}
                                     <li>Procuration donnée au premier volontaire</li>
                                 {% else %}
-                                    <li>Procuration donnée à &nbsp;<b>{{ proxy_given.owner.user.firstname }} {{ proxy_given.owner.user.lastname }}</b></li>
+                                    <li>Procuration donnée à &nbsp;<b>{{ proxy_given.owner }}</b></li>
                                 {% endif %}
                             {% endif %}
                             {% for proxy_received_item in proxy_received %}
                                 {% if proxy_received_item.giver %}
-                                    <li>Procuration portée par <b>{{ proxy_received_item.owner.user.firstname }}</b> de la part de&nbsp;<b>{{ proxy_received_item.giver.mainBeneficiary.user.firstname }} {{ proxy_received_item.giver.mainBeneficiary.user.lastname }}</b></li>
+                                    <li>Procuration portée par <b>{{ proxy_received_item.owner.user.firstname }}</b> de la part de&nbsp;<b>{{ proxy_received_item.giver.mainBeneficiary }}</b></li>
                                 {% else %}
                                     <li><b>{{ proxy_received_item.owner.user.firstname }}</b> accepte une procuration. <a href="{{ path("event_proxy_lite_remove",{'event':event.id,'proxy':proxy_received_item.id}) }}" class="red-text">X</a></li>
                                 {% endif %}
                             {% endfor %}
                         </ul>
-                        {% if proxy_given is null and (proxy_received|length == 0) %}
-                            <a href="{{ path("event_proxy_give",{'id':event.id}) }}" class="waves-effect waves-light btn purple hide-on-small-only" title="Je ne peux pas venir, je fais une procuration">Je ne peux pas venir, je fais une procuration</a>
-                            <a href="{{ path("event_proxy_give",{'id':event.id}) }}" class="waves-effect waves-light purple-text hide-on-med-and-up" title="Je ne peux pas venir, je fais une procuration">Je ne peux pas venir, je fais une procuration</a>
+                        {% if (proxy_given is null) and (proxy_received|length == 0) %}
+                            <a href="{{ path("event_proxy_give",{'id':event.id}) }}" class="waves-effect waves-light btn purple hide-on-small-only" title="Je ne peux pas venir, je fais une procuration">
+                                Je ne peux pas venir, je fais une procuration
+                            </a>
+                            <a href="{{ path("event_proxy_give",{'id':event.id}) }}" class="waves-effect waves-light purple-text hide-on-med-and-up" title="Je ne peux pas venir, je fais une procuration">
+                                Je ne peux pas venir, je fais une procuration
+                            </a>
                             {% if event.anonymousProxy %}
-                                <a href="{{ path("event_proxy_take",{'id':event.id}) }}" class="waves-effect waves-light btn green hide-on-small-only" title="Je viens, j'accepte une procuration">Je viens, j'accepte une procuration</a>
-                                <a href="{{ path("event_proxy_take",{'id':event.id}) }}" class="waves-effect waves-light green-text hide-on-med-and-up" title="Je viens, j'accepte une procuration">Je viens, j'accepte une procuration</a>
+                                <a href="{{ path("event_proxy_take",{'id':event.id}) }}" class="waves-effect waves-light btn green hide-on-small-only" title="Je viens, j'accepte une procuration">
+                                    Je viens, j'accepte une procuration
+                                </a>
+                                <a href="{{ path("event_proxy_take",{'id':event.id}) }}" class="waves-effect waves-light green-text hide-on-med-and-up" title="Je viens, j'accepte une procuration">
+                                    Je viens, j'accepte une procuration
+                                </a>
                             {% endif %}
                         {% endif %}
                     {% endif %}

--- a/app/Resources/views/default/event/_event.html.twig
+++ b/app/Resources/views/default/event/_event.html.twig
@@ -16,7 +16,7 @@
                     <span>Oups, nous n'avons enregistré aucune adhésion pour ton compte. Tu ne pourras pas voter pour cet événement.</span>
                 {% else %}
                     {% set proxy_given = event | givenProxy %}
-                    {% set proxy_received = event | receivedProxy %}
+                    {% set proxy_received = event | receivedProxies %}
                     {% if proxy_given is not null %}
                         {% if proxy_given.owner is null %}
                             <span>Procuration donnée au premier membre volontaire</span>
@@ -24,14 +24,16 @@
                             <span>Procuration donnée à &nbsp;<b>{{ proxy_given.owner.user.firstname }} {{ proxy_given.owner.user.lastname }}</b></span>
                         {% endif %}
                     {% endif %}
-                    {% if proxy_received is not null %}
-                        {% if proxy_received.giver %}
-                            <span>Procuration portée par <b>{{ proxy_received.owner.user.firstname }}</b> de la part de&nbsp;<b>{{ proxy_received.giver.mainBeneficiary.user.firstname }} {{ proxy_received.giver.mainBeneficiary.user.lastname }}</b></span>
-                        {% else %}
-                            <span><b>{{ proxy_received.owner.user.firstname }}</b> accepte une procuration. <a href="{{ path("event_proxy_lite_remove",{'event':event.id,'proxy':proxy_received.id}) }}" class="red-text">X</a></span>
-                        {% endif %}
+                    {% if proxy_received|length > 0 %}
+                        {% for proxy_received_item in proxy_received %}
+                            {% if proxy_received_item.giver %}
+                                <div>Procuration portée par <b>{{ proxy_received_item.owner.user.firstname }}</b> de la part de&nbsp;<b>{{ proxy_received_item.giver.mainBeneficiary.user.firstname }} {{ proxy_received_item.giver.mainBeneficiary.user.lastname }}</b></div>
+                            {% else %}
+                                <div><b>{{ proxy_received_item.owner.user.firstname }}</b> accepte une procuration. <a href="{{ path("event_proxy_lite_remove",{'event':event.id,'proxy':proxy_received_item.id}) }}" class="red-text">X</a></div>
+                            {% endif %}
+                        {% endfor %}
                     {% endif %}
-                    {% if proxy_received is null and proxy_given is null %}
+                    {% if proxy_given is null and proxy_received|length == 0 %}
                         <a class="activator waves-effect waves-light btn orange hide-on-small-only" href="#" onclick="return false;"><i class="material-icons">list</i>
                             {% if event.anonymousProxy %}
                             Donner / recevoir une procuration
@@ -58,7 +60,7 @@
                     <b>Oups, nous n'avons enregistré aucune adhésion pour ton compte. Tu ne pourras pas voter pour cet événement.</b>
                 {% else %}
                     {% set proxy_given = event | givenProxy %}
-                    {% set proxy_received = event | receivedProxy %}
+                    {% set proxy_received = event | receivedProxies %}
                     {% if (registration_duration is not null) %}
                         {% set minDateOfLastRegistration = event.maxDateOfLastRegistration | date_modify('-' ~ registration_duration) %}
                     {% else %}
@@ -80,20 +82,22 @@
                                 {% endif %}
                             {% endif %}
 
-                            {% if proxy_received is not null %}
-                                {% if proxy_received.giver %}
-                                    <li>Procuration portée par <b>{{ proxy_received.owner.user.firstname }}</b> de la part de&nbsp;<b>{{ proxy_received.giver.mainBeneficiary.user.firstname }} {{ proxy_received.giver.mainBeneficiary.user.lastname }}</b></li>
-                                {% else %}
-                                    <li><b>{{ proxy_received.owner.user.firstname }}</b> accepte une procuration. <a href="{{ path("event_proxy_lite_remove",{'event':event.id,'proxy':proxy_received.id}) }}" class="red-text">X</a></li>
-                                {% endif %}
+                            {% if proxy_received|length > 0 %}
+                                {% for proxy_received_item in proxy_received %}
+                                    {% if proxy_received_item.giver %}
+                                        <li>Procuration portée par <b>{{ proxy_received_item.owner.user.firstname }}</b> de la part de&nbsp;<b>{{ proxy_received_item.giver.mainBeneficiary.user.firstname }} {{ proxy_received_item.giver.mainBeneficiary.user.lastname }}</b></li>
+                                    {% else %}
+                                        <li><b>{{ proxy_received_item.owner.user.firstname }}</b> accepte une procuration. <a href="{{ path("event_proxy_lite_remove",{'event':event.id,'proxy':proxy_received_item.id}) }}" class="red-text">X</a></li>
+                                    {% endif %}
+                                {% endfor %}
                             {% endif %}
                         </ul>
-                        {% if proxy_given is null and proxy_received is null %}
-                            <a href="{{ path("event_proxy_give",{'id':event.id}) }}" class="waves-effect waves-light btn purple hide-on-small-only">Je ne peux pas venir, je fais une procuration</a>
-                            <a href="{{ path("event_proxy_give",{'id':event.id}) }}" class="waves-effect waves-light purple-text hide-on-med-and-up">Je ne peux pas venir, je fais une procuration</a>
+                        {% if proxy_given is null and (proxy_received|length == 0) %}
+                            <a href="{{ path("event_proxy_give",{'id':event.id}) }}" class="waves-effect waves-light btn purple hide-on-small-only" title="Je ne peux pas venir, je fais une procuration">Je ne peux pas venir, je fais une procuration</a>
+                            <a href="{{ path("event_proxy_give",{'id':event.id}) }}" class="waves-effect waves-light purple-text hide-on-med-and-up" title="Je ne peux pas venir, je fais une procuration">Je ne peux pas venir, je fais une procuration</a>
                             {% if event.anonymousProxy %}
-                            <a href="{{ path("event_proxy_take",{'id':event.id}) }}" class="waves-effect waves-light btn green hide-on-small-only">Je viens, j'accepte une procuration</a>
-                            <a href="{{ path("event_proxy_take",{'id':event.id}) }}" class="waves-effect waves-light green-text hide-on-med-and-up">Je viens, j'accepte une procuration</a>
+                                <a href="{{ path("event_proxy_take",{'id':event.id}) }}" class="waves-effect waves-light btn green hide-on-small-only" title="Je viens, j'accepte une procuration">Je viens, j'accepte une procuration</a>
+                                <a href="{{ path("event_proxy_take",{'id':event.id}) }}" class="waves-effect waves-light green-text hide-on-med-and-up" title="Je viens, j'accepte une procuration">Je viens, j'accepte une procuration</a>
                             {% endif %}
                         {% endif %}
                     {% endif %}

--- a/app/Resources/views/default/event/proxy/give.html.twig
+++ b/app/Resources/views/default/event/proxy/give.html.twig
@@ -49,6 +49,10 @@
             </div>
         </div>
         {{ form_end(confirm_form) }}
+
+        <a href="{{ path("event_proxy_give", { 'id': event.id }) }}" class="btn waves-effect waves-light">
+            <i class="material-icons left">keyboard_return</i>Retourner à la recherche
+        </a>
     {% endif %}
 
     {% if event.anonymousProxy %}

--- a/app/Resources/views/default/event/proxy/give.html.twig
+++ b/app/Resources/views/default/event/proxy/give.html.twig
@@ -1,64 +1,64 @@
 {% extends 'layout.html.twig' %}
 
+{% block title %}Procuration - {{ site_name }}{% endblock %}
+
 {% block breadcrumbs %}
-    <a href="{{ path('homepage') }}"><i class="material-icons">home</i></a><i class="material-icons">chevron_right</i>
-    <i class="material-icons">add</i>Procuration
+<a href="{{ path('homepage') }}"><i class="material-icons">home</i></a><i class="material-icons">chevron_right</i>
+<i class="material-icons">add</i>Procuration
 {% endblock %}
 
 {% block content %}
-
-    <h4 class="">Donner une procuration</h4>
-    <h5 class="">{{ event.title }}&nbsp;<i>{{ event.date | date('d F Y H:i') }}</i></h5>
+    <h4>Donner une procuration</h4>
+    <h5>{{ event.title }}&nbsp;<i>{{ event.date | date('d F Y H:i') }}</i></h5>
 
     {% if search_form is defined %}
-    {{ form_start(search_form) }}
-    <h6 class="">Donner ma procuration à une personne que je connais</h6>
-    <div class="row">
-        <div class="col s6">
-            <div class="errors">
-                {{ form_errors(search_form.firstname) }}
+        {{ form_start(search_form) }}
+        <h6>Donner ma procuration à une personne que je connais</h6>
+        <div class="row">
+            <div class="col s6">
+                <div class="errors">
+                    {{ form_errors(search_form.firstname) }}
+                </div>
+                <div class="input-field">
+                    {{ form_widget(search_form.firstname) }}
+                    {{ form_label(search_form.firstname) }}
+                </div>
             </div>
-            <div class="input-field">
-                {{ form_widget(search_form.firstname) }}
-                {{ form_label(search_form.firstname) }}
+            <div class="col s6">
+                <button type="submit" class="btn-large waves-effect waves-light purple" id="find_beneficiary"><i class="material-icons left">search</i>Chercher ce bénéficiaire</button>
             </div>
         </div>
-        <div class="col s6">
-            <button type="submit" class="btn-large waves-effect waves-light purple" id="find_beneficiary"><i class="material-icons left">search</i>Chercher ce bénéficiaire</button>
-        </div>
-    </div>
-    {{ form_end(search_form) }}
+        {{ form_end(search_form) }}
     {% endif %}
 
     {% if confirm_form is defined %}
-    {{ form_start(confirm_form) }}
-    <h6 class="">Donner ma procuration à une personne que je connais</h6>
-    <div class="row">
-        <div class="col s6">
-            <div class="errors">
-                {{ form_errors(confirm_form.owner) }}
+        {{ form_start(confirm_form) }}
+        <h6>Donner ma procuration à une personne que je connais</h6>
+        <div class="row">
+            <div class="col s6">
+                <div class="errors">
+                    {{ form_errors(confirm_form.owner) }}
+                </div>
+                <div class="input-field">
+                    {{ form_widget(confirm_form.owner) }}
+                    {{ form_label(confirm_form.owner) }}
+                </div>
             </div>
-            <div class="input-field">
-                {{ form_widget(confirm_form.owner) }}
-                {{ form_label(confirm_form.owner) }}
+            <div class="col s6">
+                <button type="submit" class="btn-large waves-effect waves-light purple" id="find_beneficiary"><i class="material-icons left">check</i>Valider</button>
             </div>
         </div>
-        <div class="col s6">
-            <button type="submit" class="btn-large waves-effect waves-light purple" id="find_beneficiary"><i class="material-icons left">check</i>Valider</button>
-        </div>
-    </div>
-    {{ form_end(confirm_form) }}
+        {{ form_end(confirm_form) }}
     {% endif %}
 
     {% if event.anonymousProxy %}
-    {% if confirm_form is not defined %}
-    {{ form_start(form) }}
-    <div>
-        <h6 class="">Donner ma procuration à une personne qui se propose</h6>
-        <button type="submit" class="btn-large waves-effect waves-light green" id="submit">Oui, Merci à elle !</button>
-    </div>
-    {{ form_end(form) }}
+        {% if confirm_form is not defined %}
+            {{ form_start(form) }}
+            <div>
+                <h6>Donner ma procuration à une personne qui se propose</h6>
+                <button type="submit" class="btn-large waves-effect waves-light green" id="submit">Oui, Merci à elle !</button>
+            </div>
+            {{ form_end(form) }}
+        {% endif %}
     {% endif %}
-    {% endif %}
-
 {% endblock %}

--- a/app/Resources/views/default/event/proxy/give.html.twig
+++ b/app/Resources/views/default/event/proxy/give.html.twig
@@ -12,7 +12,7 @@
 
     {% if search_form is defined %}
     {{ form_start(search_form) }}
-    <h6 class="">Donner ma procuration une personne que je connais</h6>
+    <h6 class="">Donner ma procuration à une personne que je connais</h6>
     <div class="row">
         <div class="col s6">
             <div class="errors">
@@ -32,7 +32,7 @@
 
     {% if confirm_form is defined %}
     {{ form_start(confirm_form) }}
-    <h6 class="">Donner ma procuration une personne que je connais</h6>
+    <h6 class="">Donner ma procuration à une personne que je connais</h6>
     <div class="row">
         <div class="col s6">
             <div class="errors">

--- a/app/Resources/views/default/event/proxy/take.html.twig
+++ b/app/Resources/views/default/event/proxy/take.html.twig
@@ -6,7 +6,6 @@
 {% endblock %}
 
 {% block content %}
-
     <h4 class="">Accepter une procuration</h4>
     <h5 class="">{{ event.title }}&nbsp;<i>{{ event.date | date('d F Y H:i') }}</i></h5>
 
@@ -21,5 +20,4 @@
         <button type="submit" class="btn-large waves-effect waves-light green">J'accepte une procuration</button>
     </div>
     {{ form_end(form) }}
-
 {% endblock %}

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -63,6 +63,7 @@ twig:
     code_generation_enabled: '%code_generation_enabled%'
     local_currency_name: '%local_currency_name%'
     use_fly_and_fixed: '%use_fly_and_fixed%'
+    max_event_proxy_per_member: '%max_event_proxy_per_member%'
     display_gauge: '%display_gauge%'
     profile_display_task_list: '%profile_display_task_list%'
     profile_display_time_log: '%profile_display_time_log%'

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -121,7 +121,7 @@ parameters:
     display_swipe_cards_settings: true
 
     # Events
-    max_event_proxy_per_user: 1
+    max_event_proxy_per_member: 1
 
     logging.mattermost.enabled: false
     logging.mattermost.level: 'critical'

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -120,6 +120,9 @@ parameters:
     swipe_card_logging_anonymous: true
     display_swipe_cards_settings: true
 
+    # Events
+    max_event_proxy_per_user: 1
+
     logging.mattermost.enabled: false
     logging.mattermost.level: 'critical'
     logging.mattermost.url: 'http://mattermost.yourcoop.local'

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -106,6 +106,9 @@ parameters:
     use_card_reader_to_validate_shifts: false
     max_time_at_end_of_shift: 0
 
+    # Events
+    max_event_proxy_per_member: 1
+
     # Profile configuration
     profile_display_task_list: true
     profile_display_time_log: true
@@ -119,9 +122,6 @@ parameters:
     swipe_card_logging: true
     swipe_card_logging_anonymous: true
     display_swipe_cards_settings: true
-
-    # Events
-    max_event_proxy_per_member: 1
 
     logging.mattermost.enabled: false
     logging.mattermost.level: 'critical'

--- a/src/AppBundle/Controller/EventController.php
+++ b/src/AppBundle/Controller/EventController.php
@@ -23,16 +23,17 @@ use Symfony\Component\HttpFoundation\Session\Session;
  */
 class EventController extends Controller
 {
-
     /**
      * Lists all events.
      *
      * @Route("/", name="event_list", methods={"GET"})
      * @Security("has_role('ROLE_PROCESS_MANAGER')")
      */
-    public function listAction(Request $request) {
+    public function listAction(Request $request)
+    {
         $em = $this->getDoctrine()->getManager();
         $events = $em->getRepository('AppBundle:Event')->findAll();
+
         return $this->render('admin/event/list.html.twig', array(
             'events' => $events,
         ));
@@ -44,13 +45,15 @@ class EventController extends Controller
      * @Route("/proxies_list", name="proxies_list", methods={"GET"})
      * @Security("has_role('ROLE_ADMIN')")
      */
-    public function listProxiesAction(){
+    public function listProxiesAction()
+    {
         $em = $this->getDoctrine()->getManager();
         $proxies = $em->getRepository('AppBundle:Proxy')->findAll();
         $delete_forms = array();
         foreach ($proxies as $proxy){
             $delete_forms[$proxy->getId()] = $this->getProxyDeleteForm($proxy)->createView();
         }
+
         return $this->render('admin/event/proxy/list.html.twig', array(
             'proxies' => $proxies,
             'delete_forms' => $delete_forms,
@@ -64,13 +67,14 @@ class EventController extends Controller
      * @Route("/{id}/proxies_list", name="event_proxies_list", methods={"GET"})
      * @Security("has_role('ROLE_ADMIN')")
      */
-    public function listEventProxiesAction(Event $event,Request $request){
-
+    public function listEventProxiesAction(Event $event, Request $request)
+    {
         $proxies = $event->getProxies();
         $delete_forms = array();
         foreach ($proxies as $proxy){
             $delete_forms[$proxy->getId()] = $this->getProxyDeleteForm($proxy)->createView();
         }
+
         return $this->render('admin/event/proxy/list.html.twig', array(
             'proxies' => $proxies,
             'delete_forms' => $delete_forms,
@@ -97,6 +101,7 @@ class EventController extends Controller
             $session->getFlashBag()->add('success', 'L\'événement a bien été créé !');
             return $this->redirectToRoute('event_edit', array('id' => $event->getId()));
         }
+
         return $this->render('admin/event/new.html.twig', array(
             'commission' => $event,
             'form' => $form->createView(),
@@ -110,7 +115,7 @@ class EventController extends Controller
      * @Route("/{id}/edit", name="event_edit", methods={"GET","POST"})
      * @Security("has_role('ROLE_ADMIN')")
      */
-    public function editAction(Request $request,Event $event)
+    public function editAction(Request $request, Event $event)
     {
         $session = new Session();
 
@@ -118,7 +123,6 @@ class EventController extends Controller
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-
             $em = $this->getDoctrine()->getManager();
 
             $em->persist($event);
@@ -127,7 +131,6 @@ class EventController extends Controller
             $session->getFlashBag()->add('success', 'L\'événement a bien été édité !');
 
             return $this->redirectToRoute('event_list');
-
         }
 
         return $this->render('admin/event/edit.html.twig', array(
@@ -148,13 +151,14 @@ class EventController extends Controller
         $session = new Session();
         $form = $this->getDeleteForm($event);
         $form->handleRequest($request);
+
         if ($form->isSubmitted() && $form->isValid()) {
             $em = $this->getDoctrine()->getManager();
-
             $em->remove($event);
             $em->flush();
             $session->getFlashBag()->add('success', 'L événement a bien été supprimée !');
         }
+
         return $this->redirectToRoute('event_list');
     }
 
@@ -164,19 +168,20 @@ class EventController extends Controller
      * @Route("/proxy/{id}", name="proxy_delete", methods={"DELETE"})
      * @Security("has_role('ROLE_SUPER_ADMIN')")
      */
-    public function removeProxyAction(Request $request,Proxy $proxy)
+    public function removeProxyAction(Request $request, Proxy $proxy)
     {
         $session = new Session();
         $form = $this->getProxyDeleteForm($proxy);
         $form->handleRequest($request);
+
         if ($form->isSubmitted() && $form->isValid()) {
             $em = $this->getDoctrine()->getManager();
-
             $em->remove($proxy);
             $em->flush();
             $session->getFlashBag()->add('success', 'La procuration a bien été supprimée !');
         }
-        return $this->redirectToRoute('event_proxies_list',array('id'=>$proxy->getEvent()->getId()));
+
+        return $this->redirectToRoute('event_proxies_list', array('id'=>$proxy->getEvent()->getId()));
     }
 
     /**
@@ -287,11 +292,12 @@ class EventController extends Controller
      *
      * @Route("/{id}/proxy/give", name="event_proxy_give", methods={"GET","POST"})
      */
-    public function giveProxyAction(Event $event,Request $request,\Swift_Mailer $mailer){
+    public function giveProxyAction(Event $event, Request $request, \Swift_Mailer $mailer)
+    {
         $session = new Session();
         $em = $this->getDoctrine()->getManager();
         $current_app_user = $this->get('security.token_storage')->getToken()->getUser();
-        $myproxy = $em->getRepository('AppBundle:Proxy')->findOneBy(array("event"=>$event,"giver"=>$current_app_user));
+        $myproxy = $em->getRepository('AppBundle:Proxy')->findOneBy(array("event"=>$event, "giver"=>$current_app_user));
 
         if ($myproxy){
             $session->getFlashBag()->add('error', 'Oups, tu as déjà donné une procuration');
@@ -356,7 +362,7 @@ class EventController extends Controller
             $em->persist($proxy);
             $em->flush();
             $session = new Session();
-            $session->getFlashBag()->add('success', 'Votre réquète a bien été acceptée !');
+            $session->getFlashBag()->add('success', 'Votre réquête a bien été acceptée !');
 
             if ($proxy->getGiver() && $proxy->getOwner()){
                 $this->sendProxyMail($proxy,$mailer);
@@ -437,8 +443,9 @@ class EventController extends Controller
 
     /**
      * Generate a page for a beneficiary to choose a proxy able to vote for an event.
-     * Automatically remove the withdrawn members and if a registration_duration
-     * is defined, the member with an expired registration.
+     * Automatically remove:
+     * - the withdrawn members
+     * - and if a registration_duration is defined, the members with an expired registration
      *
      * Goes with the Twig template views/beneficiary/find_member_number.html.twig
      * @Route("/{id}/proxy/find_beneficiary", name="event_proxy_find_beneficiary", methods={"POST"})
@@ -472,7 +479,7 @@ class EventController extends Controller
                 ->andWhere("m != :current_member" )
                     ->setParameter('current_member',$membership);
 
-            if(!is_null($registrationDuration)){
+            if (!is_null($registrationDuration)){
                 $beneficiaries_request = $beneficiaries_request
                     ->andWhere('r.date >= :min_last_registration')
                         ->setParameter('min_last_registration', $minLastRegistration)
@@ -492,8 +499,8 @@ class EventController extends Controller
                 function($b) use ($min_time_count) {return $b->getMembership()->getTimeCount()>$min_time_count*60;}
             );
 
-            if(count($filtered_beneficiaries) != count($beneficiaries)){
-                $session->getFlashBag()->add('notice',"Certains bénéficiaires ne sont pas présents dans " .
+            if (count($filtered_beneficiaries) != count($beneficiaries)){
+                $session->getFlashBag()->add('notice', "Certains bénéficiaires ne sont pas présents dans " .
                     "cette liste, car leur compte est en dessous de la limite d'heure de retard.");
             }
 
@@ -505,8 +512,9 @@ class EventController extends Controller
                 'params' => ['id' => $event->getId()]
             ));
         }
-        $session->getFlashBag()->add('error',"oups, quelque chose c'est mal passé");
-        return $this->redirectToRoute("event_proxy_give",array('id'=>$event->getId()));
+
+        $session->getFlashBag()->add('error', "oups, quelque chose c'est mal passé");
+        return $this->redirectToRoute("event_proxy_give", array('id'=>$event->getId()));
     }
 
     /**
@@ -535,12 +543,16 @@ class EventController extends Controller
 
         $em = $this->getDoctrine()->getManager();
         $current_app_user = $this->get('security.token_storage')->getToken()->getUser();
-        $myproxy = $em->getRepository('AppBundle:Proxy')->findOneBy(array("event"=>$event,"giver"=>$current_app_user));
+        $myproxy = $em->getRepository('AppBundle:Proxy')->findOneBy(array("event"=>$event, "giver"=>$current_app_user));
         $session = new Session();
-        if ($myproxy){
+
+        // check if proxy already given by user
+        if ($myproxy) {
             $session->getFlashBag()->add('error', 'Oups, tu as déjà donné une procuration');
             return $this->redirectToRoute('homepage');
         }
+
+        // check if user is allowed to vote (membership)
         $registrationDuration = $this->getParameter('registration_duration');
         if ($registrationDuration) {
             $minDateOfLastRegistration = clone $event->getMaxDateOfLastRegistration();
@@ -558,7 +570,8 @@ class EventController extends Controller
                 ' peuvent voter à cet événement. Pense à mettre à jour ton adhésion pour participer !');
             return $this->redirectToRoute('homepage');
         }
-        $proxy = $em->getRepository('AppBundle:Proxy')->findOneBy(array("event"=>$event,"owner"=>null));
+
+        $proxy = $em->getRepository('AppBundle:Proxy')->findOneBy(array("event"=>$event, "owner"=>null));
         if (!$proxy){
             $proxy = new Proxy();
             $proxy->setEvent($event);
@@ -568,21 +581,21 @@ class EventController extends Controller
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $myproxy = $em->getRepository('AppBundle:Proxy')->findOneBy(array("event"=>$event,"owner"=>$form->getData()->getOwner()));
-            if ($myproxy){
-                $session->getFlashBag()->add('error', $myproxy->getOwner()->getFirstname().' accepte déjà une procuration.');
-                return $this->redirectToRoute('event_proxy_take',array('id'=>$event->getId()));
+            $max_event_proxy_per_user = $this->container->getParameter("max_event_proxy_per_user");
+            $myproxy = $em->getRepository('AppBundle:Proxy')->findBy(array("event"=>$event, "owner"=>$form->getData()->getOwner()));
+            if (count($myproxy) == $max_event_proxy_per_user) {
+                $session->getFlashBag()->add('error', $myproxy->getOwner()->getFirstname().' accepte déjà '. $max_event_proxy_per_user .' procuration.');
+                return $this->redirectToRoute('event_proxy_take', array('id'=>$event->getId()));
             }
             $em->persist($proxy);
             $em->flush();
-            $session->getFlashBag()->add('success', 'Votre réquète a bien été acceptée !');
+            $session->getFlashBag()->add('success', 'Votre réquête a bien été acceptée !');
 
             if ($proxy->getGiver() && $proxy->getOwner()){
                 $this->sendProxyMail($proxy,$mailer);
             }
 
             return $this->redirectToRoute('homepage');
-
         }
 
         return $this->render('default/event/proxy/take.html.twig', array(
@@ -592,7 +605,7 @@ class EventController extends Controller
 
     }
 
-    public function sendProxyMail(Proxy $proxy,\Swift_Mailer $mailer){
+    public function sendProxyMail(Proxy $proxy, \Swift_Mailer $mailer){
 
         $giverMainBeneficiary = $proxy->getGiver()->getMainBeneficiary();
 

--- a/src/AppBundle/Controller/EventController.php
+++ b/src/AppBundle/Controller/EventController.php
@@ -420,7 +420,7 @@ class EventController extends Controller
                     $em->persist($proxy);
                     $em->flush();
                     $session = new Session();
-                    $session->getFlashBag()->add('success', 'Procuration acceptée !');
+                    $session->getFlashBag()->add('success', 'Procuration donnée à '. $proxy->getOwner() .' !');
 
                     if ($proxy->getGiver() && $proxy->getOwner()){
                         $this->sendProxyMail($proxy,$mailer);

--- a/src/AppBundle/Controller/EventController.php
+++ b/src/AppBundle/Controller/EventController.php
@@ -400,7 +400,7 @@ class EventController extends Controller
                 $member_owner_proxies = $em->getRepository('AppBundle:Proxy')->findBy(
                     array("owner" => $beneficiaries_ids, "event" => $event)
                 );
-                if (count($member_owner_proxies) == $max_event_proxy_per_member) {
+                if (count($member_owner_proxies) >= $max_event_proxy_per_member) {
                     $session->getFlashBag()->add('error', $beneficiary->getUser()->getFirstName() . ' accepte déjà de prendre le nombre maximal de procurations ('. $max_event_proxy_per_member .')');
                     return $this->redirectToRoute('homepage');
                 }
@@ -536,10 +536,11 @@ class EventController extends Controller
      *
      * @Route("/{event}/proxy/remove/{proxy}", name="event_proxy_lite_remove", methods={"GET"})
      */
-    public function removeProxyLiteAction(Event $event,Proxy $proxy,Request $request){
+    public function removeProxyLiteAction(Event $event, Proxy $proxy, Request $request)
+    {
         $session = new Session();
         $current_app_user = $this->get('security.token_storage')->getToken()->getUser();
-        if ($proxy->getEvent() === $event && $proxy->getOwner()->getUser() == $current_app_user){
+        if (($proxy->getEvent() === $event) && ($proxy->getOwner()->getUser() == $current_app_user)) {
             $em = $this->getDoctrine()->getManager();
             $em->remove($proxy);
             $em->flush();
@@ -553,7 +554,7 @@ class EventController extends Controller
      *
      * @Route("/{id}/proxy/take", name="event_proxy_take", methods={"GET","POST"})
      */
-    public function acceptProxyAction(Event $event,Request $request,\Swift_Mailer $mailer)
+    public function acceptProxyAction(Event $event, Request $request, \Swift_Mailer $mailer)
     {
         $em = $this->getDoctrine()->getManager();
         $session = new Session();
@@ -600,7 +601,7 @@ class EventController extends Controller
             // check if member doesn't already have the maximum nomber of proxies (%max_event_proxy_per_member%)
             $max_event_proxy_per_member = $this->container->getParameter("max_event_proxy_per_member");
             $myproxy = $em->getRepository('AppBundle:Proxy')->findBy(array("event" => $event, "owner" => $form->getData()->getOwner()));
-            if (count($myproxy) == $max_event_proxy_per_member) {
+            if (count($myproxy) >= $max_event_proxy_per_member) {
                 $session->getFlashBag()->add('error', $myproxy->getOwner()->getFirstname().' accepte déjà '. $max_event_proxy_per_member .' procuration.');
                 return $this->redirectToRoute('event_proxy_take', array('id'=>$event->getId()));
             }

--- a/src/AppBundle/Controller/EventController.php
+++ b/src/AppBundle/Controller/EventController.php
@@ -298,6 +298,7 @@ class EventController extends Controller
         $em = $this->getDoctrine()->getManager();
         $current_app_user = $this->get('security.token_storage')->getToken()->getUser();
         $myproxy = $em->getRepository('AppBundle:Proxy')->findOneBy(array("event"=>$event, "giver"=>$current_app_user));
+        $max_event_proxy_per_user = $this->container->getParameter("max_event_proxy_per_user");
 
         // check if user has already given a proxy
         if ($myproxy){
@@ -317,10 +318,11 @@ class EventController extends Controller
                 "event" => $event
             )
         );
+        var_dump($received_proxy);
         if ($received_proxy){
             foreach ($received_proxy as $rp){
                 if ($rp->getGiver()){ //someone give a proxy
-                    $session->getFlashBag()->add('error', 'Oups, '.$rp->getGiver().' a donné une procuration à '.$rp->getOwner().', il compte dessus !');
+                    $session->getFlashBag()->add('error', 'Oups, '. $rp->getGiver() .' a donné une procuration à '. $rp->getOwner() .', il compte dessus !');
                     return $this->redirectToRoute('homepage');
                 }else{ //no-one give a proxy, lets remove the waiting one
                     $em->remove($rp);
@@ -381,37 +383,46 @@ class EventController extends Controller
         if ($request->get("beneficiary") > 0){
             $em = $this->getDoctrine()->getManager();
             $beneficiary = $em->getRepository('AppBundle:Beneficiary')->find($request->get("beneficiary"));
-            if ($beneficiary){
+            if ($beneficiary) {
                 $beneficiaries_ids = [];
-                foreach ($beneficiary->getMembership()->getBeneficiaries() as $b){
+                foreach ($beneficiary->getMembership()->getBeneficiaries() as $b) {
                     $beneficiaries_ids[] = $b;
                 }
-                /** @var Proxy $proxy */
-                $proxy = $em->getRepository('AppBundle:Proxy')->findBy(
+
+                // check if beneficiary hasn't already given a procuration
+                $beneficiary_giver_proxies = $em->getRepository('AppBundle:Proxy')->findBy(
+                    array("giver" => $beneficiary->getMembership(), "event" => $event)
+                );
+                if (count($beneficiary_giver_proxies) > 0) {
+                    $session->getFlashBag()->add('error', $beneficiary->getUser()->getFirstName() . ' a déjà donné sa procuration');
+                    return $this->redirectToRoute('homepage');
+                }
+
+                // check if beneficiary doesn't already have maximum number of procuration(s)
+                $beneficiary_owner_proxies = $em->getRepository('AppBundle:Proxy')->findBy(
                     array("owner" => $beneficiaries_ids, "event" => $event)
                 );
-                $max_event_proxy_per_user = $this->container->getParameter("max_event_proxy_per_user");
-
-                if (count($proxy) == $max_event_proxy_per_user) {
+                if (count($beneficiary_owner_proxies) == $max_event_proxy_per_user) {
                     if ($max_event_proxy_per_user == 1) {
-                        if ($proxy->getGiver() !== null) {
+                        if ($beneficiary_owner_proxies->first()->getGiver() !== null) {
                             $session->getFlashBag()->add('error', $beneficiary->getUser()->getFirstName() . ' accepte déjà de prendre une procuration d\'une autre personne');
-                            return $this->redirectToRoute('homepage');
-                        } else if ($proxy->getOwner()!=$beneficiary){
+                        } else if ($beneficiary_owner_proxies->first()->getOwner() != $beneficiary) {
                             $session->getFlashBag()->add('notice', $beneficiary->getUser()->getFirstName() . ' partage son adhésion #' . $beneficiary->getMemberNumber() . ' avec ' . $proxy->getOwner()->getUser()->getFirstname() . ' qui accepte de prendre une procuration pour cet événement !');
                         }
+                        return $this->redirectToRoute('homepage');
                     } else {
                         $session->getFlashBag()->add('error', $beneficiary->getUser()->getFirstName() . ' accepte déjà de prendre le nombre maximal de procurations ('. $max_event_proxy_per_user .')');
                         return $this->redirectToRoute('homepage');
                     }
-                } else {
-                    $proxy = new Proxy();
-                    $proxy->setEvent($event);
-                    $proxy->setCreatedAt(new \DateTime());
-                    $proxy->setOwner($beneficiary);
                 }
-                $current_app_user = $this->get('security.token_storage')->getToken()->getUser();
+
+                // create proxy
+                $proxy = new Proxy();
+                $proxy->setEvent($event);
+                $proxy->setCreatedAt(new \DateTime());
+                $proxy->setOwner($beneficiary);
                 $proxy->setGiver($current_app_user->getBeneficiary()->getMembership());
+
                 $confirm_form = $this->createForm(ProxyType::class, $proxy);
                 $confirm_form->handleRequest($request);
 

--- a/src/AppBundle/Controller/EventController.php
+++ b/src/AppBundle/Controller/EventController.php
@@ -297,16 +297,16 @@ class EventController extends Controller
         $session = new Session();
         $em = $this->getDoctrine()->getManager();
         $current_app_user = $this->get('security.token_storage')->getToken()->getUser();
-        $myproxy = $em->getRepository('AppBundle:Proxy')->findOneBy(array("event" => $event, "giver" => $current_app_user));
         $max_event_proxy_per_member = $this->container->getParameter("max_event_proxy_per_member");
 
-        // check if user has already given a proxy
-        if ($myproxy) {
+        // check if member hasn't already given a proxy
+        $member_given_proxy = $em->getRepository('AppBundle:Proxy')->findOneBy(array("event" => $event, "giver" => $current_app_user->getBeneficiary()->getMembership()));
+        if ($member_given_proxy) {
             $session->getFlashBag()->add('error', 'Oups, tu as déjà donné une procuration');
             return $this->redirectToRoute('homepage');
         }
 
-        // check if member has already received a proxy
+        // check if member hasn't already received a proxy
         $membership = $current_app_user->getBeneficiary()->getMembership();
         $beneficiaries = $membership->getBeneficiaries();
         $beneficiariesId = array_map(function(Beneficiary $beneficiary) {
@@ -383,7 +383,7 @@ class EventController extends Controller
             $em = $this->getDoctrine()->getManager();
             $beneficiary = $em->getRepository('AppBundle:Beneficiary')->find($request->get("beneficiary"));
             if ($beneficiary) {
-                // check if member hasn't already given a procuration
+                // check if member hasn't already given a proxy
                 $member_giver_proxies = $em->getRepository('AppBundle:Proxy')->findBy(
                     array("giver" => $beneficiary->getMembership(), "event" => $event)
                 );

--- a/src/AppBundle/Service/EventService.php
+++ b/src/AppBundle/Service/EventService.php
@@ -40,7 +40,7 @@ class EventService
             ->setParameter('event', $event)
             ->setParameter('beneficiaries', $beneficiary->getMembership()->getBeneficiaries());
 
-        // getResult instead of getOneOrNullResult? member can have multiple proxies (%max_event_proxy_per_user%)
+        // getResult instead of getOneOrNullResult? member can have multiple proxies (%max_event_proxy_per_member%)
         return $qb->getQuery()->getResult();
     }
 }

--- a/src/AppBundle/Service/EventService.php
+++ b/src/AppBundle/Service/EventService.php
@@ -36,11 +36,11 @@ class EventService
         $qb = $this->em->getRepository('AppBundle:Proxy')->createQueryBuilder('p');
 
         $qb->where('p.event = :event')
-            ->andWhere( 'p.owner = :beneficiary')
+            ->andWhere('p.owner IN (:beneficiaries)')
             ->setParameter('event', $event)
-            ->setParameter('beneficiary', $beneficiary);
+            ->setParameter('beneficiaries', $beneficiary->getMembership()->getBeneficiaries());
 
-        // can have multiple proxies (%max_event_proxy_per_user%)
+        // getResult instead of getOneOrNullResult? member can have multiple proxies (%max_event_proxy_per_user%)
         return $qb->getQuery()->getResult();
     }
 }

--- a/src/AppBundle/Service/EventService.php
+++ b/src/AppBundle/Service/EventService.php
@@ -31,7 +31,7 @@ class EventService
         return $qb->getQuery()->getOneOrNullResult();
     }
 
-    public function getReceivedProxyOfBeneficiaryForAnEvent(Event $event, Beneficiary $beneficiary)
+    public function getReceivedProxiesOfBeneficiaryForAnEvent(Event $event, Beneficiary $beneficiary)
     {
         $qb = $this->em->getRepository('AppBundle:Proxy')->createQueryBuilder('p');
 
@@ -40,6 +40,7 @@ class EventService
             ->setParameter('event', $event)
             ->setParameter('beneficiary', $beneficiary);
 
-        return $qb->getQuery()->getOneOrNullResult();
+        // can have multiple proxies (%max_event_proxy_per_user%)
+        return $qb->getQuery()->getResult();
     }
 }

--- a/src/AppBundle/Twig/Extension/EventExtension.php
+++ b/src/AppBundle/Twig/Extension/EventExtension.php
@@ -31,11 +31,11 @@ class EventExtension extends AbstractExtension
     {
         return array(
             new TwigFilter('givenProxy', array($this, 'givenProxy')),
-            new TwigFilter('receivedProxy', array($this, 'receivedProxy')),
+            new TwigFilter('receivedProxies', array($this, 'receivedProxies')),
         );
     }
 
-    public function givenProxy(Event $event) : ?Proxy
+    public function givenProxy(Event $event): ?Proxy
     {
         /** @var User $user */
         $user = $this->tokenStorage->getToken()->getUser();
@@ -45,13 +45,13 @@ class EventExtension extends AbstractExtension
         return $this->eventService->getGivenProxyOfMembershipForAnEvent($event, $user->getBeneficiary()->getMembership());
     }
 
-    public function receivedProxy(Event $event) : ?Proxy
+    public function receivedProxies(Event $event): array
     {
         /** @var User $user */
         $user = $this->tokenStorage->getToken()->getUser();
         if (!$user) {
             return null;
         }
-        return $this->eventService->getReceivedProxyOfBeneficiaryForAnEvent($event, $user->getBeneficiary());
+        return $this->eventService->getReceivedProxiesOfBeneficiaryForAnEvent($event, $user->getBeneficiary());
     }
 }


### PR DESCRIPTION
Actuellement, dans un événement avec procurations, un membre peut porter seulement une procuration.

Le but de cette PR est de pouvoir configurer le nombre maximal de procurations qu'un membre peut porter : 
- nouveau paramètre `max_event_proxy_per_member`
- modifié `EventController` pour permettre de donner / recevoir le bon nombre de procurations
- modifié l'affichage pour être en mesure de lister les procurations reçues
- j'ai aussi réparé un bug où un membre qui avant déjà donné procuration pouvait encore en recevoir