### PR TITLE
Amélioration des log de temps

### DIFF
--- a/app/DoctrineMigrations/Version20221029073034.php
+++ b/app/DoctrineMigrations/Version20221029073034.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20221029073034 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE time_log CHANGE date created_at DATETIME NOT NULL');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE time_log CHANGE created_at date DATETIME NOT NULL');
+    }
+}

--- a/app/DoctrineMigrations/Version20221029094650.php
+++ b/app/DoctrineMigrations/Version20221029094650.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20221029094650 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE time_log ADD created_by_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE time_log ADD CONSTRAINT FK_55BE03AFB03A8386 FOREIGN KEY (created_by_id) REFERENCES fos_user (id)');
+        $this->addSql('CREATE INDEX IDX_55BE03AFB03A8386 ON time_log (created_by_id)');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE time_log DROP FOREIGN KEY FK_55BE03AFB03A8386');
+        $this->addSql('DROP INDEX IDX_55BE03AFB03A8386 ON time_log');
+        $this->addSql('ALTER TABLE time_log DROP created_by_id');
+    }
+}

--- a/app/Resources/views/member/_partial/time_logs.html.twig
+++ b/app/Resources/views/member/_partial/time_logs.html.twig
@@ -43,7 +43,7 @@
     <tbody>
         {% for timeLog in member.timeLogs %}
             <tr class="{% if timeLog.time > 0 %}green{% elseif timeLog.time < 0 %}red{% else %}grey{% endif %} lighten-5">
-                <td>{{ timeLog.date | date_fr_full }}</td>
+                <td>{{ timeLog.createdAt | date_fr_full }}</td>
                 <td>{{ timeLog.time | duration_from_minutes }}</td>
                 <td>{{ timeLog.computedDescription }}</td>
                 <td>

--- a/app/Resources/views/member/_partial/time_logs.html.twig
+++ b/app/Resources/views/member/_partial/time_logs.html.twig
@@ -35,6 +35,7 @@
     <thead>
         <tr class="grey lighten-2">
             <th>Date du log</th>
+            <th>Auteur</th>
             <th>Temps</th>
             <th>Motif</th>
             <th></th>
@@ -44,6 +45,7 @@
         {% for timeLog in member.timeLogs %}
             <tr class="{% if timeLog.time > 0 %}green{% elseif timeLog.time < 0 %}red{% else %}grey{% endif %} lighten-5">
                 <td>{{ timeLog.createdAt | date_fr_full }}</td>
+                <td>{{ timeLog.createdBy }}</td>
                 <td>{{ timeLog.time | duration_from_minutes }}</td>
                 <td>{{ timeLog.computedDescription }}</td>
                 <td>

--- a/app/Resources/views/member/_partial/time_logs.html.twig
+++ b/app/Resources/views/member/_partial/time_logs.html.twig
@@ -47,7 +47,7 @@
                 <td>{{ timeLog.time | duration_from_minutes }}</td>
                 <td>{{ timeLog.computedDescription }}</td>
                 <td>
-                    {% if from_admin is defined and is_granted("ROLE_SHIFT_MANAGER") %}
+                    {% if from_admin is defined and is_granted("ROLE_SUPER_ADMIN") %}
                         <a href="{{ path('member_timelog_delete',{ "id":member.id, "timelog_id": timeLog.id }) }}" class="red-text">X</a>
                     {% endif %}
                 </td>

--- a/src/AppBundle/Command/InitTimeLogCommand.php
+++ b/src/AppBundle/Command/InitTimeLogCommand.php
@@ -68,7 +68,7 @@ class InitTimeLogCommand extends ContainerAwareCommand
         $log->setMembership($membership);
         $log->setTime($shift->getDuration());
         $log->setShift($shift);
-        $log->setDate($shift->getStart());
+        $log->setCreatedAt($shift->getStart());
         $log->setType(TimeLog::TYPE_SHIFT);
         $em->persist($log);
     }
@@ -84,7 +84,7 @@ class InitTimeLogCommand extends ContainerAwareCommand
         $log = new TimeLog();
         $log->setMembership($membership);
         $log->setTime(-180);
-        $log->setDate($date);
+        $log->setCreatedAt($date);
         $log->setType(TimeLog::TYPE_CYCLE_END);
         $em->persist($log);
     }

