### PR TITLE
Mieux afficher et exporter les procurations

### DIFF
--- a/app/Resources/views/admin/event/list.html.twig
+++ b/app/Resources/views/admin/event/list.html.twig
@@ -40,7 +40,6 @@
                             {{ event.description | markdown | raw }}
                         </div>
                         <div class="card-action">
-
                             <div class="left">
                                 <a href="{{ path("event_edit",{'id':event.id}) }}"><i class="material-icons left">edit</i>Editer</a>
                             </div>

--- a/app/Resources/views/admin/event/proxy/list.html.twig
+++ b/app/Resources/views/admin/event/proxy/list.html.twig
@@ -14,14 +14,14 @@
     <h4>Liste des procurations en cours <small>({{ proxies | length }})</small></h4>
 
     {% if max_event_proxy_per_member > 0 %}
-    <blockquote class="red-text">
-        chaque membre peut porter au maximum <strong>{{ max_event_proxy_per_member }} procuration{% if max_event_proxy_per_member > 1 %}s{% endif %}</strong>
-    </blockquote>
+        <blockquote class="red-text">
+            chaque membre peut porter au maximum <strong>{{ max_event_proxy_per_member }} procuration{% if max_event_proxy_per_member > 1 %}s{% endif %}</strong>
+        </blockquote>
     {% endif %}
     {% if maximum_nb_of_beneficiaries_in_membership > 1 %}
-    <blockquote class="red-text">
-        si un membre a <strong>plusieurs</strong> bénéficiaires, c'est le bénéficiaire <strong>principal</strong> qui sera affiché à droite
-    </blockquote>
+        <blockquote class="red-text">
+            si un membre a <strong>plusieurs</strong> bénéficiaires, c'est n'importe lequel des bénéficiaires qui peut porter la procuration
+        </blockquote>
     {% endif %}
 
     {% if event %}
@@ -35,12 +35,12 @@
                     {% if not proxy.giver %}
                         Pour le premier volontaire
                     {% else %}
-                        De &nbsp;<b>{{ proxy.giver.mainBeneficiary }}</b>&nbsp;
+                        De &nbsp;<b>{{ proxy.giver.memberNumberWithBeneficiaryListString }}</b>&nbsp;
                     {% endif %}
                     {% if not proxy.owner %}
                         porté par le premier volontaire
                     {% else %}
-                        porté par &nbsp;<b>{{ proxy.owner.membership.mainBeneficiary }}</b>&nbsp;
+                        porté par &nbsp;<b>{{ proxy.owner.membership.memberNumberWithBeneficiaryListString }}</b>&nbsp;
                     {% endif %}
                     {% if not event and proxy.event %}
                         [{{ proxy.event.title }}]

--- a/app/Resources/views/admin/event/proxy/list.html.twig
+++ b/app/Resources/views/admin/event/proxy/list.html.twig
@@ -6,7 +6,9 @@
 <a href="{{ path('homepage') }}"><i class="material-icons">home</i></a><i class="material-icons">chevron_right</i>
 <a href="{{ path('admin') }}"><i class="material-icons">build</i>&nbsp;Administration</a><i class="material-icons">chevron_right</i>
 <a href="{{ path('event_list') }}"><i class="material-icons">list</i>&nbsp;Liste des événements</a><i class="material-icons">chevron_right</i>
-<i class="material-icons">event</i>&nbsp;{{ event.title }}<i class="material-icons">chevron_right</i>
+{% if event %}
+    <i class="material-icons">event</i>&nbsp;{{ event.title }}<i class="material-icons">chevron_right</i>
+{% endif %}
 <i class="material-icons">list</i>&nbsp;Procurations
 {% endblock %}
 
@@ -25,40 +27,64 @@
     {% endif %}
 
     {% if event %}
-        <h5>{{ event.title }}</h5>
+        <h5>{{ event.title }} <small>{{ event.date | date('d F Y H:i') }}</small></h5>
     {% endif %}
 
-    <ul class="collapsible popout">
-        {% for proxy in proxies %}
-            <li>
-                <div class="collapsible-header">
-                    {% if not proxy.giver %}
-                        Pour le premier volontaire
-                    {% else %}
-                        De &nbsp;<b>{{ proxy.giver.memberNumberWithBeneficiaryListString }}</b>&nbsp;
-                    {% endif %}
-                    {% if not proxy.owner %}
-                        porté par le premier volontaire
-                    {% else %}
-                        porté par &nbsp;<b>{{ proxy.owner.membership.memberNumberWithBeneficiaryListString }}</b>&nbsp;
-                    {% endif %}
-                    {% if not event and proxy.event %}
-                        [{{ proxy.event.title }}]
-                    {% endif %}
-                </div>
-                {% if is_granted("ROLE_SUPER_ADMIN") %}
-                    <div class="collapsible-body">
-                        <a href="{{ path("proxy_edit",{'id':proxy.id}) }}" class="btn waves-effect waves-light">Editer</a>
-
-                        {{ form_start(delete_forms[proxy.id]) }}
-                        {{ form_widget(delete_forms[proxy.id]) }}
-                        <div>
-                            <button type="submit" class="btn waves-effect waves-light red">Supprimer</button>
-                        </div>
-                        {{ form_end(delete_forms[proxy.id]) }}
-                    </div>
+    <table class="responsive-table striped">
+        <thead>
+            <tr>
+                {% if not event %}
+                    <th>Evénement</th>
                 {% endif %}
-            </li>
-        {% endfor %}
-    </ul>
+                <th>De</th>
+                <th>Porté par</th>
+                <th>Date</th>
+                {% if is_granted("ROLE_SUPER_ADMIN") %}
+                    <th>Actions</th>
+                {% endif %}
+            </tr>
+        </thead>
+
+        <tbody>
+            {% for proxy in proxies %}
+                <tr>
+                    {% if not event %}
+                        <td>
+                            {% if proxy.event %}
+                                {{ proxy.event.title }}
+                            {% endif %}
+                        </td>
+                    {% endif %}
+                    <td>
+                        {% if not proxy.giver %}
+                            Pour le premier volontaire
+                        {% else %}
+                            {{ proxy.giver.memberNumberWithBeneficiaryListString }}
+                        {% endif %}
+                    </td>
+                    <td>
+                        {% if not proxy.owner %}
+                            porté par le premier volontaire
+                        {% else %}
+                            {{ proxy.owner.membership.memberNumberWithBeneficiaryListString }}
+                        {% endif %}
+                    </td>
+                    <td title="{{ proxy.createdAt | date('d F Y H:i') }}">
+                        {{ proxy.createdAt | date('d F Y') }}
+                    </td>
+                    {% if is_granted("ROLE_SUPER_ADMIN") %}
+                        <td>
+                            <a href="{{ path("proxy_edit",{'id':proxy.id}) }}"><i class="material-icons">edit</i>Editer</a>
+                            {{ form_start(delete_forms[proxy.id]) }}
+                            {{ form_widget(delete_forms[proxy.id]) }}
+                            <div>
+                                <button type="submit" class="btn btn-small waves-effect waves-light red">Supprimer</button>
+                            </div>
+                            {{ form_end(delete_forms[proxy.id]) }}
+                        </td>
+                    {% endif %}
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
 {% endblock %}

--- a/app/Resources/views/admin/event/proxy/list.html.twig
+++ b/app/Resources/views/admin/event/proxy/list.html.twig
@@ -13,9 +13,16 @@
 {% block content %}
     <h4>Liste des procurations en cours <small>({{ proxies | length }})</small></h4>
 
