### PR TITLE
Liste des membres : améliorer le fonctionnement pour les comptes avec plusieurs bénéficiaires

### DIFF
--- a/app/Resources/views/admin/helloasso/_partial/campaign.html.twig
+++ b/app/Resources/views/admin/helloasso/_partial/campaign.html.twig
@@ -23,7 +23,7 @@
                             {% if campaign.state == 'PRIVATE' %}
                                 <i class="material-icons tiny">visibility_off</i> privé
                             {% elseif campaign.state == 'DISABLED' %}
-                                <i class="material-icons tiny">do_not_disturb</i> désactivé
+                                <i class="material-icons tiny">block</i> désactivé
                             {% elseif campaign.state == 'PUBLIC' %}
                                 <i class="material-icons tiny">public</i> publique
                             {% else %}

--- a/app/Resources/views/admin/user/list.html.twig
+++ b/app/Resources/views/admin/user/list.html.twig
@@ -218,19 +218,24 @@
                 <tr class="{% if member.withdrawn %}withdrawn{% endif %} {% if member.frozen %}frozen{% endif %}" data-url="{{ path('member_show', { 'member_number': member.memberNumber }) }}" >
                     <td class="hide-on-med-and-down">
                         {% if member.withdrawn %}
-                            <i class="material-icons">block</i>
+                            <i class="material-icons" title="Compte fermé">block</i>
                         {% else %}
                             {% if not member.mainBeneficiary.user.isEnabled %}
-                                <i class="material-icons">phonelink_off</i>
+                                <i class="material-icons" title="Compte pas encore activé">phonelink_off</i>
                             {% endif %}
                             {% if member.frozen %}
-                                <i class="material-icons">ac_unit</i>
+                                <i class="material-icons" title="Compte gelé">ac_unit</i>
                             {% endif %}
                         {% endif %}
                     </td>
-                    <td><a href="{{ path('member_show', { 'member_number': member.memberNumber }) }}">{{ member.memberNumber }}</a></td>
-                    <td>{{ member.mainBeneficiary.user.username }}</td>
-
+                    <td>
+                        <a href="{{ path('member_show', { 'member_number': member.memberNumber }) }}">{{ member.memberNumber }}</a>
+                    </td>
+                    <td>
+                        {% for beneficiary in member.beneficiaries %}
+                            {{ beneficiary.user.username }}<br/>
+                        {% endfor %}
+                    </td>
                     <td>
                         {% for beneficiary in member.beneficiaries %}
                             {{ beneficiary.firstname }}<br/>

--- a/app/Resources/views/admin/user/list.html.twig
+++ b/app/Resources/views/admin/user/list.html.twig
@@ -23,104 +23,108 @@
                     <div class="col s12 m4">
                         <h5>Compte</h5>
                         <div class="row">
-                            <div class="col s4">
+                            <div class="col s3">
                                 ∅ fermé :
                                 {{ form_widget(form.withdrawn) }}
                                 {{ form_label(form.withdrawn) }}
                             </div>
-                            <div class="col s4">
+                            <div class="col s3">
                                 activé :
                                 {{ form_widget(form.enabled) }}
                                 {{ form_label(form.enabled) }}
                             </div>
-                            <div class="col s4">
+                            <div class="col s3">
                                 ❄️ gelé :
                                 {{ form_widget(form.frozen) }}
                                 {{ form_label(form.frozen) }}
                             </div>
+                            <div class="col s3">
+                                <div class="input-field">
+                                    {{ form_widget(form.beneficiary_count) }}
+                                    {{ form_label(form.beneficiary_count) }}
+                                </div>
+                            </div>
                         </div>
-                        <div>
-                            <div class="row">
-                                <div class="col s3">
-                                    <div class="input-field">
-                                        {{ form_widget(form.membernumber) }}
-                                        {{ form_label(form.membernumber) }}
-                                    </div>
-                                </div>
-                                <div class="col s3">
-                                    <div class="input-field">
-                                        {{ form_widget(form.membernumberdiff) }}
-                                        {{ form_label(form.membernumberdiff) }}
-                                    </div>
-                                </div>
-                                <div class="col s3">
-                                    <div class="input-field">
-                                        {{ form_widget(form.membernumbergt) }}
-                                        {{ form_label(form.membernumbergt) }}
-                                    </div>
-                                </div>
-                                <div class="col s3">
-                                    <div class="input-field">
-                                        {{ form_widget(form.membernumberlt) }}
-                                        {{ form_label(form.membernumberlt) }}
-                                    </div>
+                        <div class="row">
+                            <div class="col s3">
+                                <div class="input-field">
+                                    {{ form_widget(form.membernumber) }}
+                                    {{ form_label(form.membernumber) }}
                                 </div>
                             </div>
