### PR TITLE
Profile : enlever le bouton "Mon badge"

### DIFF
--- a/app/Resources/views/default/index.html.twig
+++ b/app/Resources/views/default/index.html.twig
@@ -85,11 +85,6 @@
                                     </a>
                                 {% else %}
                                     <div>
-                                        <div>
-                                            {% if display_swipe_cards_settings %}
-                                                {% include "member/_partial/swipe_card.html.twig" with { member: app.user.beneficiary.membership, showBadgeImage: false } %}
-                                            {% endif %}
-                                        </div>
                                         <a href="{{ path("fos_user_profile_show") }}" class="waves-effect waves-light blue-grey btn">
                                             <i class="material-icons left">settings</i>Gérer mon compte
                                         </a>


### PR DESCRIPTION
### Quoi ?

Enlever le bouton "Mon badge" de son profil

### Pourquoi ?

- parce que il y a déjà les détails de son badge dans la page  "Gerer mon profil"
- ca fait un peu de place :)

### Captures d'écran

|Avant|Après|
|---|---|
|![Screenshot from 2022-10-31 15-14-49](https://user-images.githubusercontent.com/7147385/199031954-91737c0d-dbef-46f2-8afa-de81517b4590.png)|![Screenshot from 2022-10-31 15-28-30](https://user-images.githubusercontent.com/7147385/199031971-bface5c2-154e-4e5b-8fb3-49b56ebd3d8f.png)|

Aperçu de la page "Gérer mon profil"


![Screenshot from 2022-10-31 15-15-13](https://user-images.githubusercontent.com/7147385/199032042-d996e52c-ebfe-4fcd-a8d2-b72ae40b12ca.png)
