### PR TITLE
Profile : pouvoir cacher le bouton "Tâches en cours"

### DIFF
--- a/app/Resources/views/default/index.html.twig
+++ b/app/Resources/views/default/index.html.twig
@@ -105,15 +105,17 @@
                             <a href="{{ path("schedule") }}" class="waves-effect waves-light btn teal darken-1">
                                 <i class="material-icons left">schedule</i>Planning
                             </a>
-                            <br>
-                            <br>
-                            <a href="{{ path("tasks_list") }}" class="waves-effect waves-light btn blue-grey">
-                                <i class="material-icons left">list</i>Taches en cours
-                            </a>
-                            <br>
+                            <br />
+                            <br />
+                            {% if profile_display_task_list %}
+                                <a href="{{ path("tasks_list") }}" class="waves-effect waves-light btn blue-grey">
+                                    <i class="material-icons left">list</i>Tâches en cours
+                                </a>
+                                <br />
+                            {% endif %}
                             <a href="{{ path("process_update_list") }}" class="btn blue-grey" id="news_home_button" style="position: relative">
                                 <i class="material-icons left" >info</i>Les nouveautés
-                                <span class="bubble_counter red white-text" style="display:none;">{{ app.user.beneficiary | last_shift_date | count_updates_list_from_date}}</span>
+                                <span class="bubble_counter red white-text" style="display:none;">{{ app.user.beneficiary | last_shift_date | count_updates_list_from_date }}</span>
                             </a>
                             <script>
                                 defer(function () {

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -62,6 +62,7 @@ twig:
     local_currency_name: '%local_currency_name%'
     use_fly_and_fixed: '%use_fly_and_fixed%'
     display_gauge: '%display_gauge%'
+    profile_display_task_list: '%profile_display_time_log%'
     profile_display_time_log: '%profile_display_time_log%'
     display_swipe_cards_settings: '%display_swipe_cards_settings%'
     display_freeze_account: '%display_freeze_account%'

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -106,7 +106,8 @@ parameters:
     max_time_at_end_of_shift: 0
 
     # Profile configuration
-    profile_display_time_log: false
+    profile_display_task_list: true
+    profile_display_time_log: true
 
     # Swipe card configuration
     swipe_card_logging: true


### PR DESCRIPTION
### Quoi ?

Nouveau paramètre `profile_display_task_list` pour cacher le bouton "Tâches en cours" du profil des membres.

### Pourquoi ?

Sur son profile, il y a quelques boutons, dont un intitulé "Tâches en cours".
Il correspond à des tâches crées par des commissions.
Mais si la coop utilise l'outil sans créer de commissions, alors pas besoin d'afficher ce bouton.

### Capture d'écran (actuellement)

![Screenshot from 2022-10-31 15-09-58](https://user-images.githubusercontent.com/7147385/199027850-44872b68-fc65-4ad5-b4fc-f4bb086951bd.png)
