### PR TITLE
Bugfix : liste des membres : si le compte est fermé, affiché un fond rouge par défaut

### DIFF
--- a/app/Resources/views/admin/user/list.html.twig
+++ b/app/Resources/views/admin/user/list.html.twig
@@ -222,17 +222,16 @@
         <tbody>
         {% for member in members %}
             {% if member.mainBeneficiary %}
-                <tr class="{% if member.withdrawn %}withdrawn{% endif %} {% if member.frozen %}frozen{% endif %}" data-url="{{ path('member_show', { 'member_number': member.memberNumber }) }}" >
+                <tr class="{% if member.withdrawn %}withdrawn{% elseif member.frozen %}frozen{% endif %}" data-url="{{ path('member_show', { 'member_number': member.memberNumber }) }}" >
                     <td class="hide-on-med-and-down">
                         {% if member.withdrawn %}
                             <i class="material-icons" title="Compte fermé">block</i>
-                        {% else %}
-                            {% if not member.mainBeneficiary.user.isEnabled %}
-                                <i class="material-icons" title="Compte pas encore activé">phonelink_off</i>
-                            {% endif %}
-                            {% if member.frozen %}
-                                <i class="material-icons" title="Compte gelé">ac_unit</i>
-                            {% endif %}
+                        {% endif %}
+                        {% if member.frozen %}
+                            <i class="material-icons" title="Compte gelé">ac_unit</i>
+                        {% endif %}
+                        {% if not member.mainBeneficiary.user.isEnabled %}
+                            <i class="material-icons" title="Compte pas encore activé">phonelink_off</i>
                         {% endif %}
                     </td>
                     <td>

--- a/app/Resources/views/beneficiary/_partial/info.html.twig
+++ b/app/Resources/views/beneficiary/_partial/info.html.twig
@@ -21,21 +21,23 @@
 
 <div class="row">
     <div class="col s12 truncate">
-        <i class="material-icons tiny">phone</i>&nbsp;{{ beneficiary.phone }}
+        <i class="material-icons tiny">phone</i>
+        <span>{{ beneficiary.phone }}</span>
     </div>
     {% if phone_only is not defined %}
         <div class="col s12 truncate">
-            <i class="material-icons tiny">mail</i>&nbsp;{{ beneficiary.email }}
+            <i class="material-icons tiny">mail</i>
+            <span>{{ beneficiary.email }}</span>
         </div>
         {% if beneficiary.address %}
             <div class="col s12 truncate">
                 <i class="material-icons tiny">location_on</i>
-                &nbsp;{{ beneficiary.address.street1 }}
+                {{ beneficiary.address.street1 }}
                 {% if beneficiary.address.street2 %}
-                    &nbsp;{{ beneficiary.address.street2 }}
+                    {{ beneficiary.address.street2 }}
                 {% endif %}
-                &nbsp;{{ "%05d"|format(beneficiary.address.zipCode) }}
-                &nbsp;{{ beneficiary.address.city }}
+                {{ "%05d"|format(beneficiary.address.zipCode) }}
+                {{ beneficiary.address.city }}
             </div>
         {% endif %}
     {% endif %}
@@ -52,7 +54,7 @@
     </div>
     {% if use_fly_and_fixed %}
         <div class="col s12 truncate">
-            <i class="material-icons tiny">accessibility</i>&nbsp;
+            <i class="material-icons tiny">accessibility</i>
             {% if beneficiary.flying %}
                 <div class="chip green-text">Equipe volante</div>
             {% else %}
@@ -62,7 +64,7 @@
     {% endif %}
     {% if beneficiary.formations | length %}
         <div class="col s12 truncate">
-            <i class="material-icons tiny">assignment_ind</i>&nbsp;
+            <i class="material-icons tiny">assignment_ind</i>
             {% for formation in beneficiary.formations %}
                 <div class="chip red-text">{{ formation.name }}</div>
             {% endfor %}
@@ -70,7 +72,7 @@
     {% endif %}
     {% if beneficiary.commissions | length %}
         <div class="col s12 truncate">
-            <i class="material-icons tiny">group</i>&nbsp;
+            <i class="material-icons tiny">group</i>
             {% for commission in beneficiary.commissions %}
                 <div class="chip blue-text">{{ commission.name }}</div>
             {% endfor %}
@@ -78,7 +80,7 @@
     {% endif %}
     {% if beneficiary.user and beneficiary.user.roles | length %}
         <div class="col s12 truncate">
-            <i class="material-icons tiny">settings</i>&nbsp;
+            <i class="material-icons tiny">settings</i>
             {% for role in beneficiary.user.roles %}
                 <div class="chip purple-text">{{ role }}</div>
             {% endfor %}
@@ -86,8 +88,8 @@
     {% endif %}
     {% if beneficiary.membership.lastRegistration %}
         <div class="col s12 truncate">
-            <i class="material-icons tiny">perm_contact_calendar</i>&nbsp;
-            Adhésion du {{ beneficiary.membership.lastRegistration.date | date_fr_full }} au {{ beneficiary.membership | expire | date_fr_full }}
+            <i class="material-icons tiny">perm_contact_calendar</i>
+            <span>Adhésion du {{ beneficiary.membership.lastRegistration.date | date_fr_full }} au {{ beneficiary.membership | expire | date_fr_full }}</span>
         </div>
     {% endif %}
 </div>


### PR DESCRIPTION
Suite de https://github.com/elefan-grenoble/gestion-compte/pull/589

Si le compte est fermé + gelé : 
- afficher le fond rouge en priorité
- afficher les 2 icones (si filtre sur "compte gelé", alors ca permet d'être transparent avec l'utilisateur)

|Avant|Après|
|---|---|
|![Screenshot from 2022-11-08 12-53-05](https://user-images.githubusercontent.com/7147385/200559758-c52265b5-0347-4fa2-ab92-0c7174b4b66d.png)|![Screenshot from 2022-11-08 12-54-05](https://user-images.githubusercontent.com/7147385/200559763-1e327093-65fd-4ae4-9199-a4ee5c2c21c8.png)|
