### PR TITLE
Profile : bouger la section "Action" plus haut

### DIFF
--- a/app/Resources/views/default/index.html.twig
+++ b/app/Resources/views/default/index.html.twig
@@ -145,31 +145,31 @@
                         {% endif %}
                     </div>
                 </div>
+                {% if app.user.beneficiary and app.user.beneficiary.ownedCommissions | length %}
+                    <div class="homebox">
+                        <h5><span class="white">Mes commissions</h5>
+                        {% for commission in app.user.beneficiary.ownedCommissions %}
+                            <a href="{{ path("commission_edit",{'id': commission.id }) }}" class="waves-effect waves-light btn blue-grey">
+                                Gérer la commission {{ commission.name }}
+                            </a>
+                        {% endfor %}
+                    </div>
+                {% endif %}
+                {% if app.user.beneficiary and (app.user.beneficiary.membership | uptodate) and display_keys_shop %}
+                    <div class="homebox">
+                        <h5><span class="white"><i class="material-icons">build</i>&nbsp;Outils</span></h5>
+                        {% if display_keys_shop %}
+                            {{ render(controller("AppBundle:Code:homepageDashboard")) }}
+                        {% endif %}
+                    </div>
+                {% endif %}
             </div>
         </div>
     {% endif %}
     {% if app.user.beneficiary and app.user.beneficiary.membership | uptodate %}
         <div id="home-shifts" class="row">
             <div class="col s12">
-                {{ render(controller("AppBundle:Booking:homepageShifts")) }}{# use include instead?#}
-            </div>
-        </div>
-        <div class="row center">
-            <div class="col offset-xl3 xl6 m8 offset-m2 s12">
-                <div class="homebox">
-                    <h5><span class="white"><i class="material-icons">build</i>&nbsp;Action</span></h5>
-
-                    {{ render(controller("AppBundle:Code:homepageDashboard")) }}{# use include instead?#}
-
-                    {% if app.user.beneficiary and app.user.beneficiary.ownedCommissions | length %}
-                        <h5>Mes commissions</h5>
-                        {% for com in app.user.beneficiary.ownedCommissions %}
-                            <a href="{{ path("commission_edit",{'id': com.id }) }}" class="waves-effect waves-light btn blue-grey">
-                                Gérer la commission {{ com.name }}
-                            </a>
-                        {% endfor %}
-                    {% endif %}
-                </div>
+                {{ render(controller("AppBundle:Booking:homepageShifts")) }}{# use include instead? #}
             </div>
         </div>
     {% endif %}

--- a/src/AppBundle/Controller/CodeController.php
+++ b/src/AppBundle/Controller/CodeController.php
@@ -34,7 +34,7 @@ class CodeController extends Controller
         if (!$codes) {
             $codes[] = new Code();
         }
-        return $this->render('default/code/home_dashboard.html.twig',array('codes'=>$codes));
+        return $this->render('default/code/home_dashboard.html.twig', array('codes' => $codes));
     }
 
     /**


### PR DESCRIPTION
### Quoi ?

- dans le profil des membres, remonter la section "Action"
- renommer la section "Action" en "Outils"
- laisser en bas les actions liés aux commissions (et renommer en "Mes commissions")

### Pourquoi ?

- suite des 2 PR sur le profile : https://github.com/elefan-grenoble/gestion-compte/pull/576 & https://github.com/elefan-grenoble/gestion-compte/pull/575 pour faire un peu de place sur le tableau de bord des membres.
- dans l'idée aussi d'y rajouter ensuite un bouton vers notre tableau de stats : https://github.com/elefan-grenoble/gestion-compte/issues/574

### Captures d'écran

|Avant|Après|
|---|---|
|![Screenshot from 2022-11-02 11-11-04](https://user-images.githubusercontent.com/7147385/199463154-cae7e567-505d-4bc5-85a7-708e34bd51dc.png)|![Screenshot from 2022-11-02 11-11-41](https://user-images.githubusercontent.com/7147385/199463156-7f70584f-f40e-47e3-9a1d-1f94728e75b9.png)|