-                            <h5>Adhésion(s)</h5>
-                            <div class="row">
-                                <div class="col s4">
-                                    <div class="input-field">
-                                        {{ form_widget(form.registrationdate) }}
-                                        {{ form_label(form.registrationdate) }}
-                                    </div>
-                                </div>
-                                <div class="col s4">
-                                    <div class="input-field">
-                                        {{ form_widget(form.registrationdategt) }}
-                                        {{ form_label(form.registrationdategt) }}
-                                    </div>
-                                </div>
-                                <div class="col s4">
-                                    <div class="input-field">
-                                        {{ form_widget(form.registrationdatelt) }}
-                                        {{ form_label(form.registrationdatelt) }}
-                                    </div>
+                            <div class="col s3">
+                                <div class="input-field">
+                                    {{ form_widget(form.membernumberdiff) }}
+                                    {{ form_label(form.membernumberdiff) }}
                                 </div>
                             </div>
-                            <h5>Dernière Adhésion</h5>
-                            <div class="row">
-                                <div class="col s4">
-                                    <div class="input-field">
-                                        {{ form_widget(form.lastregistrationdate) }}
-                                        {{ form_label(form.lastregistrationdate) }}
-                                    </div>
-                                </div>
-                                <div class="col s4">
-                                    <div class="input-field">
-                                        {{ form_widget(form.lastregistrationdategt) }}
-                                        {{ form_label(form.lastregistrationdategt) }}
-                                    </div>
-                                </div>
-                                <div class="col s4">
-                                    <div class="input-field">
-                                        {{ form_widget(form.lastregistrationdatelt) }}
-                                        {{ form_label(form.lastregistrationdatelt) }}
-                                    </div>
+                            <div class="col s3">
+                                <div class="input-field">
+                                    {{ form_widget(form.membernumbergt) }}
+                                    {{ form_label(form.membernumbergt) }}
                                 </div>
                             </div>
-                            <h5>Compteur</h5>
-                            <div class="row valign-wrapper">
-                                <div class="input-field col s3">
-                                    {{ form_widget(form.compteurgt) }}
-                                    {{ form_label(form.compteurgt) }}
+                            <div class="col s3">
+                                <div class="input-field">
+                                    {{ form_widget(form.membernumberlt) }}
+                                    {{ form_label(form.membernumberlt) }}
                                 </div>
-                                <div class="col s6 center">
-                                    < &nbsp; compteur &nbsp; <
+                            </div>
+                        </div>
+                        <h5>Adhésion(s)</h5>
+                        <div class="row">
+                            <div class="col s4">
+                                <div class="input-field">
+                                    {{ form_widget(form.registrationdate) }}
+                                    {{ form_label(form.registrationdate) }}
                                 </div>
-                                <div class="input-field col s3">
-                                    {{ form_widget(form.compteurlt) }}
-                                    {{ form_label(form.compteurlt) }}
+                            </div>
+                            <div class="col s4">
+                                <div class="input-field">
+                                    {{ form_widget(form.registrationdategt) }}
+                                    {{ form_label(form.registrationdategt) }}
                                 </div>
+                            </div>
+                            <div class="col s4">
+                                <div class="input-field">
+                                    {{ form_widget(form.registrationdatelt) }}
+                                    {{ form_label(form.registrationdatelt) }}
+                                </div>
+                            </div>
+                        </div>
+                        <h5>Dernière Adhésion</h5>
+                        <div class="row">
+                            <div class="col s4">
+                                <div class="input-field">
+                                    {{ form_widget(form.lastregistrationdate) }}
+                                    {{ form_label(form.lastregistrationdate) }}
+                                </div>
+                            </div>
+                            <div class="col s4">
+                                <div class="input-field">
+                                    {{ form_widget(form.lastregistrationdategt) }}
+                                    {{ form_label(form.lastregistrationdategt) }}
+                                </div>
+                            </div>
+                            <div class="col s4">
+                                <div class="input-field">
+                                    {{ form_widget(form.lastregistrationdatelt) }}
+                                    {{ form_label(form.lastregistrationdatelt) }}
+                                </div>
+                            </div>
+                        </div>
+                        <h5>Compteur</h5>
+                        <div class="row valign-wrapper">
+                            <div class="input-field col s3">
+                                {{ form_widget(form.compteurgt) }}
+                                {{ form_label(form.compteurgt) }}
+                            </div>
+                            <div class="col s6 center">
+                                < &nbsp; compteur &nbsp; <
+                            </div>
+                            <div class="input-field col s3">
+                                {{ form_widget(form.compteurlt) }}
+                                {{ form_label(form.compteurlt) }}
                             </div>
                         </div>
                     </div>

--- a/app/Resources/views/admin/user/list.html.twig
+++ b/app/Resources/views/admin/user/list.html.twig
@@ -24,19 +24,22 @@
                         <h5>Compte</h5>
                         <div class="row">
                             <div class="col s3">
