### PR TITLE
Pouvoir ajouter une description sur une formation

### DIFF
--- a/app/DoctrineMigrations/Version20221107144041.php
+++ b/app/DoctrineMigrations/Version20221107144041.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20221107144041 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE formation ADD description LONGTEXT DEFAULT NULL');
+        $this->addSql('ALTER TABLE membership DROP FOREIGN KEY FK_86FFD28589BE4D2E');
+        $this->addSql('DROP INDEX IDX_86FFD28589BE4D2E ON membership');
+        $this->addSql('ALTER TABLE membership DROP withdrawn_by_id, DROP withdrawn_date');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE formation DROP description');
+        $this->addSql('ALTER TABLE membership ADD withdrawn_by_id INT DEFAULT NULL, ADD withdrawn_date DATE DEFAULT NULL');
+        $this->addSql('ALTER TABLE membership ADD CONSTRAINT FK_86FFD28589BE4D2E FOREIGN KEY (withdrawn_by_id) REFERENCES fos_user (id)');
+        $this->addSql('CREATE INDEX IDX_86FFD28589BE4D2E ON membership (withdrawn_by_id)');
+    }
+}

--- a/app/DoctrineMigrations/Version20221110144041_formation_description.php
+++ b/app/DoctrineMigrations/Version20221110144041_formation_description.php
@@ -10,7 +10,7 @@ use Doctrine\Migrations\AbstractMigration;
 /**
  * Auto-generated Migration: Please modify to your needs!
  */
-final class Version20221107144041 extends AbstractMigration
+final class Version20221110144041 extends AbstractMigration
 {
     public function getDescription() : string
     {
@@ -23,9 +23,6 @@ final class Version20221107144041 extends AbstractMigration
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE formation ADD description LONGTEXT DEFAULT NULL');
-        $this->addSql('ALTER TABLE membership DROP FOREIGN KEY FK_86FFD28589BE4D2E');
-        $this->addSql('DROP INDEX IDX_86FFD28589BE4D2E ON membership');
-        $this->addSql('ALTER TABLE membership DROP withdrawn_by_id, DROP withdrawn_date');
     }
 
     public function down(Schema $schema) : void
@@ -34,8 +31,5 @@ final class Version20221107144041 extends AbstractMigration
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE formation DROP description');
-        $this->addSql('ALTER TABLE membership ADD withdrawn_by_id INT DEFAULT NULL, ADD withdrawn_date DATE DEFAULT NULL');
-        $this->addSql('ALTER TABLE membership ADD CONSTRAINT FK_86FFD28589BE4D2E FOREIGN KEY (withdrawn_by_id) REFERENCES fos_user (id)');
-        $this->addSql('CREATE INDEX IDX_86FFD28589BE4D2E ON membership (withdrawn_by_id)');
     }
 }

--- a/app/Resources/views/admin/formation/_form.html.twig
+++ b/app/Resources/views/admin/formation/_form.html.twig
@@ -1,0 +1,14 @@
+{{ form_start(form) }}
+
+<div class="row">
+    {{ form_row(form.name) }}
+</div>
+<div class="row">
+    {{ form_row(form.description) }}
+</div>
+
+<div>
+    <button type="submit" class="btn waves-effect waves-light"><i class="material-icons left">save</i>Enregistrer</button>
+</div>
+
+{{ form_end(form) }}

--- a/app/Resources/views/admin/formation/edit.html.twig
+++ b/app/Resources/views/admin/formation/edit.html.twig
@@ -12,17 +12,7 @@
 {% block content %}
     <h4>Editer une formation</h4>
 
-    {{ form_start(form) }}
-    <div class="row">
-        <div class="col s6">
-            {{ form_row(form.name) }}
-        </div>
-    </div>
-    <div>
-        <button type="submit" class="btn waves-effect waves-light"><i class="material-icons left">save</i>Enregistrer</button>
-    </div>
-    {{ form_widget(form) }}
-    {{ form_end(form) }}
+    {% include "admin/formation/_form.html.twig" with { form: form } %}
 
     {% if is_granted("ROLE_SUPER_ADMIN") %}
         {{ form_start(delete_form) }}