-    <p class="red-text">
-        Rappel : chaque membre peut porter au maximum <strong>{{ max_event_proxy_per_member }} procuration{% if max_event_proxy_per_member > 1 %}s{% endif %}</strong>
-    </p>
+    {% if max_event_proxy_per_member > 0 %}
+    <blockquote class="red-text">
+        chaque membre peut porter au maximum <strong>{{ max_event_proxy_per_member }} procuration{% if max_event_proxy_per_member > 1 %}s{% endif %}</strong>
+    </blockquote>
+    {% endif %}
+    {% if maximum_nb_of_beneficiaries_in_membership > 1 %}
+    <blockquote class="red-text">
+        si un membre a <strong>plusieurs</strong> bénéficiaires, c'est le bénéficiaire <strong>principal</strong> qui sera affiché à droite
+    </blockquote>
+    {% endif %}
 
     {% if event %}
         <h5>{{ event.title }}</h5>
@@ -33,9 +40,11 @@
                     {% if not proxy.owner %}
                         porté par le premier volontaire
                     {% else %}
-                        porté par &nbsp;<b>{{ proxy.owner }}</b>&nbsp;
+                        porté par &nbsp;<b>{{ proxy.owner.membership.mainBeneficiary }}</b>&nbsp;
                     {% endif %}
-                    {% if  not event and proxy.event  %}[{{ proxy.event.title }}]{% endif %}
+                    {% if not event and proxy.event %}
+                        [{{ proxy.event.title }}]
+                    {% endif %}
                 </div>
                 {% if is_granted("ROLE_SUPER_ADMIN") %}
                     <div class="collapsible-body">

