### PR TITLE
Pouvoir ajouter une url sur un poste de bénévolat

### DIFF
--- a/app/DoctrineMigrations/Version20221105112542.php
+++ b/app/DoctrineMigrations/Version20221105112542.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20221105112542 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE job ADD url VARCHAR(255) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE job DROP url');
+    }
+}

--- a/app/Resources/views/admin/job/_form.html.twig
+++ b/app/Resources/views/admin/job/_form.html.twig
@@ -35,6 +35,11 @@
     {{ form_widget(form.description) }}
 </div>
 <div class="row">
+    {{ form_label(form.url) }}
+    {{ form_errors(form.url) }}
+    {{ form_widget(form.url) }}
+</div>
+<div class="row">
     {{ form_errors(form.enabled) }}
     <label>
         {{ form_widget(form.enabled) }}

--- a/app/Resources/views/admin/job/list.html.twig
+++ b/app/Resources/views/admin/job/list.html.twig
@@ -14,10 +14,10 @@
     <table class="responsive-table striped">
         <thead>
             <tr>
-                <th>id</th>
                 <th>Poste</th>
                 <th>Couleur</th>
                 <th>Description</th>
+                <th>Lien<br />(vers une doc)</th>
                 <th>Nombre de créneaux<br />(semaine type)</th>
                 <th>Actions</th>
             </tr>
@@ -26,12 +26,16 @@
         <tbody>
             {% for job in jobs %}
                 <tr>
-                    <td>{{ job.id }}</td>
                     <td {% if not job.enabled %}style="text-decoration: line-through"{% endif %}>{{ job.name }}</td>
                     <td class="{{ job.color }} white-text">{{ job.color }}</td>
                     <td class="center-align">
                         {% if job.description is not empty %}
                             <i class="material-icons" title="{{ job.description }}">playlist_add_check</i>
+                        {% endif %}
+                    </td>
+                    <td class="center-align">
+                        {% if job.url is not empty %}
+                            <a href="{{ job.url }}" target="_blank">lien</a>
                         {% endif %}
                     </td>
                     <td>{{ job.periods | length }}</td>

--- a/src/AppBundle/Controller/JobController.php
+++ b/src/AppBundle/Controller/JobController.php
@@ -27,10 +27,11 @@ class JobController extends Controller
      * @Method("GET")
      * @Security("has_role('ROLE_ADMIN')")
      */
-    public function listAction(Request $request){
-
+    public function listAction(Request $request)
+    {
         $em = $this->getDoctrine()->getManager();
         $jobs = $em->getRepository('AppBundle:Job')->findAll();
+
         return $this->render('admin/job/list.html.twig', array(
             'jobs' => $jobs
         ));
@@ -55,22 +56,20 @@ class JobController extends Controller
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-
             $em->persist($job);
             $em->flush();
 
             $session->getFlashBag()->add('success', 'Le nouveau poste a été créé !');
-
             return $this->redirectToRoute('job_list');
         }
+
         return $this->render('admin/job/new.html.twig', array(
             'form' => $form->createView()
         ));
-
     }
 
     /**
-     * add new job.
+     * Edit job.
      *
      * @Route("/edit/{id}", name="job_edit")
      * @Method({"GET","POST"})
@@ -85,24 +84,22 @@ class JobController extends Controller
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-
             $em->persist($job);
             $em->flush();
 
             $session->getFlashBag()->add('success', 'Le poste a bien été édité !');
-
             return $this->redirectToRoute('job_list');
         }
+
         return $this->render('admin/job/edit.html.twig', array(
             'form' => $form->createView(),
             'delete_form' => $this->getDeleteForm($job)->createView()
         ));
-
     }
 
 
     /**
-     * job delete
+     * Delete job.
      *
      * @Route("/{id}", name="job_delete")
      * @Method({"DELETE"})
@@ -113,12 +110,14 @@ class JobController extends Controller
         $session = new Session();
         $form = $this->getDeleteForm($job);
         $form->handleRequest($request);
+
         if ($form->isSubmitted() && $form->isValid()) {
             $em = $this->getDoctrine()->getManager();
             $em->remove($job);
             $em->flush();
             $session->getFlashBag()->add('success', 'Le poste a bien été supprimée !');
         }
+
         return $this->redirectToRoute('job_list');
     }
 
@@ -132,5 +131,4 @@ class JobController extends Controller
             ->setMethod('DELETE')
             ->getForm();
     }
-
 }

--- a/src/AppBundle/Controller/ServiceController.php
+++ b/src/AppBundle/Controller/ServiceController.php
@@ -19,7 +19,7 @@ use Symfony\Component\Validator\Constraints\DateTime;
 
 
 /**
- * Task controller.
+ * Service controller.
  *
  * @Route("services")
  */