-                                ∅ fermé :
-                                {{ form_widget(form.withdrawn) }}
-                                {{ form_label(form.withdrawn) }}
+                                <div class="input-field">
+                                    {{ form_widget(form.withdrawn) }}
+                                    {{ form_label(form.withdrawn) }}
+                                </div>
                             </div>
                             <div class="col s3">
-                                activé :
-                                {{ form_widget(form.enabled) }}
-                                {{ form_label(form.enabled) }}
+                                <div class="input-field">
+                                    {{ form_widget(form.enabled) }}
+                                    {{ form_label(form.enabled) }}
+                                </div>
                             </div>
                             <div class="col s3">
-                                ❄️ gelé :
-                                {{ form_widget(form.frozen) }}
-                                {{ form_label(form.frozen) }}
+                                <div class="input-field">
+                                    {{ form_widget(form.frozen) }}
+                                    {{ form_label(form.frozen) }}
+                                </div>
                             </div>
                             <div class="col s3">
                                 <div class="input-field">

--- a/app/Resources/views/member/show.html.twig
+++ b/app/Resources/views/member/show.html.twig
@@ -6,6 +6,7 @@
 <a href="{{ path('homepage') }}"><i class="material-icons">home</i></a><i class="material-icons">chevron_right</i>
 {% if is_granted("ROLE_ADMIN") %}
     <a href="{{ path('admin') }}"><i class="material-icons">build</i>&nbsp;Administration</a><i class="material-icons">chevron_right</i>
+    <a href="{{ path('user_index') }}"><i class="material-icons">people</i>&nbsp;Liste des membres</a><i class="material-icons">chevron_right</i>
 {% else %}
     <a href="{{ path('user_office_tools') }}"><i class="material-icons">folder_shared</i>&nbsp;Adhésion et ré-adhésion</a><i class="material-icons">chevron_right</i>
 {% endif %}

--- a/src/AppBundle/Controller/AdminController.php
+++ b/src/AppBundle/Controller/AdminController.php
@@ -174,9 +174,9 @@ class AdminController extends Controller
         $page = 1;
         $order = 'ASC';
         $sort = 'o.member_number';
+        $limit = 25;
 
         if ($form->isSubmitted() && $form->isValid()) {
-
             if ($form->get('page')->getData() > 0) {
                 $page = $form->get('page')->getData();
             }
@@ -186,19 +186,16 @@ class AdminController extends Controller
             if ($form->get('dir')->getData()) {
                 $order = $form->get('dir')->getData();
             }
-
             $formHelper->processSearchFormData($form, $qb);
-
         } else {
             $form->get('sort')->setData($sort);
             $form->get('dir')->setData($order);
         }
-
         $formHelper->processSearchQueryData($request->getQueryString(), $qb);
 
-        $limit = 25;
-
         $qb = $qb->orderBy($sort, $order);
+
+        // Export CSV
         if ($action == "csv") {
             $members = $qb->getQuery()->getResult();
             $return = '';
@@ -219,6 +216,7 @@ class AdminController extends Controller
                 'Content-Type' => 'application/force-download; charset=UTF-8',
                 'Content-Disposition' => 'attachment; filename="emails_' . date('dmyhis') . '.csv"'
             ));
+        // Envoyer un mail
         } else if ($action === "mail") {
             return $this->redirectToRoute('mail_edit', [
                 'request' => $request

--- a/src/AppBundle/Service/SearchUserFormHelper.php
+++ b/src/AppBundle/Service/SearchUserFormHelper.php
@@ -30,10 +30,16 @@ class SearchUserFormHelper {
             )));
         }
         $formBuilder->add('frozen', ChoiceType::class, array('label' => 'gelé', 'required' => false, 'choices' => array(
-                'gelé' => 2,
-                'Non gelé' => 1,
+            'gelé' => 2,
+            'Non gelé' => 1,
+        )));
+        if (!$ambassador) {
+            $formBuilder->add('beneficiary_count', ChoiceType::class, array('label' => 'nb de bénéficiaires', 'required' => false, 'choices' => array(
+                // '0' => 1,
+                '1' => 2,
+                '2' => 3,
             )));
-
+        }
         if ($params && isset($params['membernumber']) && $params['membernumber'])
             $formBuilder->add('membernumber', TextType::class, array('label' => '# =', 'required' => false, 'attr' => array('value' => $params['membernumber'])));
         else
