### PR TITLE
Envoi d'e-mail : pouvoir mettre l'expéditeur en copie

### DIFF
--- a/app/Resources/views/admin/mail/edit.html.twig
+++ b/app/Resources/views/admin/mail/edit.html.twig
@@ -22,6 +22,15 @@
             <div class="non-members chips ">
             </div>
         </div>
+        <div class="col s12">
+            <label>
+                {{ form_widget(form.from_in_cc) }}
+                <span>{{ form.from_in_cc.vars.label }}</span>
+            </label>
+        </div>
+    </div>
+
+    <div class="row">
         <div class="input-field col s12">
             {{ form_widget(form.subject) }}
             {{ form_label(form.subject) }}


### PR DESCRIPTION
### Quoi ?

Nouveau champ dans le formulaire d'envoi d'e-mail : "mettre l'expéditeur en copie"

### Pourquoi ?

On veut parfois garder une trace des envois faits aux membres

### Capture d'écran

![Screenshot from 2022-11-02 21-01-09](https://user-images.githubusercontent.com/7147385/199591533-c48d3e18-02e5-4012-8ccf-502ece18e79f.png)