@@ -136,7 +136,7 @@ class ServiceController extends Controller
 
 
     /**
-     * edit service.
+     * delete service.
      *
      * @Route("/{id}", name="service_remove")
      * @Method({"DELETE"})

--- a/src/AppBundle/Entity/Job.php
+++ b/src/AppBundle/Entity/Job.php
@@ -47,6 +47,13 @@ class Job
     private $description;
 
     /**
+     * @var string
+     * 
+     * @ORM\Column(name="url", type="string", length=255, nullable=true)
+     */
+    private $url;
+
+    /**
      * @var int
      * 
      * @ORM\Column(name="min_shifter_alert", type="integer", options={"default" : 2})
@@ -289,6 +296,30 @@ class Job
     {
         $this->description = $description;
         return $this;
+    }
+
+    /**
+     * Set url
+     *
+     * @param string $url
+     *
+     * @return Job
+     */
+    public function setUrl($url)
+    {
+        $this->url = $url;
+
+        return $this;
+    }
+
+    /**
+     * Get url
+     *
+     * @return string
+     */
+    public function getUrl()
+    {
+        return $this->url;
     }
 
     /**

--- a/src/AppBundle/Entity/Service.php
+++ b/src/AppBundle/Entity/Service.php
@@ -107,6 +107,14 @@ class Service
     private $clients;
 
     /**
+     * Constructor
+     */
+    public function __construct()
+    {
+        $this->users = new \Doctrine\Common\Collections\ArrayCollection();
+    }
+
+    /**
      * @ORM\PrePersist
      */
     public function setUpdatedAtValue()
@@ -219,13 +227,6 @@ class Service
     public function getUrl()
     {
         return $this->url;
-    }
-    /**
-     * Constructor
-     */
-    public function __construct()
-    {
-        $this->users = new \Doctrine\Common\Collections\ArrayCollection();
     }
 
     /**

--- a/src/AppBundle/Form/JobType.php
+++ b/src/AppBundle/Form/JobType.php
@@ -22,6 +22,7 @@ class JobType extends AbstractType
             ->add('min_shifter_alert', IntegerType::class, array('label' => 'Nombre minimum de bénévoles inscrits sur le créneau pour ne pas envoyer d\'alerte', 'required' => true, 'data' => 2, 'empty_data' => 2))
             ->add('color', TextType::class, array('label'=>'Couleur des créneaux dans le planning'))
             ->add('description', MarkdownEditorType::class, array('label' => 'Description', 'required' => false, 'empty_data' => ''))
+            ->add('url', TextType::class, array('label'=>'Lien vers une documentation', 'required' => false))
             ->add('enabled', CheckboxType::class, array('required' => false, 'label' => 'Poste activé', 'attr' => array('class' => 'filled-in')));
     }
 


### PR DESCRIPTION
### Quoi ?

- nouveau champ `Job.url`
- l'afficher dans la liste des jobs, pouvoir le remplir dans le formulaire de création d'un job

### Pourquoi ?

- pour permettre ensuite de pointer vers la doc correspondante lorsqu'on affiche le créneau (e-mail, planning) (futur PR)