--- a/src/AppBundle/Controller/TimeLogController.php
+++ b/src/AppBundle/Controller/TimeLogController.php
@@ -26,7 +26,7 @@ class TimeLogController extends Controller
      *
      * @Route("/{id}/timelog_delete/{timelog_id}", name="member_timelog_delete")
      * @Method({"GET"})
-     * @Security("has_role('ROLE_SHIFT_MANAGER')")
+     * @Security("has_role('ROLE_SUPER_ADMIN')")
      * @param Membership $member
      * @param $timelog_id
      * @return \Symfony\Component\HttpFoundation\RedirectResponse

--- a/src/AppBundle/Controller/TimeLogController.php
+++ b/src/AppBundle/Controller/TimeLogController.php
@@ -65,7 +65,6 @@ class TimeLogController extends Controller
 
         if ($form->isSubmitted() && $form->isValid()) {
 
-            $timeLog->setDate(new \DateTime());
             $timeLog->setMembership($member);
             $timeLog->setTime($form->get('time')->getData());
             $timeLog->setDescription($form->get('description')->getData());

--- a/src/AppBundle/Controller/TimeLogController.php
+++ b/src/AppBundle/Controller/TimeLogController.php
@@ -67,6 +67,8 @@ class TimeLogController extends Controller
 
             $timeLog->setMembership($member);
             $timeLog->setTime($form->get('time')->getData());
+            $current_user = $this->get('security.token_storage')->getToken()->getUser();
+            $timeLog->setCreatedBy($current_user);
             $timeLog->setDescription($form->get('description')->getData());
             $timeLog->setType(TimeLog::TYPE_CUSTOM);
 

--- a/src/AppBundle/Entity/Membership.php
+++ b/src/AppBundle/Entity/Membership.php
@@ -99,7 +99,7 @@ class Membership
 
     /**
      * @ORM\OneToMany(targetEntity="TimeLog", mappedBy="membership",cascade={"persist", "remove"})
-     * @OrderBy({"date" = "DESC"})
+     * @OrderBy({"createdAt" = "DESC"})
      */
     private $timeLogs;
 
@@ -676,7 +676,7 @@ class Membership
         };
         if ($before)
             $logs = $this->getTimeLogs()->filter(function ($log) use ($before){
-                return ($log->getDate() < $before);
+                return ($log->getCreatedAt() < $before);
             });
         else
             $logs = $this->getTimeLogs();

--- a/src/AppBundle/Entity/TimeLog.php
+++ b/src/AppBundle/Entity/TimeLog.php
@@ -8,6 +8,7 @@ use Doctrine\ORM\Mapping as ORM;
  * TimeLog
  *
  * @ORM\Table(name="time_log")
+ * @ORM\HasLifecycleCallbacks()
  * @ORM\Entity(repositoryClass="AppBundle\Repository\TimeLogRepository")
  */
 class TimeLog
@@ -33,9 +34,9 @@ class TimeLog
     /**
      * @var \DateTime
      *
-     * @ORM\Column(name="date", type="datetime")
+     * @ORM\Column(name="created_at", type="datetime")
      */
-    private $date;
+    private $createdAt;
 
     /**
      * @var int
@@ -81,27 +82,13 @@ class TimeLog
     }
 
     /**
-     * Set date
-     *
-     * @param \DateTime $date
-     *
-     * @return TimeLog
-     */
-    public function setDate($date)
-    {
-        $this->date = $date;
-
-        return $this;
-    }
-
-    /**
-     * Get date
+     * Get createdAt
      *
      * @return \DateTime
      */
