### PR TITLE
Ajustements sur l'affichage des états d'un membre

### DIFF
--- a/app/Resources/views/admin/user/list.html.twig
+++ b/app/Resources/views/admin/user/list.html.twig
@@ -24,7 +24,7 @@
                         <h5>Compte</h5>
                         <div class="row">
                             <div class="col s4">
-                                fermé :
+                                ∅ fermé :
                                 {{ form_widget(form.withdrawn) }}
                                 {{ form_label(form.withdrawn) }}
                             </div>
@@ -34,7 +34,7 @@
                                 {{ form_label(form.enabled) }}
                             </div>
                             <div class="col s4">
-                                gelé :
+                                ❄️ gelé :
                                 {{ form_widget(form.frozen) }}
                                 {{ form_label(form.frozen) }}
                             </div>
@@ -217,15 +217,15 @@
             {% if member.mainBeneficiary %}
                 <tr class="{% if member.withdrawn %}withdrawn{% endif %} {% if member.frozen %}frozen{% endif %}" data-url="{{ path('member_show', { 'member_number': member.memberNumber }) }}" >
                     <td class="hide-on-med-and-down">
-                        {% if not member.withdrawn %}
+                        {% if member.withdrawn %}
+                            <i class="material-icons">block</i>
+                        {% else %}
                             {% if not member.mainBeneficiary.user.isEnabled %}
                                 <i class="material-icons">phonelink_off</i>
                             {% endif %}
                             {% if member.frozen %}
                                 <i class="material-icons">ac_unit</i>
                             {% endif %}
-                        {% else %}
-                                <i class="material-icons">do_not_disturb</i>
                         {% endif %}
                     </td>
                     <td><a href="{{ path('member_show', { 'member_number': member.memberNumber }) }}">{{ member.memberNumber }}</a></td>

--- a/app/Resources/views/admin/user/list.html.twig
+++ b/app/Resources/views/admin/user/list.html.twig
@@ -222,7 +222,7 @@
                                 <i class="material-icons">phonelink_off</i>
                             {% endif %}
                             {% if member.frozen %}
-                                <i class="material-icons">notifications_paused</i>
+                                <i class="material-icons">ac_unit</i>
                             {% endif %}
                         {% else %}
                                 <i class="material-icons">do_not_disturb</i>

--- a/app/Resources/views/ambassador/phone/list.html.twig
+++ b/app/Resources/views/ambassador/phone/list.html.twig
@@ -27,7 +27,7 @@
                                     {{ form_label(form.withdrawn) }}
                                 </div>
                                 <div class="col s6">
-                                    gelé :
+                                    ❄️ gelé :
                                     {{ form_widget(form.frozen) }}
                                     {{ form_label(form.frozen) }}
                                 </div>

--- a/app/Resources/views/beneficiary/_partial/beneficiary_card.html.twig
+++ b/app/Resources/views/beneficiary/_partial/beneficiary_card.html.twig
@@ -39,7 +39,7 @@
                 {% endif %}
                 {% if not beneficiary.isMain %}
                     <div class="card-btn">
-                        <a href="{{ path('beneficiary_set_main', { 'id': beneficiary.id }) }}" class="modal-trigger btn btn-floating waves-effect waves-light purple" title="mettre en beneficiaire principal">
+                        <a href="{{ path('beneficiary_set_main', { 'id': beneficiary.id }) }}" class="modal-trigger btn btn-floating waves-effect waves-light purple" title="mettre en bénéficiaire principal">
                             <i class="material-icons">flag</i>
                         </a>
                     </div>

--- a/app/Resources/views/beneficiary/_partial/info.html.twig
+++ b/app/Resources/views/beneficiary/_partial/info.html.twig
@@ -1,15 +1,21 @@
 <div class="card-title">
     <img src="{{ gravatar(beneficiary.email,40) }}" alt="{{ beneficiary.firstname | lower | capitalize }}" class="circle responsive-img" />
     {{ beneficiary.firstname | lower | capitalize }} {{ beneficiary.lastname | upper }}
-    {% if beneficiary.isMain %}<span class="teal white-text badge">principal</span>{% endif %}
-    {% if beneficiary.membership.withdrawn %}<span class="red white-text badge">fermé</span>{% endif %}
+    {% if beneficiary.isMain %}
+        <span class="teal white-text badge">principal</span>
+    {% endif %}
+    {% if beneficiary.membership.withdrawn %}
+        <span class="red white-text badge">fermé</span>
+    {% endif %}
     {% if beneficiary.membership.frozenChange %}
-        {% if beneficiary.membership.frozen %}<span class="deep-purple white-text badge">Dégel à la fin du cycle</span>
-        {% else %}<span class="deep-purple white-text badge">Gel à la fin du cycle</span>
+        {% if beneficiary.membership.frozen %}
+            <span class="deep-purple white-text badge">Dégel à la fin du cycle</span>
+        {% else %}
+            <span class="deep-purple white-text badge">Gel à la fin du cycle</span>
         {% endif %}
     {% endif %}
     {% if beneficiary.membership.frozen %}