--- a/app/Resources/views/admin/event/signatures.html.twig
+++ b/app/Resources/views/admin/event/signatures.html.twig
@@ -15,7 +15,7 @@
         {% if not beneficiary.isMain %}
             {# Not main benificiary, only one vote per memeber whatever the beneficiries number -----#}
             <td colspan="2" class="warning" style="background: gray; color: white;">
-                Bénéficiaire de <strong>{{ beneficiary.membership.mainBeneficiary.lastname }}&nbsp;{{ beneficiary.membership.mainBeneficiary.firstname }}</strong>
+                Bénéficiaire de <strong>{{ beneficiary.membership.mainBeneficiary.displayName }}</strong>
                 <br />
                 &#9888&nbsp;<strong>NE PAS SIGNER ICI</strong>&nbsp;&#9888
             </td>
@@ -29,15 +29,14 @@
             </td>
 
         {% elseif (event.proxiesByGiver(beneficiary.membership) | length > 0) %}
-            {# This memeber designated a proxy to vote and is not the proxy ------------------------- #}
+            {# This member designated a proxy to vote and is not the proxy ------------------------- #}
+            {# first? only 1 proxy per member #}
             <td colspan="2" class="warning" style="background: gray; color: white;">
                 Procuration donnée à
                 <br />
-                {% if event.proxiesByGiver(beneficiary.membership).first.owner.membership.mainBeneficiary  %}
+                {% if event.proxiesByGiver(beneficiary.membership).first.owner.membership.mainBeneficiary %}
                     <strong>
-                        {{ event.proxiesByGiver(beneficiary.membership).first.owner.membership.mainBeneficiary.lastname }}
-                        {{ event.proxiesByGiver(beneficiary.membership).first.owner.membership.mainBeneficiary.firstname }}
-                        #{{ event.proxiesByGiver(beneficiary.membership).first.owner.membership.memberNumber }}
+                        {{ event.proxiesByGiver(beneficiary.membership).first.owner.membership.memberNumberWithBeneficiaryListString }}
                     </strong>
                 {% else %}
                     Membre supprimé
@@ -58,10 +57,30 @@
      #########################################################################}
     {% macro table_line(beneficiary, event) %}
         <tr>
-            <td {% if beneficiary.lastname | length > 12 %}class="smaller"{% endif %}>{{ beneficiary.lastname }}</td>
-            <td {% if beneficiary.firstname | length > 12 %}class="smaller"{% endif %}>{{ beneficiary.firstname }}</td>
-            <td>#{{ beneficiary.membership.memberNumber }}</td>
-            <td class="date">{{ beneficiary.membership.lastRegistration.date | date('d-m-Y') }}</td>
+            <td {% if beneficiary.lastname | length > 12 %}class="smaller"{% endif %}>
+                {{ beneficiary.lastname }}
+                {% if (maximum_nb_of_beneficiaries_in_membership > 1) and beneficiary.isMain %}
+                    {% for other_beneficiary in beneficiary.membership.beneficiaries %}
+                        {% if other_beneficiary != beneficiary %}
+                            <br />
+                            <small>{{ other_beneficiary.lastname }}</small>
+                        {% endif %}
+                    {% endfor %}
+                {% endif %}
+            </td>
+            <td {% if beneficiary.firstname | length > 12 %}class="smaller"{% endif %}>
+                {{ beneficiary.firstname }}
+                {% if (maximum_nb_of_beneficiaries_in_membership > 1) and beneficiary.isMain %}
+                    {% for other_beneficiary in beneficiary.membership.beneficiaries %}
+                        {% if other_beneficiary != beneficiary %}
+                            <br />
+                            <small>{{ other_beneficiary.firstname }}</small>
+                        {% endif %}
+                    {% endfor %}
+                {% endif %}
+            </td>
+            <td class="center">#{{ beneficiary.membership.memberNumber }}</td>
+            <td class="center date">{{ beneficiary.membership.lastRegistration.date | date('d/m/Y') }}</td>
             {{ _self.sign_cells(beneficiary, event) }}
         </tr>
 
@@ -70,12 +89,31 @@
             {% for proxy in event.proxiesByOwnerMembershipMainBeneficiary(beneficiary) %}
                 <tr>
                     <td>
-                        <spam class="smaller">&#8618;&nbsp;A une procuration pour</spam>
-                        <br>{{ proxy.giver.mainBeneficiary.lastname }}
+                        <span class="smaller">&#8618;&nbsp;A une procuration pour</span>
+                        <br />
+                        {{ proxy.giver.mainBeneficiary.lastname }}
+                        {% if maximum_nb_of_beneficiaries_in_membership > 1 %}
+                            {% for other_beneficiary in proxy.giver.mainBeneficiary.membership.beneficiaries %}
+                                {% if other_beneficiary != proxy.giver.mainBeneficiary %}
+                                    <br />
+                                    <small>{{ other_beneficiary.lastname }}</small>
+                                {% endif %}
+                            {% endfor %}
+                        {% endif %}
                     </td>
-                    <td>{{ proxy.giver.mainBeneficiary.firstname }}</td>
-                    <td>#{{ proxy.giver.mainBeneficiary.memberNumber }}</td>
-                    <td>{{ proxy.giver.mainBeneficiary.membership.lastRegistration.date | date('d-m-Y') }}</td>
+                    <td>
+                        {{ proxy.giver.mainBeneficiary.firstname }}
+                        {% if maximum_nb_of_beneficiaries_in_membership > 1 %}
+                            {% for other_beneficiary in proxy.giver.mainBeneficiary.membership.beneficiaries %}
+                                {% if other_beneficiary != proxy.giver.mainBeneficiary %}
+                                    <br />
+                                    <small>{{ other_beneficiary.firstname }}</small>
+                                {% endif %}
+                            {% endfor %}
+                        {% endif %}
+                    </td>
+                    <td class="center">#{{ proxy.giver.mainBeneficiary.memberNumber }}</td>
+                    <td class="center">{{ proxy.giver.mainBeneficiary.membership.lastRegistration.date | date('d/m/Y') }}</td>
 
                 {% if (proxy.giver.mainBeneficiary.membership.getTimeCount(event.maxDateOfLastRegistration) <= time_after_which_members_are_late_with_shifts * 60) %}
                     {# this member is too late in his/her shifts cannot vote ---------------------------------- #}
@@ -102,8 +140,8 @@
             <tr>
                 <th>Nom</th>
                 <th>Prénom</th>
-                <th>#</th>
-                <th>Adhésion</th>
+                <th class="center">#</th>
+                <th class="center">Adhésion</th>
                 <th>Signature</th>
                 <th>Vote</th>
             </tr>
@@ -130,8 +168,9 @@
                 {% set number_of_voters = number_of_voters+1 %}
             {% endif %}
         {% endfor %}
-        <br>Nombre de votants : {{ number_of_voters }}
-        <br>Nombre de procurations : {{ number_of_proxy }}
+        Nombre de votants : {{ number_of_voters }}
+        <br />
+        Nombre de procurations : {{ number_of_proxy }}
     {% endmacro member_count %}
 
 {% endblock %}
@@ -225,10 +264,6 @@
             /*background: white;*/
         }
 
-        .subpage td:nth-child(3) {
-            text-align: center;
-        }
-
         .subpage tr:nth-child(even) {
             background: lightgray !important;
             -webkit-print-color-adjust: exact;
@@ -289,8 +324,9 @@
             <div class="subpage">
                 <div class="title" id="main_title">
                     Liste des votants pour l'événement "{{ event.title() }}"
-                    <span style="white-space: nowrap;">le {{ event.date | date('d-m-Y') }}</span>
-                    généré le <span style="white-space: nowrap;">{{ "now" | date('d-m-Y') }}</span>
+                    <span style="white-space: nowrap;">le {{ event.date | date('d F Y H:i') }}</span>
+                    <br />
+                    <small>généré le <span style="white-space: nowrap;">{{ "now" | date('d F Y H:i') }}</span></small>
                 </div>
                 <div class="center" id="member_count">
                     <p>{{ _self.member_count(beneficiaries, event) }}</p>

--- a/app/Resources/views/admin/event/signatures.html.twig
+++ b/app/Resources/views/admin/event/signatures.html.twig
@@ -16,8 +16,6 @@
             {# Not main benificiary, only one vote per memeber whatever the beneficiries number -----#}
             <td colspan="2" class="warning" style="background: gray; color: white;">
                 Bénéficiaire de <strong>{{ beneficiary.membership.mainBeneficiary.displayName }}</strong>
-                <br />
-                &#9888&nbsp;<strong>NE PAS SIGNER ICI</strong>&nbsp;&#9888
             </td>
 
         {% elseif (beneficiary.membership.getTimeCount(event.maxDateOfLastRegistration) <= time_after_which_members_are_late_with_shifts * 60) %}

--- a/app/Resources/views/admin/event/signatures.html.twig
+++ b/app/Resources/views/admin/event/signatures.html.twig
@@ -1,42 +1,39 @@
 {#########################################################################
- # Twig template for  /Controller/EventController.php/signaturesListAction()
+ # Twig template for /Controller/EventController.php/signaturesListAction()
  #
  # @param beneficiaries: beneficiary entity for this line
  # @param event: The event entity object signature sheet
  #########################################################################}
 
-
 {% block macro %}
     {#########################################################################
-     # Compute and output the 2 last cells of a table_line depending of the
-     # beneficiary status.
+     # Compute and output the 2 last cells of a table_line depending of the beneficiary status.
      # @param beneficiary: beneficiary entity for this line
      # @param event: The event entity object signature sheet
      #########################################################################}
     {% macro sign_cells(beneficiary, event) %}
 
-        {% if not beneficiary.isMain%}
+        {% if not beneficiary.isMain %}
             {# Not main benificiary, only one vote per memeber whatever the beneficiries number -----#}
             <td colspan="2" class="warning" style="background: gray; color: white;">
-                Bénéficiaire de <b>{{ beneficiary.membership.mainBeneficiary.lastname }}
-                    &nbsp;{{ beneficiary.membership.mainBeneficiary.firstname }}</b>
-                <br>
-                &#9888&nbsp;<b>NE PAS SIGNER ICI</b>&nbsp;&#9888
+                Bénéficiaire de <strong>{{ beneficiary.membership.mainBeneficiary.lastname }}&nbsp;{{ beneficiary.membership.mainBeneficiary.firstname }}</strong>
+                <br />
+                &#9888&nbsp;<strong>NE PAS SIGNER ICI</strong>&nbsp;&#9888
             </td>
 
-        {% elseif (beneficiary.membership.getTimeCount(event.maxDateOfLastRegistration)
-            <= time_after_which_members_are_late_with_shifts * 60) %}
+        {% elseif (beneficiary.membership.getTimeCount(event.maxDateOfLastRegistration) <= time_after_which_members_are_late_with_shifts * 60) %}
             {# this member is too late in his/her shifts cannot vote ---------------------------------- #}
             <td colspan="2" class="wrong" style="background: gray; color: white;">
-                Compteur de créneaux
-                à {{ beneficiary.membership.getTimeCount(event.maxDateOfLastRegistration) | duration_from_minutes }}
-                <br>&#9888&nbsp;<b>VOTE IMPOSSIBLE</b>&nbsp;&#9888
+                Compteur de créneaux à {{ beneficiary.membership.getTimeCount(event.maxDateOfLastRegistration) | duration_from_minutes }}
+                <br />
+                &#9888&nbsp;<strong>VOTE IMPOSSIBLE</strong>&nbsp;&#9888
             </td>
 
         {% elseif (event.proxiesByGiver(beneficiary.membership) | length > 0) %}
             {# This memeber designated a proxy to vote and is not the proxy ------------------------- #}
             <td colspan="2" class="warning" style="background: gray; color: white;">
-                Procuration donnée à <br>
+                Procuration donnée à
+                <br />
                 {% if event.proxiesByGiver(beneficiary.membership).first.owner %}
                     <strong>{{ event.proxiesByGiver(beneficiary.membership).first.owner.lastname }}&nbsp;{{ event.proxiesByGiver(beneficiary.membership).first.owner.firstname }}&nbsp;#{{ event.proxiesByGiver(beneficiary.membership).first.owner.membership.memberNumber }}</strong>
                 {% else %}
@@ -45,7 +42,7 @@
             </td>
 
         {% else %}
-            {# This beneficiry can vote ------------------------------------------------------------ #}
+            {# This beneficiary can vote ------------------------------------------------------------ #}
             <td></td>
             <td></td>
         {% endif %}
@@ -53,7 +50,7 @@
     {% endmacro sign_cells %}
 
     {#########################################################################
-     # Compute and output a line for a benyficiary
+     # Compute and output a line for a beneficiary
      # @param beneficiary: beneficiary entity for this line
      # @param event: The event entity object signature sheet
      #########################################################################}
@@ -67,26 +64,24 @@
         </tr>
 
         {# this beneficiary designated a proxy so generation of a additional line for this proxy to sign #}
-        {% if (((event.proxiesByOwner(beneficiary) | length) > 0)
-            and (event.proxiesByOwner(beneficiary).first.giver)) %}
-            {% set proxied_bneficiary = event.proxiesByOwner(beneficiary).first.giver.mainBeneficiary %}
+        {% if (((event.proxiesByOwner(beneficiary) | length) > 0) and (event.proxiesByOwner(beneficiary).first.giver)) %}
+            {% set proxied_beneficiary = event.proxiesByOwner(beneficiary).first.giver.mainBeneficiary %}
             <tr>
                 <td>
                     <spam class="smaller">&#8618;&nbsp;A une procuration pour</spam>
-                    <br>{{ proxied_bneficiary.lastname }}
+                    <br>{{ proxied_beneficiary.lastname }}
                 </td>
-                <td>{{ proxied_bneficiary.firstname }}</td>
-                <td>#{{ proxied_bneficiary.memberNumber }}</td>
-                <td>{{ proxied_bneficiary.membership.lastRegistration.date | date('d-m-Y') }}</td>
+                <td>{{ proxied_beneficiary.firstname }}</td>
+                <td>#{{ proxied_beneficiary.memberNumber }}</td>
+                <td>{{ proxied_beneficiary.membership.lastRegistration.date | date('d-m-Y') }}</td>
 
-            {% if (proxied_bneficiary.membership.getTimeCount(event.maxDateOfLastRegistration)
-                        <= time_after_which_members_are_late_with_shifts * 60) %}
+            {% if (proxied_beneficiary.membership.getTimeCount(event.maxDateOfLastRegistration) <= time_after_which_members_are_late_with_shifts * 60) %}
                 {# this member is too late in his/her shifts cannot vote ---------------------------------- #}
                 {# Todo: Maybe it should be put in the sign_cells macro #}
                 <td colspan="2" class="wrong" style="background: gray; color: white;">
-                    Compteur de créneaux de #{{ proxied_bneficiary.memberNumber }}
-                    à {{ proxied_bneficiary.membership.getTimeCount(event.maxDateOfLastRegistration) | duration_from_minutes }}
-                    <br>&#9888&nbsp;<b>VOTE IMPOSSIBLE</b>&nbsp;&#9888
+                    Compteur de créneaux de #{{ proxied_beneficiary.memberNumber }} à {{ proxied_beneficiary.membership.getTimeCount(event.maxDateOfLastRegistration) | duration_from_minutes }}
+                    <br />
+                    &#9888&nbsp;<strong>VOTE IMPOSSIBLE</strong>&nbsp;&#9888
                 </td>
             {% else %}
                 <td></td>
@@ -110,7 +105,6 @@
                 <th>Vote</th>
             </tr>
         </thead>
-
     {% endmacro table_header %}
 
     {#########################################################################
@@ -119,25 +113,22 @@
      # @param event: The event entity object signature sheet
      #########################################################################}
     {% macro member_count(beneficiaries, event) %}
-        {% set  number_of_voters = 0 %}
-        {% set  number_of_proxy = 0 %}
+        {% set number_of_voters = 0 %}
+        {% set number_of_proxy = 0 %}
 
         {% for beneficiary in beneficiaries %}
-            {% set  time_count_ok =  not (beneficiary.membership.getTimeCount(event.maxDateOfLastRegistration)
-                <= time_after_which_members_are_late_with_shifts * 60) %}
+            {% set time_count_ok = not (beneficiary.membership.getTimeCount(event.maxDateOfLastRegistration) <= time_after_which_members_are_late_with_shifts * 60) %}
 
-            {% if ((event.proxiesByGiver(beneficiary.membership) | length > 0) and beneficiary.isMain)  %}
-                {% set  number_of_proxy = number_of_proxy + 1 %}
+            {% if ((event.proxiesByGiver(beneficiary.membership) | length > 0) and beneficiary.isMain) %}
+                {% set number_of_proxy = number_of_proxy + 1 %}
             {% endif %}
 
             {% if beneficiary.isMain and time_count_ok %}
-                {% set  number_of_voters = number_of_voters+1 %}
+                {% set number_of_voters = number_of_voters+1 %}
             {% endif %}
-
         {% endfor %}
         <br>Nombre de votants : {{ number_of_voters }}
         <br>Nombre de procurations : {{ number_of_proxy }}
-
     {% endmacro member_count %}
 
 {% endblock %}
@@ -299,7 +290,7 @@
                     généré le <span style="white-space: nowrap;">{{ "now" | date('d-m-Y') }}</span>
                 </div>
                 <div class="center" id="member_count">
-                    <p>{{ _self.member_count(beneficiaries, event)  }}</p>
+                    <p>{{ _self.member_count(beneficiaries, event) }}</p>
                 </div>
                 <table>
                     {# keep track of the number of line generated to make page break #}

--- a/app/Resources/views/admin/event/signatures.html.twig
+++ b/app/Resources/views/admin/event/signatures.html.twig
@@ -67,29 +67,30 @@
 
         {# this beneficiary designated a proxy so generation of a additional line for this proxy to sign #}
         {% if ((event.proxiesByOwnerMembershipMainBeneficiary(beneficiary) | length) > 0) and (event.proxiesByOwnerMembershipMainBeneficiary(beneficiary).first.giver) %}
-            {% set proxied_beneficiary = event.proxiesByOwnerMembershipMainBeneficiary(beneficiary).first.giver.mainBeneficiary %}
-            <tr>
-                <td>
-                    <spam class="smaller">&#8618;&nbsp;A une procuration pour</spam>
-                    <br>{{ proxied_beneficiary.lastname }}
-                </td>
-                <td>{{ proxied_beneficiary.firstname }}</td>
-                <td>#{{ proxied_beneficiary.memberNumber }}</td>
-                <td>{{ proxied_beneficiary.membership.lastRegistration.date | date('d-m-Y') }}</td>
+            {% for proxy in event.proxiesByOwnerMembershipMainBeneficiary(beneficiary) %}
+                <tr>
+                    <td>
+                        <spam class="smaller">&#8618;&nbsp;A une procuration pour</spam>
+                        <br>{{ proxy.giver.mainBeneficiary.lastname }}
+                    </td>
+                    <td>{{ proxy.giver.mainBeneficiary.firstname }}</td>
+                    <td>#{{ proxy.giver.mainBeneficiary.memberNumber }}</td>
+                    <td>{{ proxy.giver.mainBeneficiary.membership.lastRegistration.date | date('d-m-Y') }}</td>
 
-            {% if (proxied_beneficiary.membership.getTimeCount(event.maxDateOfLastRegistration) <= time_after_which_members_are_late_with_shifts * 60) %}
-                {# this member is too late in his/her shifts cannot vote ---------------------------------- #}
-                {# Todo: Maybe it should be put in the sign_cells macro #}
-                <td colspan="2" class="wrong" style="background: gray; color: white;">
-                    Compteur de créneaux de #{{ proxied_beneficiary.memberNumber }} à {{ proxied_beneficiary.membership.getTimeCount(event.maxDateOfLastRegistration) | duration_from_minutes }}
-                    <br />
-                    &#9888&nbsp;<strong>VOTE IMPOSSIBLE</strong>&nbsp;&#9888
-                </td>
-            {% else %}
-                <td></td>
-                <td></td>
-            {% endif %}
-            </tr>
+                {% if (proxy.giver.mainBeneficiary.membership.getTimeCount(event.maxDateOfLastRegistration) <= time_after_which_members_are_late_with_shifts * 60) %}
+                    {# this member is too late in his/her shifts cannot vote ---------------------------------- #}
+                    {# Todo: Maybe it should be put in the sign_cells macro #}
+                    <td colspan="2" class="wrong" style="background: gray; color: white;">
+                        Compteur de créneaux de #{{ proxy.giver.mainBeneficiary.memberNumber }} à {{ proxy.giver.mainBeneficiary.membership.getTimeCount(event.maxDateOfLastRegistration) | duration_from_minutes }}
+                        <br />
+                        &#9888&nbsp;<strong>VOTE IMPOSSIBLE</strong>&nbsp;&#9888
+                    </td>
+                {% else %}
+                    <td></td>
+                    <td></td>
+                {% endif %}
+                </tr>
+            {% endfor %}
         {% endif %}
     {% endmacro table_line %}
 

--- a/app/Resources/views/admin/event/signatures.html.twig
+++ b/app/Resources/views/admin/event/signatures.html.twig
@@ -38,9 +38,7 @@
             <td colspan="2" class="warning" style="background: gray; color: white;">
                 Procuration donnée à <br>
                 {% if event.proxiesByGiver(beneficiary.membership).first.owner %}
-                    {{ event.proxiesByGiver(beneficiary.membership).first.owner.lastname }}&nbsp;
-                    {{ event.proxiesByGiver(beneficiary.membership).first.owner.firstname }}&nbsp;
-                    {{ event.proxiesByGiver(beneficiary.membership).first.owner.membership.memberNumber }}
+                    <strong>{{ event.proxiesByGiver(beneficiary.membership).first.owner.lastname }}&nbsp;{{ event.proxiesByGiver(beneficiary.membership).first.owner.firstname }}&nbsp;#{{ event.proxiesByGiver(beneficiary.membership).first.owner.membership.memberNumber }}</strong>
                 {% else %}
                     Membre supprimé
                 {% endif %}

--- a/app/Resources/views/admin/event/signatures.html.twig
+++ b/app/Resources/views/admin/event/signatures.html.twig
@@ -7,12 +7,11 @@
 
 {% block macro %}
     {#########################################################################
-     # Compute and output the 2 last cells of a table_line depending of the beneficiary status.
+     # Compute and output the 2 last cells of a table_line depending on the beneficiary status.
      # @param beneficiary: beneficiary entity for this line
      # @param event: The event entity object signature sheet
      #########################################################################}
     {% macro sign_cells(beneficiary, event) %}
-
         {% if not beneficiary.isMain %}
             {# Not main benificiary, only one vote per memeber whatever the beneficiries number -----#}
             <td colspan="2" class="warning" style="background: gray; color: white;">
@@ -34,8 +33,12 @@
             <td colspan="2" class="warning" style="background: gray; color: white;">
                 Procuration donnée à
                 <br />
-                {% if event.proxiesByGiver(beneficiary.membership).first.owner %}
-                    <strong>{{ event.proxiesByGiver(beneficiary.membership).first.owner.lastname }}&nbsp;{{ event.proxiesByGiver(beneficiary.membership).first.owner.firstname }}&nbsp;#{{ event.proxiesByGiver(beneficiary.membership).first.owner.membership.memberNumber }}</strong>
+                {% if event.proxiesByGiver(beneficiary.membership).first.owner.membership.mainBeneficiary  %}
+                    <strong>
+                        {{ event.proxiesByGiver(beneficiary.membership).first.owner.membership.mainBeneficiary.lastname }}
+                        {{ event.proxiesByGiver(beneficiary.membership).first.owner.membership.mainBeneficiary.firstname }}
+                        #{{ event.proxiesByGiver(beneficiary.membership).first.owner.membership.memberNumber }}
+                    </strong>
                 {% else %}
                     Membre supprimé
                 {% endif %}
@@ -46,11 +49,10 @@
             <td></td>
             <td></td>
         {% endif %}
-
     {% endmacro sign_cells %}
 
     {#########################################################################
-     # Compute and output a line for a beneficiary
+     # Compute and output a line for each beneficiary
      # @param beneficiary: beneficiary entity for this line
      # @param event: The event entity object signature sheet
      #########################################################################}
@@ -64,8 +66,8 @@
         </tr>
 
         {# this beneficiary designated a proxy so generation of a additional line for this proxy to sign #}
-        {% if (((event.proxiesByOwner(beneficiary) | length) > 0) and (event.proxiesByOwner(beneficiary).first.giver)) %}
-            {% set proxied_beneficiary = event.proxiesByOwner(beneficiary).first.giver.mainBeneficiary %}
+        {% if ((event.proxiesByOwnerMembershipMainBeneficiary(beneficiary) | length) > 0) and (event.proxiesByOwnerMembershipMainBeneficiary(beneficiary).first.giver) %}
+            {% set proxied_beneficiary = event.proxiesByOwnerMembershipMainBeneficiary(beneficiary).first.giver.mainBeneficiary %}
             <tr>
                 <td>
                     <spam class="smaller">&#8618;&nbsp;A une procuration pour</spam>
@@ -119,7 +121,7 @@
         {% for beneficiary in beneficiaries %}
             {% set time_count_ok = not (beneficiary.membership.getTimeCount(event.maxDateOfLastRegistration) <= time_after_which_members_are_late_with_shifts * 60) %}
 
-            {% if ((event.proxiesByGiver(beneficiary.membership) | length > 0) and beneficiary.isMain) %}
+            {% if (event.proxiesByGiver(beneficiary.membership) | length > 0) and beneficiary.isMain %}
                 {% set number_of_proxy = number_of_proxy + 1 %}
             {% endif %}
 
@@ -313,8 +315,7 @@
                         {# generate a benificiary line -------------------- #}
                         {{ _self.table_line(beneficiary, event) }}
                         {# if proxy, a line is added, so index++ ----------- #}
-                        {% if ((event.proxiesByOwner(beneficiary) | length) > 0)
-                            and (event.proxiesByOwner(beneficiary).first.giver) %}
+                        {% if ((event.proxiesByOwnerMembershipMainBeneficiary(beneficiary) | length) > 0) and (event.proxiesByOwnerMembershipMainBeneficiary(beneficiary).first.giver) %}
                             {% set index = index + 1 %}
                         {% endif %}
                         {% set index = index + 1 %}

--- a/app/Resources/views/beneficiary/find_member_number.html.twig
+++ b/app/Resources/views/beneficiary/find_member_number.html.twig
@@ -28,25 +28,29 @@
                 {{ form_end(form) }}
             {% endif %}
             {% if beneficiaries %}
-            <div class="collection">
-                {% for beneficiary in beneficiaries %}
-                    <form action="{{ path(return_path, { (routeParam): beneficiary.id } | merge(params)) }}" method="post" class="collection-item">
-                        <a href="#" onclick="$(this).closest('form').submit()" >{{ beneficiary.publicDisplayNameWithMemberNumber }}{% if beneficiary.membership.lastRegistration %} - {{ beneficiary.membership.lastRegistration.date | date('d F Y') }}{% endif %}</a>
-                    </form>
-                {% endfor %}
-            </div>
-            {% elseif not form %}
-                <div class="row center">
-                    <p class=" col s12 light">Oups, aucun résultats pour ce prénom !<br>
-                        <a href="{{ path('find_member_number') }}" class="btn">Essayer un autre ?</a>
-                    </p>
+                <div class="collection">
+                    {% for beneficiary in beneficiaries %}
+                        <form action="{{ path(return_path, { (routeParam): beneficiary.id } | merge(params)) }}" method="POST" class="collection-item">
+                            <a href="#" onclick="$(this).closest('form').submit()" >{{ beneficiary.publicDisplayNameWithMemberNumber }}{% if beneficiary.membership.lastRegistration %} - {{ beneficiary.membership.lastRegistration.date | date('d F Y') }}{% endif %}</a>
+                        </form>
+                    {% endfor %}
                 </div>
+            {% elseif not form %}
+                <p class=" col s12 light">Oups, aucun résultats pour ce prénom !</p>
+                <br />
+                {% if 'proxy' in return_path %}
+                    <a href="{{ path(return_path, params) }}" class="btn waves-effect waves-light">
+                        <i class="material-icons left">keyboard_return</i>Retourner à la recherche
+                    </a>
+                {% else %}
+                    <a href="{{ path('find_member_number') }}" class="btn">Essayer un autre ?</a>
+                {% endif %}
             {% endif %}
             {% if not is_granted("IS_AUTHENTICATED_REMEMBERED") %}
             <div class="row center">
                 <p class=" col s12 light">Déjà un compte ? <a href="{{ path('fos_user_security_login') }}">identifiez-vous</a></p>
             </div>
-            {% endif %}
+        {% endif %}
         </div>
     </div>
 {% endblock %}

--- a/app/Resources/views/default/event/_event.html.twig
+++ b/app/Resources/views/default/event/_event.html.twig
@@ -21,14 +21,14 @@
                         {% if proxy_given.owner is null %}
                             <span>Procuration donnée au premier membre volontaire</span>
                         {% else %}
-                            <span>Procuration donnée à &nbsp;<b>{{ proxy_given.owner }}</b></span>
+                            <span>Procuration donnée à &nbsp;<b>{{ proxy_given.owner.membership.mainBeneficiary }}</b></span>
                         {% endif %}
                     {% endif %}
                     {% for proxy_received_item in proxy_received %}
                         {% if proxy_received_item.giver %}
-                            <div>Procuration portée par <b>{{ proxy_received_item.owner.user.firstname }}</b> de la part de&nbsp;<b>{{ proxy_received_item.giver.mainBeneficiary }}</b></div>
+                            <div>Procuration portée par <b>{{ proxy_received_item.owner.membership.mainBeneficiary }}</b> de la part de&nbsp;<b>{{ proxy_received_item.giver.mainBeneficiary }}</b></div>
                         {% else %}
-                            <div><b>{{ proxy_received_item.owner.user.firstname }}</b> accepte une procuration. <a href="{{ path("event_proxy_lite_remove",{'event':event.id,'proxy':proxy_received_item.id}) }}" class="red-text">X</a></div>
+                            <div><b>{{ proxy_received_item.owner.membership.mainBeneficiary }}</b> accepte une procuration. <a href="{{ path("event_proxy_lite_remove",{'event':event.id,'proxy':proxy_received_item.id}) }}" class="red-text">X</a></div>
                         {% endif %}
                     {% endfor %}
                     {% if (proxy_given is null) and (proxy_received|length == 0) %}
@@ -84,14 +84,14 @@
                                 {% if proxy_given.owner is null %}
                                     <li>Procuration donnée au premier volontaire</li>
                                 {% else %}
-                                    <li>Procuration donnée à &nbsp;<b>{{ proxy_given.owner }}</b></li>
+                                    <li>Procuration donnée à &nbsp;<b>{{ proxy_given.owner.membership.mainBeneficiary }}</b></li>
                                 {% endif %}
                             {% endif %}
                             {% for proxy_received_item in proxy_received %}
                                 {% if proxy_received_item.giver %}
-                                    <li>Procuration portée par <b>{{ proxy_received_item.owner.user.firstname }}</b> de la part de&nbsp;<b>{{ proxy_received_item.giver.mainBeneficiary }}</b></li>
+                                    <li>Procuration portée par <b>{{ proxy_received_item.owner.membership.mainBeneficiary }}</b> de la part de&nbsp;<b>{{ proxy_received_item.giver.mainBeneficiary }}</b></li>
                                 {% else %}
-                                    <li><b>{{ proxy_received_item.owner.user.firstname }}</b> accepte une procuration. <a href="{{ path("event_proxy_lite_remove",{'event':event.id,'proxy':proxy_received_item.id}) }}" class="red-text">X</a></li>
+                                    <li><b>{{ proxy_received_item.owner.membership.mainBeneficiary }}</b> accepte une procuration. <a href="{{ path("event_proxy_lite_remove",{'event':event.id,'proxy':proxy_received_item.id}) }}" class="red-text">X</a></li>
                                 {% endif %}
                             {% endfor %}
                         </ul>

--- a/app/Resources/views/default/event/_event.html.twig
+++ b/app/Resources/views/default/event/_event.html.twig
@@ -21,14 +21,14 @@
                         {% if proxy_given.owner is null %}
                             <span>Procuration donnée au premier membre volontaire</span>
                         {% else %}
-                            <span>Procuration donnée à &nbsp;<b>{{ proxy_given.owner.membership.mainBeneficiary }}</b></span>
+                            <span>Procuration donnée à &nbsp;<b>{{ proxy_given.owner.membership.memberNumberWithBeneficiaryListString }}</b></span>
                         {% endif %}
                     {% endif %}
                     {% for proxy_received_item in proxy_received %}
                         {% if proxy_received_item.giver %}
-                            <div>Procuration portée par <b>{{ proxy_received_item.owner.membership.mainBeneficiary }}</b> de la part de&nbsp;<b>{{ proxy_received_item.giver.mainBeneficiary }}</b></div>
+                            <div>Procuration portée par <b>{{ proxy_received_item.owner.membership.memberNumberWithBeneficiaryListString }}</b> de la part de&nbsp;<b>{{ proxy_received_item.giver.memberNumberWithBeneficiaryListString }}</b></div>
                         {% else %}
-                            <div><b>{{ proxy_received_item.owner.membership.mainBeneficiary }}</b> accepte une procuration. <a href="{{ path("event_proxy_lite_remove",{'event':event.id,'proxy':proxy_received_item.id}) }}" class="red-text">X</a></div>
+                            <div><b>{{ proxy_received_item.owner.membership.memberNumberWithBeneficiaryListString }}</b> accepte une procuration. <a href="{{ path("event_proxy_lite_remove",{'event':event.id,'proxy':proxy_received_item.id}) }}" class="red-text">X</a></div>
                         {% endif %}
                     {% endfor %}
                     {% if (proxy_given is null) and (proxy_received|length == 0) %}
@@ -84,14 +84,14 @@
                                 {% if proxy_given.owner is null %}
                                     <li>Procuration donnée au premier volontaire</li>
                                 {% else %}
-                                    <li>Procuration donnée à &nbsp;<b>{{ proxy_given.owner.membership.mainBeneficiary }}</b></li>
+                                    <li>Procuration donnée à &nbsp;<b>{{ proxy_given.owner.membership.memberNumberWithBeneficiaryListString }}</b></li>
                                 {% endif %}
                             {% endif %}
                             {% for proxy_received_item in proxy_received %}
                                 {% if proxy_received_item.giver %}
-                                    <li>Procuration portée par <b>{{ proxy_received_item.owner.membership.mainBeneficiary }}</b> de la part de&nbsp;<b>{{ proxy_received_item.giver.mainBeneficiary }}</b></li>
+                                    <li>Procuration portée par <b>{{ proxy_received_item.owner.membership.memberNumberWithBeneficiaryListString }}</b> de la part de&nbsp;<b>{{ proxy_received_item.giver.memberNumberWithBeneficiaryListString }}</b></li>
                                 {% else %}
-                                    <li><b>{{ proxy_received_item.owner.membership.mainBeneficiary }}</b> accepte une procuration. <a href="{{ path("event_proxy_lite_remove",{'event':event.id,'proxy':proxy_received_item.id}) }}" class="red-text">X</a></li>
+                                    <li><b>{{ proxy_received_item.owner.membership.memberNumberWithBeneficiaryListString }}</b> accepte une procuration. <a href="{{ path("event_proxy_lite_remove",{'event':event.id,'proxy':proxy_received_item.id}) }}" class="red-text">X</a></li>
                                 {% endif %}
                             {% endfor %}
                         </ul>

--- a/src/AppBundle/Controller/EventController.php
+++ b/src/AppBundle/Controller/EventController.php
@@ -420,9 +420,13 @@ class EventController extends Controller
                     $em->persist($proxy);
                     $em->flush();
                     $session = new Session();
-                    $session->getFlashBag()->add('success', 'Procuration donnée à '. $proxy->getOwner() .' !');
+                    if ($proxy->getOwner() == $proxy->getOwner()->getMembership()->getMainBeneficiary()) {
+                        $session->getFlashBag()->add('success', 'Procuration donnée à '. $proxy->getOwner() .' !');
+                    } else {
+                        $session->getFlashBag()->add('success', 'Procuration donnée à '. $proxy->getOwner() .' (bénéficiaire de '. $proxy->getOwner()->getMembership()->getMainBeneficiary() .') !');
+                    }
 
-                    if ($proxy->getGiver() && $proxy->getOwner()){
+                    if ($proxy->getGiver() && $proxy->getOwner()) {
                         $this->sendProxyMail($proxy,$mailer);
                     }
 

--- a/src/AppBundle/Controller/EventController.php
+++ b/src/AppBundle/Controller/EventController.php
@@ -388,7 +388,7 @@ class EventController extends Controller
                     array("giver" => $beneficiary->getMembership(), "event" => $event)
                 );
                 if (count($member_giver_proxies) > 0) {
-                    $session->getFlashBag()->add('error', $beneficiary->getUser()->getFirstName() . ' a déjà donné sa procuration');
+                    $session->getFlashBag()->add('error', $beneficiary->getPublicDisplayName() . ' a déjà donné sa procuration');
                     return $this->redirectToRoute('homepage');
                 }
 
@@ -401,7 +401,7 @@ class EventController extends Controller
                     array("owner" => $beneficiaries_ids, "event" => $event)
                 );
                 if (count($member_owner_proxies) >= $max_event_proxy_per_member) {
-                    $session->getFlashBag()->add('error', $beneficiary->getUser()->getFirstName() . ' accepte déjà de prendre le nombre maximal de procurations ('. $max_event_proxy_per_member .')');
+                    $session->getFlashBag()->add('error', $beneficiary->getPublicDisplayName() . ' accepte déjà de prendre le nombre maximal de procurations ('. $max_event_proxy_per_member .')');
                     return $this->redirectToRoute('homepage');
                 }
 
@@ -420,14 +420,10 @@ class EventController extends Controller
                     $em->persist($proxy);
                     $em->flush();
                     $session = new Session();
-                    if ($proxy->getOwner() == $proxy->getOwner()->getMembership()->getMainBeneficiary()) {
-                        $session->getFlashBag()->add('success', 'Procuration donnée à '. $proxy->getOwner() .' !');
-                    } else {
-                        $session->getFlashBag()->add('success', 'Procuration donnée à '. $proxy->getOwner() .' (bénéficiaire de '. $proxy->getOwner()->getMembership()->getMainBeneficiary() .') !');
-                    }
+                    $session->getFlashBag()->add('success', 'Procuration donnée à '. $proxy->getOwner()->getMembership()->getMemberNumberWithBeneficiaryListString() .' !');
 
                     if ($proxy->getGiver() && $proxy->getOwner()) {
-                        $this->sendProxyMail($proxy,$mailer);
+                        $this->sendProxyMail($proxy, $mailer);
                     }
 
                     return $this->redirectToRoute('homepage');

--- a/src/AppBundle/Controller/EventController.php
+++ b/src/AppBundle/Controller/EventController.php
@@ -43,7 +43,7 @@ class EventController extends Controller
      * Lists all proxy
      *
      * @Route("/proxies_list", name="proxies_list", methods={"GET"})
-     * @Security("has_role('ROLE_ADMIN')")
+     * @Security("has_role('ROLE_PROCESS_MANAGER')")
      */
     public function listProxiesAction()
     {
@@ -65,7 +65,7 @@ class EventController extends Controller
      * Lists all proxy for one event.
      *
      * @Route("/{id}/proxies_list", name="event_proxies_list", methods={"GET"})
-     * @Security("has_role('ROLE_ADMIN')")
+     * @Security("has_role('ROLE_PROCESS_MANAGER')")
      */
     public function listEventProxiesAction(Event $event, Request $request)
     {

--- a/src/AppBundle/Controller/EventController.php
+++ b/src/AppBundle/Controller/EventController.php
@@ -388,7 +388,7 @@ class EventController extends Controller
                     array("giver" => $beneficiary->getMembership(), "event" => $event)
                 );
                 if (count($member_giver_proxies) > 0) {
-                    $session->getFlashBag()->add('error', $beneficiary->getPublicDisplayName() . ' a déjà donné sa procuration');
+                    $session->getFlashBag()->add('error', $beneficiary->getPublicDisplayNameWithMemberNumber() . ' a déjà donné sa procuration');
                     return $this->redirectToRoute('homepage');
                 }
 
@@ -401,7 +401,7 @@ class EventController extends Controller
                     array("owner" => $beneficiaries_ids, "event" => $event)
                 );
                 if (count($member_owner_proxies) >= $max_event_proxy_per_member) {
-                    $session->getFlashBag()->add('error', $beneficiary->getPublicDisplayName() . ' accepte déjà de prendre le nombre maximal de procurations ('. $max_event_proxy_per_member .')');
+                    $session->getFlashBag()->add('error', $beneficiary->getPublicDisplayNameWithMemberNumber() . ' accepte déjà de prendre le nombre maximal de procurations ('. $max_event_proxy_per_member .')');
                     return $this->redirectToRoute('homepage');
                 }
 

--- a/src/AppBundle/Entity/Beneficiary.php
+++ b/src/AppBundle/Entity/Beneficiary.php
@@ -160,21 +160,6 @@ class Beneficiary
     }
 
     /**
-     * Constructor
-     */
-    public function __construct()
-    {
-        $this->commissions = new ArrayCollection();
-        $this->formations = new ArrayCollection();
-        $this->shifts = new ArrayCollection();
-    }
-
-    public function __toString()
-    {
-        return $this->getDisplayName();
-    }
-
-    /**
      * Get id
      *
      * @return int
@@ -242,16 +227,6 @@ class Beneficiary
         return strtoupper($this->lastname);
     }
 
-    /**
-     * Get public full name
-     *
-     * @return string
-     */
-    public function getPublicFullName()
-    {
-        return $this->getFirstname() . ' ' . $this->getLastname()[0];
-    }
-
     public function getDisplayName(): string
     {
         return $this->getFirstname() . ' ' . $this->getLastname();
@@ -267,7 +242,7 @@ class Beneficiary
      */
     public function getDisplayNameWithMemberNumber(): string
     {
-        return '#' . $this->getMemberNumber() . ' ' . $this->getFullName();
+        return '#' . $this->getMemberNumber() . ' ' . $this->getDisplayName();
     }
 
     public function getDisplayNameWithMemberNumberAndStatusIcon(): string
@@ -286,16 +261,6 @@ class Beneficiary
     public function getPublicDisplayNameWithMemberNumber(): string
     {
         return '#' . $this->getMemberNumber() . ' ' . $this->getPublicDisplayName();
-    }
-
-    /**
-     * Get firstname
-     *
-     * @return string
-     */
-    public function getFirstname()
-    {
-        return ucfirst(strtolower($this->firstname));
     }
 
     /**

--- a/src/AppBundle/Entity/Beneficiary.php
+++ b/src/AppBundle/Entity/Beneficiary.php
@@ -160,6 +160,21 @@ class Beneficiary
     }
 
     /**
+     * Constructor
+     */
+    public function __construct()
+    {
+        $this->commissions = new ArrayCollection();
+        $this->formations = new ArrayCollection();
+        $this->shifts = new ArrayCollection();
+    }
+
+    public function __toString()
+    {
+        return $this->getDisplayName();
+    }
+
+    /**
      * Get id
      *
      * @return int
@@ -177,6 +192,30 @@ class Beneficiary
     public function getMemberNumber()
     {
         return $this->getMembership()->getMemberNumber();
+    }
+
+    /**
+     * Get firstname
+     *
+     * @return string
+     */
+    public function getFirstname()
+    {
+        return ucfirst(strtolower($this->firstname));
+    }
+
+    /**
+     * Set firstname
+     *
+     * @param string $firstname
+     *
+     * @return Beneficiary
+     */
+    public function setFirstname($firstname)
+    {
+        $this->firstname = $firstname;
+
+        return $this;
     }
 
     /**
@@ -204,17 +243,13 @@ class Beneficiary
     }
 
     /**
-     * Set firstname
+     * Get public full name
      *
-     * @param string $firstname
-     *
-     * @return Beneficiary
+     * @return string
      */
-    public function setFirstname($firstname)
+    public function getPublicFullName()
     {
-        $this->firstname = $firstname;
-
-        return $this;
+        return $this->getFirstname() . ' ' . $this->getLastname()[0];
     }
 
     public function getDisplayName(): string
@@ -232,7 +267,7 @@ class Beneficiary
      */
     public function getDisplayNameWithMemberNumber(): string
     {
-        return '#' . $this->getMemberNumber() . ' ' . $this->getFirstname() . ' ' . $this->getLastname();
+        return '#' . $this->getMemberNumber() . ' ' . $this->getFullName();
     }
 
     public function getDisplayNameWithMemberNumberAndStatusIcon(): string

--- a/src/AppBundle/Entity/Event.php
+++ b/src/AppBundle/Entity/Event.php
@@ -268,6 +268,13 @@ class Event
         });
     }
 
+    public function getProxiesByOwnerMembershipMainBeneficiary(Beneficiary $beneficiary)
+    {
+        return $this->proxies->filter(function (Proxy $proxy) use ($beneficiary) {
+            return ($proxy->getOwner()->getMembership()->getMainBeneficiary() === $beneficiary);
+        });
+    }
+
     public function getProxiesByGiver(Membership $membership)
     {
         return $this->proxies->filter(function (Proxy $proxy) use ($membership) {

--- a/src/AppBundle/Entity/Membership.php
+++ b/src/AppBundle/Entity/Membership.php
@@ -282,10 +282,10 @@ class Membership
     {
         $memberNumberWithBeneficiaryListString = '#' . $this->getMemberNumber();
         foreach ($this->getBeneficiariesWithMainInFirstPosition() as $key => $beneficiary) {
-            $memberNumberWithBeneficiaryListString .= ' '. $beneficiary->getFullName();
             if ($key > 0) {
                 $memberNumberWithBeneficiaryListString .= ' &';
             }
+            $memberNumberWithBeneficiaryListString .= ' '. $beneficiary->getDisplayName();
         }
         return $memberNumberWithBeneficiaryListString;
     }

--- a/src/AppBundle/Entity/Membership.php
+++ b/src/AppBundle/Entity/Membership.php
@@ -274,6 +274,23 @@ class Membership
     }
 
     /**
+     * Get member_number & list of beneficiaries
+     *
+     * @return string
+     */
+    public function getMemberNumberWithBeneficiaryListString()
+    {
+        $memberNumberWithBeneficiaryListString = '#' . $this->getMemberNumber();
+        foreach ($this->getBeneficiariesWithMainInFirstPosition() as $key => $beneficiary) {
+            $memberNumberWithBeneficiaryListString .= ' '. $beneficiary->getFullName();
+            if ($key > 0) {
+                $memberNumberWithBeneficiaryListString .= ' &';
+            }
+        }
+        return $memberNumberWithBeneficiaryListString;
+    }
+
+    /**
      * Set mainBeneficiary
      *
      * @param \AppBundle\Entity\Beneficiary $mainBeneficiary


### PR DESCRIPTION
Suite de https://github.com/elefan-grenoble/gestion-compte/pull/567

### Quoi ?

- améliorer l'affichage des procurations : afficher le nom complet du membre `#member_number <beneficiaire_principal> <beneficiaire_secondaire>`
- liste des procurations : affichage en tableau, améliorer le message "en rouge" affiché en haut
- export des signatures : rattacher les procurations au mainBeneficiary
- export des signatures : gérer les multi-procurations (en cours)

### Captures d'écran

Dans le cas où `max_event_proxy_per_member=2` & `maximum_nb_of_beneficiaries_in_membership=2`

Données de test : 
- Compte adhérent # 0001 : Raphael & Bob (procuration donnée à # 0003)
- Compte adhérent # 0002 : Elise (procuration donnée à # 0003)
- Compte adhérent # 0003 : Mathilde & Sylvain

|Page|Avant|Après|
|---|---|---|
|Profil de Raphael (# 0001)|![Screenshot from 2022-11-04 14-41-54](https://user-images.githubusercontent.com/7147385/199986861-3a55cae4-7971-4858-8292-37b51bd949d2.png)|![Screenshot from 2022-11-04 14-41-27](https://user-images.githubusercontent.com/7147385/199986841-9700c58f-43fb-4225-9b25-9f8e0ec3d653.png)|
|Profil de Sylvain (# 0003)|![Screenshot from 2022-11-04 14-11-54](https://user-images.githubusercontent.com/7147385/199986345-390b7230-c195-45a1-bc3d-80bc11116ace.png) pas de gestion des multi-procurations|![Screenshot from 2022-11-04 14-39-48](https://user-images.githubusercontent.com/7147385/199986353-c80a96b1-57b3-4a0d-ac76-4e135cff233b.png)|
|Liste des procurations|![Screenshot from 2022-11-04 14-34-32](https://user-images.githubusercontent.com/7147385/199985694-66420f7c-910f-4fa8-a3d7-765a90207e7f.png)|![Screenshot from 2022-11-04 14-35-59](https://user-images.githubusercontent.com/7147385/199985715-8cd8d700-2926-462d-bccf-3e94d038f89f.png)|

Nouvelle iste d'émargement

![Screenshot from 2022-11-04 15-33-36](https://user-images.githubusercontent.com/7147385/200002076-b5dc4a5b-abad-48ab-a4fd-2decde1043a5.png)
![Screenshot from 2022-11-04 15-34-35](https://user-images.githubusercontent.com/7147385/200002088-ab9ef2a6-2e36-4045-b9be-df70a554ab5b.png)
![Screenshot from 2022-11-04 15-35-24](https://user-images.githubusercontent.com/7147385/200002093-e1894442-97a2-4b6b-9496-55a1282fd6c4.png)
![Screenshot from 2022-11-04 15-38-25](https://user-images.githubusercontent.com/7147385/200002380-fc645603-77c3-47e2-987b-271b90bc73b2.png)