--- a/app/Resources/views/admin/formation/list.html.twig
+++ b/app/Resources/views/admin/formation/list.html.twig
@@ -15,6 +15,7 @@
         <thead>
             <tr>
                 <th>Formation</th>
+                <th>Description</th>
                 <th>Nombre de membres</th>
                 <th>Rôles associés</th>
                 <th>Actions</th>
@@ -24,6 +25,11 @@
             {% for formation in formations %}
                 <tr>
                     <td>{{ formation.name }}</td>
+                    <td class="center-align">
+                        {% if formation.description is not empty %}
+                            <i class="material-icons" title="{{ formation.description }}">playlist_add_check</i>
+                        {% endif %}
+                    </td>
                     <td>{{ formation.beneficiaries | length }}</td>
                     <td>
                         {% for role in formation.roles %}

--- a/app/Resources/views/admin/formation/new.html.twig
+++ b/app/Resources/views/admin/formation/new.html.twig
@@ -12,14 +12,5 @@
 {% block content %}
     <h4>Nouvelle formation</h4>
 
-    {{ form_start(form) }}
-    <div class="row">
-        <div class="col s6">
-            {{ form_row(form.name) }}
-        </div>
-    </div>
-    <div>
-        <button type="submit" class="btn waves-effect waves-light">Créer</button>
-    </div>
-    {{ form_end(form) }}
+    {% include "admin/formation/_form.html.twig" with { form: form } %}
 {% endblock %}

--- a/app/Resources/views/admin/job/edit.html.twig
+++ b/app/Resources/views/admin/job/edit.html.twig
@@ -12,7 +12,7 @@
 {% block content %}
     <h4>Editer le poste de bénévolat</h4>
 
-    {% include "/admin/job/_form.html.twig" with { form: form } %}
+    {% include "admin/job/_form.html.twig" with { form: form } %}
 
     {% if is_granted("ROLE_SUPER_ADMIN") %}
         {{ form_start(delete_form) }}

--- a/src/AppBundle/Entity/Formation.php
+++ b/src/AppBundle/Entity/Formation.php
@@ -25,6 +25,16 @@ class Formation extends Group
      */
     protected $id;
 
+    // private $name;  // from Group
+    // private $roles;  // from Group
+
+    /**
+     * @var string
+     * 
+     * @ORM\Column(name="description", type="text", nullable=true)
+     */
+    private $description;
+
     /**
      * Many Formations have Many Beneficiaries.
      * @ORM\ManyToMany(targetEntity="Beneficiary", mappedBy="formations")
@@ -71,6 +81,28 @@ class Formation extends Group
     public function getId()
     {
         return $this->id;
+    }
+
+    /**
+     * Get description
+     * 
+     * @return string
+     */
+    public function getDescription(): string
+    {
+        return $this->description ? $this->description : '';
+    }
+
+    /**
+     * Set description
+     * 
+     * @param string $description
+     * @return Formation
+     */
+    public function setDescription(string $description): Formation
+    {
+        $this->description = $description;
+        return $this;
     }
 
     /**
@@ -126,5 +158,4 @@ class Formation extends Group
     {
         return $this->beneficiaries;
     }
-
 }

--- a/src/AppBundle/Form/FormationType.php
+++ b/src/AppBundle/Form/FormationType.php
@@ -15,9 +15,11 @@ class FormationType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('name', TextType::class, array('label' => 'Nom'));
+        $builder
+            ->add('name', TextType::class, array('label' => 'Nom de la formation'))
+            ->add('description', MarkdownEditorType::class, array('label' => 'Description', 'required' => false, 'empty_data' => ''));
     }
-    
+
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
### Quoi ?

- ajout du champ `Formation.description` (même mécanisme que `Job.description`)
- bougé les formulaire de création et d'édition dans le même template

### Pourquoi ?

- pour décrire la formation, par exemple expliquer les raisons pour lesquelles certains rôles lui sont associés