### PR TITLE
Profile : pouvoir afficher le compteur temps

### DIFF
--- a/app/Resources/views/Profile/show_content.html.twig
+++ b/app/Resources/views/Profile/show_content.html.twig
@@ -19,6 +19,17 @@
             </div>
         </li>
 
+        {% if profile_display_time_log %}
+            <li>
+                <div class="collapsible-header">
+                    <i class="material-icons">access_time</i>Compteur de temps
+                </div>
+                <div class="collapsible-body">
+                    {% include "member/_partial/time_logs.html.twig" with { member: member } %}
+                </div>
+            </li>
+        {% endif %}
+
         <li>
             <div class="collapsible-header">
                 <i class="material-icons">ac_unit</i>Gel du compte

--- a/app/Resources/views/member/_partial/time_logs.html.twig
+++ b/app/Resources/views/member/_partial/time_logs.html.twig
@@ -13,7 +13,7 @@
     </tbody>
 </table>
 
-{% if is_granted("ROLE_SHIFT_MANAGER") %}
+{% if from_admin is defined and is_granted("ROLE_SHIFT_MANAGER") %}
     <a href="#add-time-log" class="modal-trigger waves-effect waves-light btn teal">
         <i class="material-icons left">add</i>Ajouter un log de temps
     </a>
@@ -47,7 +47,7 @@
                 <td>{{ timeLog.time | duration_from_minutes }}</td>
                 <td>{{ timeLog.computedDescription }}</td>
                 <td>
-                    {% if is_granted("ROLE_SHIFT_MANAGER") %}
+                    {% if from_admin is defined and is_granted("ROLE_SHIFT_MANAGER") %}
                         <a href="{{ path('member_timelog_delete',{ "id":member.id, "timelog_id": timeLog.id }) }}" class="red-text">X</a>
                     {% endif %}
                 </td>

--- a/app/Resources/views/member/_partial/time_logs.html.twig
+++ b/app/Resources/views/member/_partial/time_logs.html.twig
@@ -1,24 +1,23 @@
 <table>
     <thead>
-    <tr>
-        <th>TOTAL</th>
-        <th>TOTAL CYCLE EN COURS</th>
-    </tr>
+        <tr>
+            <th>TOTAL</th>
+            <th>TOTAL CYCLE EN COURS</th>
+        </tr>
     </thead>
     <tbody>
-    <tr>
-        <td>{{ member.timeCount | duration_from_minutes }}</td>
-        <td>{{ member.timeCount(member.endOfCycle(0)) | duration_from_minutes }}</td>
-    </tr>
+        <tr>
+            <td>{{ member.timeCount | duration_from_minutes }}</td>
+            <td>{{ member.timeCount(member.endOfCycle(0)) | duration_from_minutes }}</td>
+        </tr>
     </tbody>
 </table>
 
 {% if is_granted("ROLE_SHIFT_MANAGER") %}
-
     <a href="#add-time-log" class="modal-trigger waves-effect waves-light btn teal">
-        <i class="material-icons left">add</i>Ajouter un log de temps</a>
+        <i class="material-icons left">add</i>Ajouter un log de temps
+    </a>
     {{ form_start(time_log_form) }}
-
     <div id="add-time-log" class="modal">
         <div class="modal-content">
             <h5><i class="material-icons left small">access_time</i>Ajouter un log de temps</h5>
@@ -26,9 +25,7 @@
         </div>
         <div class="modal-footer">
             <a href="#!" class="modal-action modal-close waves-effect waves-green btn-flat orange-text">Annuler</a>
-
             <button type="submit" class="btn green"><i class="material-icons left">add</i>Ajouter le log de temps</button>
-
         </div>
     </div>
     {{ form_end(time_log_form) }}
@@ -36,26 +33,25 @@
 
 <table>
     <thead>
-    <tr class="grey lighten-2">
-        <th>Date du log</th>
-        <th>Temps</th>
-        <th>Motif</th>
-        <th></th>
-    </tr>
+        <tr class="grey lighten-2">
+            <th>Date du log</th>
+            <th>Temps</th>
+            <th>Motif</th>
+            <th></th>
+        </tr>
     </thead>
     <tbody>
-    {% for timeLog in member.timeLogs %}
-        <tr class="{% if timeLog.time > 0 %}green{% elseif timeLog.time < 0 %}red{% else %}grey{% endif %} lighten-5">
-            <td>{{ timeLog.date | date_fr_full }}</td>
-            <td>{{ timeLog.time | duration_from_minutes }}</td>
-            <td>{{ timeLog.computedDescription }}</td>
-            <td>
-                {% if is_granted("ROLE_SHIFT_MANAGER") %}
-                    <a href="{{ path('member_timelog_delete',{ "id":member.id, "timelog_id": timeLog.id }) }}" class="red-text">X</a>
-                {% endif %}
-            </td>
-        </tr>
-    {% endfor %}
+        {% for timeLog in member.timeLogs %}
+            <tr class="{% if timeLog.time > 0 %}green{% elseif timeLog.time < 0 %}red{% else %}grey{% endif %} lighten-5">
+                <td>{{ timeLog.date | date_fr_full }}</td>
+                <td>{{ timeLog.time | duration_from_minutes }}</td>
+                <td>{{ timeLog.computedDescription }}</td>
+                <td>
+                    {% if is_granted("ROLE_SHIFT_MANAGER") %}
+                        <a href="{{ path('member_timelog_delete',{ "id":member.id, "timelog_id": timeLog.id }) }}" class="red-text">X</a>
+                    {% endif %}
+                </td>
+            </tr>
+        {% endfor %}
     </tbody>
 </table>
-

--- a/app/Resources/views/member/show.html.twig
+++ b/app/Resources/views/member/show.html.twig
@@ -130,7 +130,7 @@
                 <i class="material-icons">access_time</i>Compteur de temps
             </div>
             <div class="collapsible-body white">
-                {% include "member/_partial/time_logs.html.twig" with { member: member, time_log_form: time_log_form } %}
+                {% include "member/_partial/time_logs.html.twig" with { member: member, from_admin: true, time_log_form: time_log_form } %}
             </div>
         </li>
 

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -62,6 +62,7 @@ twig:
     local_currency_name: '%local_currency_name%'
     use_fly_and_fixed: '%use_fly_and_fixed%'
     display_gauge: '%display_gauge%'
+    profile_display_time_log: '%profile_display_time_log%'
     display_swipe_cards_settings: '%display_swipe_cards_settings%'
     display_freeze_account: '%display_freeze_account%'
     display_freeze_account_false_message: '%display_freeze_account_false_message%'

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -105,6 +105,9 @@ parameters:
     use_card_reader_to_validate_shifts: false
     max_time_at_end_of_shift: 0
 
+    # Profile configuration
+    profile_display_time_log: false
+
     # Swipe card configuration
     swipe_card_logging: true
     swipe_card_logging_anonymous: true


### PR DESCRIPTION
### Quoi ?

Dans la page "Gérer mon profile", ou souhaite pouvoir afficher les détails du compteur de temps : 
- le template `member/_partial/time_logs.html.twig` existe déjà (car le compteur de temps est disponible dans la partie admin du profil d'un membre)
- nouveau paramètre `profile_display_time_log` pour permettre aux coop d'afficher (ou pas) cette section dans le profil des membres
- s'assurer que les actions "admin" (ajouter un log de temps, supprimer un log de temps) ne soient pas disponibles coté profil

### Capture d'écran

![Screenshot from 2022-10-29 16-53-07](https://user-images.githubusercontent.com/7147385/198838211-c5ab456b-7117-485c-b6cf-ba849b320389.png)