-        <i class="material-icons">notifications_paused</i>
+        <i class="material-icons">ac_unit</i>
         <span class="deep-purple white-text badge">❄️ gelé</span>
     {% endif %}
 </div>

--- a/app/Resources/views/beneficiary/_partial/info.html.twig
+++ b/app/Resources/views/beneficiary/_partial/info.html.twig
@@ -5,7 +5,7 @@
         <span class="teal white-text badge">principal</span>
     {% endif %}
     {% if beneficiary.membership.withdrawn %}
-        <span class="red white-text badge">fermé</span>
+        <span class="red white-text badge">∅ fermé</span>
     {% endif %}
     {% if beneficiary.membership.frozenChange %}
         {% if beneficiary.membership.frozen %}

--- a/app/Resources/views/beneficiary/_partial/info.html.twig
+++ b/app/Resources/views/beneficiary/_partial/info.html.twig
@@ -2,7 +2,7 @@
     <img src="{{ gravatar(beneficiary.email,40) }}" alt="{{ beneficiary.firstname | lower | capitalize }}" class="circle responsive-img" />
     {{ beneficiary.firstname | lower | capitalize }} {{ beneficiary.lastname | upper }}
     {% if beneficiary.isMain %}
-        <span class="teal white-text badge">principal</span>
+        <span class="teal white-text badge">⚐ principal</span>
     {% endif %}
     {% if beneficiary.membership.withdrawn %}
         <span class="red white-text badge">∅ fermé</span>
@@ -15,7 +15,6 @@
         {% endif %}
     {% endif %}
     {% if beneficiary.membership.frozen %}
-        <i class="material-icons">ac_unit</i>
         <span class="deep-purple white-text badge">❄️ gelé</span>
     {% endif %}
 </div>

--- a/app/Resources/views/member/show.html.twig
+++ b/app/Resources/views/member/show.html.twig
@@ -17,6 +17,7 @@
         {% if member.withdrawn %}<del>{% endif %}
         Membre #{{ member.memberNumber }}{% if member.withdrawn %}</del>{% endif %}
         {% if member.frozen %}<i class="material-icons">ac_unit</i>{% endif %}
+        {% if member.withdrawn %}<i class="material-icons">block</i>{% endif %}
     </h4>
 
     <div class="row">
@@ -377,7 +378,10 @@
         body {
             background: rgba(255, 50, 0, 0.2);
         }
-
+        {% elseif member.frozen %}
+        body {
+            background-color: rgba(0, 138, 255, 0.1);
+        }
         {% endif %}
     </style>
 {% endblock %}

--- a/app/Resources/views/member/show.html.twig
+++ b/app/Resources/views/member/show.html.twig
@@ -15,8 +15,7 @@
 {% block content %}
     <h4>
         {% if member.withdrawn %}<del>{% endif %}
-        Membre #{{ member.memberNumber }}
-        {% if member.withdrawn %}</del>{% endif %}
+        Membre #{{ member.memberNumber }}{% if member.withdrawn %}</del>{% endif %}
         {% if member.frozen %}<i class="material-icons">ac_unit</i>{% endif %}
     </h4>
 

--- a/app/Resources/views/member/show.html.twig
+++ b/app/Resources/views/member/show.html.twig
@@ -17,7 +17,7 @@
         {% if member.withdrawn %}<del>{% endif %}
         Membre #{{ member.memberNumber }}
         {% if member.withdrawn %}</del>{% endif %}
-        {% if member.frozen %}<i class="material-icons">notifications_paused</i>{% endif %}
+        {% if member.frozen %}<i class="material-icons">ac_unit</i>{% endif %}
     </h4>
 
     <div class="row">


### PR DESCRIPTION
### Quoi ?

- homogénéisation des icons de gel / fermé / principal
- mettre un background sur le profil des membres gelés (le même que celui qui apparait dans la liste)

### Captures d'écran

||Avant|Après|
|---|---|---|
|Compte gelé|![Screenshot from 2022-11-03 10-55-45](https://user-images.githubusercontent.com/7147385/199692091-a4823386-9822-48a0-baaf-c293afb75748.png)|![Screenshot from 2022-11-03 10-56-22](https://user-images.githubusercontent.com/7147385/199692095-afee9d7c-ff51-4ea6-827c-5bc9d5a5df1f.png)|
|Compte fermé|![Screenshot from 2022-11-03 10-58-58](https://user-images.githubusercontent.com/7147385/199692596-59921ff0-be1e-45f5-ad96-49de6347dcb4.png)|![Screenshot from 2022-11-03 11-02-11](https://user-images.githubusercontent.com/7147385/199693148-8e91b7b9-2c58-4083-a56f-29d362a9977c.png)|
