### PR TITLE
Admin : petite réorganisation des boutons

### DIFF
--- a/app/Resources/views/admin/index.html.twig
+++ b/app/Resources/views/admin/index.html.twig
@@ -26,6 +26,9 @@
                 <a href="{{ path("user_index") }}" class="waves-effect waves-light btn">
                     <i class="material-icons left">people</i>Gérer les adhérents
                 </a>
+                <a href="{{ path('ambassador_shifttimelog_list') }}" class="waves-effect waves-light btn">
+                    <i class="material-icons left">phone</i>Relances créneaux
+                </a>
             {% endif %}
             {% if is_granted("ROLE_ADMIN") %}
                 <a href="{{ path("member_join") }}" class="waves-effect waves-light btn">

--- a/app/Resources/views/default/tools/office_tools.html.twig
+++ b/app/Resources/views/default/tools/office_tools.html.twig
@@ -21,7 +21,6 @@
 <div class="row">
     <a href="{{ path("pre_user_index") }}" class="waves-effect waves-light btn"><i class="material-icons left">people</i>Suivre les pré-adhésions</a>
     <a href="{{ path('ambassador_membership_list') }}" class="waves-effect waves-light teal btn"><i class="material-icons left">phone</i>Relances ré-adhésions</a>
-    <a href="{{ path('ambassador_shifttimelog_list') }}" class="waves-effect waves-light teal btn"><i class="material-icons left">phone</i>Relances créneaux</a>
 </div>
 
 <div class="row">

--- a/src/AppBundle/Controller/AmbassadorController.php
+++ b/src/AppBundle/Controller/AmbassadorController.php
@@ -114,8 +114,8 @@ class AmbassadorController extends Controller
      * Lists all users with shift time logs older than 9 hours.
      *
      * @Route("/shifttimelog", name="ambassador_shifttimelog_list")
-     * @Method({"GET","POST"})
-     * @Security("has_role('ROLE_USER_VIEWER')")
+     * @Method({"GET", "POST"})
+     * @Security("has_role('ROLE_USER_MANAGER')")
      * @param request $request , searchuserformhelper $formhelper
      * @return response
      */
@@ -184,7 +184,6 @@ class AmbassadorController extends Controller
             'page'=>$page,
             'nb_of_pages'=>$nb_of_pages
         ));
-
     }
 
     /**


### PR DESCRIPTION
### Quoi ?

- bougé plus haut la section "Créneaux"
- bougé plus bas la section "Boitier à clefs"
- déplacé le bouton "Relances créneaux" de la section Ambassadeur vers la section Membres (demande récurrente que cette action est lié au Bureau des membres / pas utilisé par les Ambassadeurs)

### Captures d'écran

|Avant|Après|
|---|---|
|![Screenshot from 2022-10-31 11-44-00](https://user-images.githubusercontent.com/7147385/198990488-5ee4b26c-84d6-4647-80eb-32a6f9d96826.png)|![Screenshot from 2022-10-31 11-44-32](https://user-images.githubusercontent.com/7147385/198990494-b2e7b758-4fc7-4f71-898a-edbc3fa29c6e.png)|