-    public function getDate()
+    public function getCreatedAt()
     {
-        return $this->date;
+        return $this->createdAt;
     }
 
     /**
@@ -198,6 +185,27 @@ class TimeLog
     public function getType(): int
     {
         return $this->type;
+    }
+
+    /**
+     * Set created_at
+     *
+     * @param \DateTime $created_at
+     *
+     * @return TimeLog
+     */
+    public function setCreatedAt($created_at)
+    {
+        $this->createdAt = $date;
+        return $this;
+    }
+
+    /**
+     * @ORM\PrePersist
+     */
+    public function setCreatedAtValue()
+    {
+        $this->createdAt = new \DateTime();
     }
 
     /**

--- a/src/AppBundle/Entity/TimeLog.php
+++ b/src/AppBundle/Entity/TimeLog.php
@@ -39,6 +39,12 @@ class TimeLog
     private $createdAt;
 
     /**
+     * @ORM\ManyToOne(targetEntity="User")
+     * @ORM\JoinColumn(name="created_by_id", referencedColumnName="id")
+     */
+    private $createdBy;
+
+    /**
      * @var int
      *
      * @ORM\Column(name="time", type="smallint")
@@ -89,6 +95,29 @@ class TimeLog
     public function getCreatedAt()
     {
         return $this->createdAt;
+    }
+
+    /**
+     * Set createdBy
+     *
+     * @param \AppBundle\Entity\User $createBy
+     *
+     * @return TimeLog
+     */
+    public function setCreatedBy(\AppBundle\Entity\User $createdBy = null)
+    {
+        $this->createdBy = $createdBy;
+        return $this;
+    }
+
+    /**
+     * Get booker
+     *
+     * @return \AppBundle\Entity\User
+     */
+    public function getCreatedBy()
+    {
+        return $this->createdBy;
     }
 
     /**

--- a/src/AppBundle/EventListener/TimeLogEventListener.php
+++ b/src/AppBundle/EventListener/TimeLogEventListener.php
@@ -126,11 +126,11 @@ class TimeLogEventListener
         $registrationEnd = clone $member->getLastRegistration()->getDate();
         $registrationEnd->modify('+'.$this->registration_duration);
         $registrationEnd->modify('+'.$this->cycle_duration);
-        
+
         if ($date > $registrationEnd) {
-            $this->createRegistrationExpiredLog($member,$date);
+            $this->createRegistrationExpiredLog($member);
         } else if ($member->getFrozen()) {
-            $this->createFrozenLog($member,$date);
+            $this->createFrozenLog($member);
         } else {
             $this->createCycleBeginningLog($member, $date);
         }
@@ -158,7 +158,7 @@ class TimeLogEventListener
         $log->setMembership($shift->getShifter()->getMembership());
         $log->setTime($shift->getDuration());
         $log->setShift($shift);
-        $log->setDate($shift->getStart());
+        $log->setCreatedAt($shift->getStart());
         $log->setType(TimeLog::TYPE_SHIFT);
         $this->em->persist($log);
         $this->em->flush();
@@ -191,7 +191,6 @@ class TimeLogEventListener
         $log = new TimeLog();
         $log->setMembership($membership);
         $log->setTime(-1 * $this->due_duration_by_cycle);
-        $log->setDate($date);
         $log->setType(TimeLog::TYPE_CYCLE_END);
         $this->em->persist($log);
 
@@ -203,7 +202,6 @@ class TimeLogEventListener
             $log = new TimeLog();
             $log->setMembership($membership);
             $log->setTime(-1 * ($counter_today - ($this->due_duration_by_cycle + $allowed_cumul)));
-            $log->setDate($date);
             $log->setType(TimeLog::TYPE_CYCLE_END_REGULATE_OPTIONAL_SHIFTS);
             $this->em->persist($log);
         }
@@ -212,16 +210,14 @@ class TimeLogEventListener
 
     /**
      * @param Membership $membership
-     * @param \DateTime $date
      * @throws \Doctrine\ORM\ORMException
      * @throws \Doctrine\ORM\OptimisticLockException
      */
-    private function createFrozenLog(Membership $membership, \DateTime $date)
+    private function createFrozenLog(Membership $membership)
     {
         $log = new TimeLog();
         $log->setMembership($membership);
         $log->setTime(0);
-        $log->setDate($date);
         $log->setType(TimeLog::TYPE_CYCLE_END_FROZEN);
         $this->em->persist($log);
         $this->em->flush();
@@ -229,16 +225,14 @@ class TimeLogEventListener
 
     /**
      * @param Membership $membership
-     * @param \DateTime $date
      * @throws \Doctrine\ORM\ORMException
      * @throws \Doctrine\ORM\OptimisticLockException
      */
-    private function createRegistrationExpiredLog(Membership $membership, \DateTime $date)
+    private function createRegistrationExpiredLog(Membership $membership)
     {
         $log = new TimeLog();
         $log->setMembership($membership);
         $log->setTime(0);
-        $log->setDate($date);
         $log->setType(TimeLog::TYPE_CYCLE_END_EXPIRED_REGISTRATION);
         $this->em->persist($log);
         $this->em->flush();


### PR DESCRIPTION
- Renommer attribut 'date' en 'created_at' pour plus de cohérence
- Restreindre la suppression des logs de temps à SUPER_ADMIN
- Ajout d'un attribute 'createdBy'