### PR TITLE
Home : généraliser le vouvoiement si plusieurs bénéficiaires

### DIFF
--- a/app/Resources/views/booking/home_dashboard.html.twig
+++ b/app/Resources/views/booking/home_dashboard.html.twig
@@ -41,15 +41,21 @@
         {% endif %}
         {% if member.timeCount < 0 %}
             <p>
-                <i class="material-icons">warning</i> Tu as du retard sur ton bénévolat. Pense à réserver tes créneaux.
+                <i class="material-icons">warning</i>
+                {% if member.beneficiaries | length %}
+                    <span>Vous avez du retard sur votre bénévolat. Pensez à réserver vos créneaux.</span>
+                {% else %}
+                    <span>Tu as du retard sur ton bénévolat. Pense à réserver tes créneaux.</span>
+                {% endif %}
             </p>
         {% else %}
             {% set remaining = shift_service.remainingToBook(member) %}
             {% if remaining > 0 %}
                 <p>
-                    <i class="material-icons">warning</i> Pense à réserver tes créneaux.
-                    <br>
-                    Tu as encore {{ remaining | duration_from_minutes }} à effectuer.
+                    <i class="material-icons">warning</i>
+                    <span>{% if member.beneficiaries | length %}Pensez à réserver vos créneaux.{% else %}Pense à réserver tes créneaux.{% endif %}</span>
+                    <br />
+                    <span>{% if member.beneficiaries | length %}Vous avez{% else %}Tu as{% endif %} encore {{ remaining | duration_from_minutes }} à effectuer.</span>
                 </p>
             {% else %}
                 {% set duration_to_book = (shift_service.shiftTimeByCycle(member) - member.timeCount(member.endOfCycle)) %}
@@ -87,11 +93,11 @@
 
     <a href="{{ path("booking") }}" class="btn teal hide-on-small-only" title="Je réserve un créneau{% if use_fly_and_fixed %} volant{% endif %}" {% if beneficiariesWhoCanBook | length == 0 %}disabled{% endif %}>
         <i class="material-icons left">schedule</i>
-        Je réserve un créneau{% if use_fly_and_fixed %} volant{% endif %}
+        Réserver un créneau{% if use_fly_and_fixed %} volant{% endif %}
     </a>
     <a href="{{ path("booking") }}" class="btn teal hide-on-med-and-up" title="Je réserve un créneau{% if use_fly_and_fixed %} volant{% endif %}" {% if beneficiariesWhoCanBook | length == 0 %}disabled{% endif %}>
         Réserver
     </a>
 
-    <p>Mon cycle actuel se termine le {{ member.endOfCycle | date_fr_long }}</p>
+    <p>{% if member.beneficiaries | length %}Votre{% else %}Mon{% endif %} cycle actuel se termine le {{ member.endOfCycle | date_fr_long }}</p>
 {% endif %}

--- a/app/Resources/views/default/index.html.twig
+++ b/app/Resources/views/default/index.html.twig
@@ -41,7 +41,12 @@
                 {% endif %}
                 {% if app.user.beneficiary %}
                     <div class="col s12">
-                        <p>Bienvenue sur ton espace personnel à {{ project_name }}</p>
+                        <p>
+                            Bienvenue sur ton espace personnel à {{ project_name }}
+                            {% if app.user.beneficiary.membership.beneficiaries | length %}
+                            <br />Tu partages ton compte avec {% for beneficiary in app.user.beneficiary.membership.beneficiaries %}{% if beneficiary != app.user.beneficiary %}{{ beneficiary.firstname }}{% endif %}{% endfor %}
+                            {% endif %}
+                        </p>
                         {% if app.user.beneficiary.membership | uptodate and app.user.beneficiary.membership | can_register %}
                             <a href="{{ path("user_self_register") }}" class="waves-effect waves-light light-green btn"><i class="material-icons left">card_membership</i>Je ré-adhère en ligne</a>
                             <br />

--- a/app/Resources/views/default/index.html.twig
+++ b/app/Resources/views/default/index.html.twig
@@ -19,7 +19,7 @@
 
             <div class="row">
                 <div class="col s12">
-                    <h3 class="header">
+                    <h4 class="header">
                         Bonjour
                         {% if app.user.beneficiary %}
                             {{ app.user.beneficiary.firstname }}
@@ -28,7 +28,7 @@
                         {% else %}
                             {{ app.user.username }}
                         {% endif %}
-                    </h3>
+                    </h4>
                 </div>
                 {% if is_granted("ROLE_SUPER_ADMIN") %}
                     <div class="col s12">

--- a/app/Resources/views/default/index.html.twig
+++ b/app/Resources/views/default/index.html.twig
@@ -75,10 +75,10 @@
                                 {% if (app.user.beneficiary.membership.registrations | length) and not app.user.beneficiary.membership | uptodate %}
                                     <p>
                                         <i class="material-icons">warning</i>
-                                        Ton adhésion a expirée le {{ "now" | date_modify((app.user.beneficiary.membership | remainder | date("%R%a"))~" days")| date_fr_long }}
+                                        {% if app.user.beneficiary.membership.beneficiaries | length %}Votre{% else %}Ton{% endif %} adhésion a expirée le {{ "now" | date_modify((app.user.beneficiary.membership | remainder | date("%R%a"))~" days")| date_fr_long }}
                                     </p>
                                     <a href="{{ path("user_self_register") }}" class="waves-effect waves-light light-green btn">
-                                        <i class="material-icons left">card_membership</i>Je ré-adhère en ligne
+                                        <i class="material-icons left">card_membership</i>Ré-adhèrer en ligne
                                     </a>
                                 {% elseif not app.user.beneficiary.membership | uptodate %}
                                     <p>
@@ -86,7 +86,7 @@
                                         Il est temps d'adhérer.
                                     </p>
                                     <a href="{{ path("user_self_register") }}" class="waves-effect waves-light light-green btn">
-                                        <i class="material-icons left">card_membership</i>J'adhère en ligne
+                                        <i class="material-icons left">card_membership</i>Adhèrer en ligne
                                     </a>
                                 {% else %}
                                     <div>


### PR DESCRIPTION
### Quoi ?

Sur la page principale, dans le cas d'un bénéficiaire qui partage son compte avec un autre bénéficiaire : 
- il manquait des endroits où il faut utiliser le "vous" au lieu du "tu"
- indiquer avec qui l'utilisateur partage son compte

### Pourquoi ?

En ne rappelant pas sur cette page qu'on partage notre compte, on peut être un peu perturbé de l'alternance entre le tutoiement ("Bienvenue sur ton espace personnel") et le vouvoiement ("Tous vos créneaux")

### Captures d'écran

|Avant|Après|
|---|---|
|![Screenshot from 2022-11-05 13-54-07](https://user-images.githubusercontent.com/7147385/200120986-2d083137-d467-4c3d-a9a6-e93eb5869f57.png)|![Screenshot from 2022-11-05 13-53-51](https://user-images.githubusercontent.com/7147385/200120989-014bac72-f6dd-43a5-bde7-5414ffd595cc.png)|