@@ -229,6 +235,11 @@ class SearchUserFormHelper {
         if ($form->get('frozen')->getData() > 0) {
             $qb = $qb->andWhere('o.frozen = :frozen')
                 ->setParameter('frozen', $form->get('frozen')->getData()-1);
+        }
+        if ($form->get('beneficiary_count')->getData() > 0) {
+            var_dump($form->get('beneficiary_count')->getData()-1);
+            $qb = $qb->andWhere('SIZE(o.beneficiaries) = :beneficiary_count')
+                ->setParameter('beneficiary_count', $form->get('beneficiary_count')->getData()-1);
         }
 
         if ($form->get('phone')->getData() > 0) {

--- a/src/AppBundle/Service/SearchUserFormHelper.php
+++ b/src/AppBundle/Service/SearchUserFormHelper.php
@@ -19,7 +19,7 @@ class SearchUserFormHelper {
     public function getSearchForm($formBuilder, $params_string = '', $ambassador = false) {
         $params = array();
         parse_str($params_string, $params);
-        $formBuilder->add('withdrawn', ChoiceType::class, array('label' => 'fermé', 'required' => false, 'choices' => array(
+        $formBuilder->add('withdrawn', ChoiceType::class, array('label' => '∅ fermé', 'required' => false, 'choices' => array(
             'fermé' => 2,
             'ouvert' => 1,
         )));
@@ -29,7 +29,7 @@ class SearchUserFormHelper {
                 'Non activé' => 1,
             )));
         }
-        $formBuilder->add('frozen', ChoiceType::class, array('label' => 'gelé', 'required' => false, 'choices' => array(
+        $formBuilder->add('frozen', ChoiceType::class, array('label' => '❄️ gelé', 'required' => false, 'choices' => array(
             'gelé' => 2,
             'Non gelé' => 1,
         )));
@@ -237,17 +237,8 @@ class SearchUserFormHelper {
                 ->setParameter('frozen', $form->get('frozen')->getData()-1);
         }
         if ($form->get('beneficiary_count')->getData() > 0) {
-            var_dump($form->get('beneficiary_count')->getData()-1);
             $qb = $qb->andWhere('SIZE(o.beneficiaries) = :beneficiary_count')
                 ->setParameter('beneficiary_count', $form->get('beneficiary_count')->getData()-1);
-        }
-
-        if ($form->get('phone')->getData() > 0) {
-            if ($form->get('phone')->getData() == 1) { // non renseigné
-                $qb = $qb->andWhere('b.phone < 100000000');
-            } else {
-                $qb = $qb->andWhere('b.phone > 100000000');
-            }
         }
 
         if ($form->get('registrationdate')->getData()) {
@@ -347,6 +338,14 @@ class SearchUserFormHelper {
                     ->setParameter('email', '%'.$form->get('email')->getData().'%');
             }
         }
+        if ($form->get('phone')->getData() > 0) {
+            if ($form->get('phone')->getData() == 1) { // non renseigné
+                $qb = $qb->andWhere('b.phone < 100000000');
+            } else {
+                $qb = $qb->andWhere('b.phone > 100000000');
+            }
+        }
+
         $join_formations = false;
         if ($form->get('formations')->getData() && count($form->get('formations')->getData())) {
             if (($form->get('or_and_exp_formations')->getData() > 0) && (count($form->get('formations')->getData()) > 1)) { // AND not OR

--- a/src/AppBundle/Service/SearchUserFormHelper.php
+++ b/src/AppBundle/Service/SearchUserFormHelper.php
@@ -131,9 +131,9 @@ class SearchUserFormHelper {
     public function initSearchQuery($doctrineManager) {
         /** @var QueryBuilder $qb */
         $qb = $doctrineManager->getRepository("AppBundle:Membership")->createQueryBuilder('o');
-        $qb = $qb->leftJoin("o.beneficiaries", "b")->addSelect("b")
-            ->leftJoin("o.registrations", "r")->addSelect("r")
-            ->leftJoin("b.user", "u")->addSelect("u");
+        $qb = $qb->leftJoin("o.beneficiaries", "b")
+            ->leftJoin("b.user", "u")
+            ->leftJoin("o.registrations", "r")->addSelect("r");
         $qb = $qb->andWhere('o.member_number > 0'); //do not include admin user
         return $qb;
     }


### PR DESCRIPTION
### Quoi ?

- pour les comptes avec plusieurs bénéficiaires, toujours voir les 2 noms dans la liste
- pouvoir filtrer les membres par nombre de bénéficiaires

### Pourquoi ?

- clarifier dans la liste les membres seuls des membres avec un co-bénéficiaire
- aider le bureau des membres à retrouver plus facilement des membres

### Capture d'écran

![Screenshot from 2022-11-03 14-10-32](https://user-images.githubusercontent.com/7147385/199729452-2ce0a6cd-2f18-45cc-b82b-9e51af537eda.png)

### TODO

- prendre en compte `maximum_nb_of_beneficiaries_in_membership` pour afficher ou pas ce paramètre ?
- ajuster le positionnement du filtre ?
