### PR TITLE
Home : élargir le container

### DIFF
--- a/app/Resources/views/default/index.html.twig
+++ b/app/Resources/views/default/index.html.twig
@@ -13,11 +13,11 @@
 
 {% block content %}
 {% if is_granted("IS_AUTHENTICATED_REMEMBERED") %}
-    <div class="center">
+    <div id="home-announcements" class="center">
         {{ dynamicContent | markdown | raw }}
     </div>
 
-    <div class="row center">
+    <div id="home-welcome" class="row center">
         <div class="col s12">
             <h4 class="header">
                 Bonjour
@@ -56,8 +56,8 @@
         {% endif %}
     </div>
 
-    <div class="row center">
-        {% if app.user.beneficiary %}
+    {% if app.user.beneficiary %}
+        <div id="home-actions" class="row center">
             {% if app.user.beneficiary.membership | uptodate %}
                 <div class="col s12 l6">
                     <div class="homebox">
@@ -145,11 +145,15 @@
                     </div>
                 </div>
             </div>
-        {% endif %}
-        {% if app.user.beneficiary and app.user.beneficiary.membership | uptodate %}
+        </div>
+    {% endif %}
+    {% if app.user.beneficiary and app.user.beneficiary.membership | uptodate %}
+        <div id="home-shifts" class="row">
             <div class="col s12">
                 {{ render(controller("AppBundle:Booking:homepageShifts")) }}{# use include instead?#}
             </div>
+        </div>
+        <div class="row center">
             <div class="col offset-xl3 xl6 m8 offset-m2 s12">
                 <div class="homebox">
                     <h5><span class="white"><i class="material-icons">build</i>&nbsp;Action</span></h5>
@@ -166,8 +170,8 @@
                     {% endif %}
                 </div>
             </div>
-        {% endif %}
-    </div>
+        </div>
+    {% endif %}
 {% else %}
     <br>
     <br>

--- a/app/Resources/views/default/index.html.twig
+++ b/app/Resources/views/default/index.html.twig
@@ -4,210 +4,206 @@
 {% endblock %}
 
 {% block aftercontainer %}
-    <div class="center-align">
-        {% image '@AppBundle/Resources/public/img/cute-elefan.png' %}
-            <img class="responsive-img" src="{{ asset_url }}" alt="elefan" />
-        {% endimage %}
-    </div>
+<div class="center-align">
+    {% image '@AppBundle/Resources/public/img/cute-elefan.png' %}
+        <img class="responsive-img" src="{{ asset_url }}" alt="elefan" />
+    {% endimage %}
+</div>
 {% endblock %}
 
 {% block content %}
-    <div class="section" id="index-banner">
-    {% if is_granted("IS_AUTHENTICATED_REMEMBERED") %}
-        <div class="container center">
-            <div class="announcement">{{ dynamicContent | markdown | raw }}</div>
+{% if is_granted("IS_AUTHENTICATED_REMEMBERED") %}
+    <div class="center">
+        {{ dynamicContent | markdown | raw }}
+    </div>
 
-            <div class="row">
-                <div class="col s12">
-                    <h4 class="header">
-                        Bonjour
-                        {% if app.user.beneficiary %}
-                            {{ app.user.beneficiary.firstname }}
-                            <br />
-                            #{{ app.user.beneficiary.membership.memberNumber }}
-                        {% else %}
-                            {{ app.user.username }}
-                        {% endif %}
-                    </h4>
-                </div>
-                {% if is_granted("ROLE_SUPER_ADMIN") %}
-                    <div class="col s12">
-                        <p>
-                            <span class="orange-text">&lt;warning&gt;</span>
-                            <span>With great power comes great responsibility</span>
-                            <span class="orange-text">&lt;/warning&gt;</span>
-                        </p>
-                    </div>
-                {% endif %}
+    <div class="row center">
+        <div class="col s12">
+            <h4 class="header">
+                Bonjour
                 {% if app.user.beneficiary %}
-                    <div class="col s12">
-                        <p>
-                            Bienvenue sur ton espace personnel à {{ project_name }}
-                            {% if app.user.beneficiary.membership.beneficiaries | length %}
-                            <br />Tu partages ton compte avec {% for beneficiary in app.user.beneficiary.membership.beneficiaries %}{% if beneficiary != app.user.beneficiary %}{{ beneficiary.firstname }}{% endif %}{% endfor %}
-                            {% endif %}
-                        </p>
-                        {% if app.user.beneficiary.membership | uptodate and app.user.beneficiary.membership | can_register %}
-                            <a href="{{ path("user_self_register") }}" class="waves-effect waves-light light-green btn"><i class="material-icons left">card_membership</i>Je ré-adhère en ligne</a>
-                            <br />
-                            <br />
-                        {% endif %}
-                    </div>
+                    {{ app.user.beneficiary.firstname }}
+                    <br />
+                    #{{ app.user.beneficiary.membership.memberNumber }}
+                {% else %}
+                    {{ app.user.username }}
                 {% endif %}
-            </div>
-
-            <div class="row">
-                {% if app.user.beneficiary %}
-                    {% if app.user.beneficiary.membership | uptodate %}
-                        <div class="col s12 l12 xl6">
-                            <div class="homebox">
-                                <h5><span class="white">Mon Bénévolat</span></h5>
-                                {% include "booking/home_dashboard.html.twig" %}{# with { beneficiary: app.user.beneficiary } #}
-                            </div>
-                        </div>
-                    {% else %}
-                        <div class="col show-on-xl-only xl3"></div>
-                    {% endif %}
-                    <div class="col s12 l12 xl6">
-                        <div class="homebox">
-                            <h5><span class="white">Mon compte</span></h5>
-                            <div>
-                                {% if (app.user.beneficiary.membership.registrations | length) and not app.user.beneficiary.membership | uptodate %}
-                                    <p>
-                                        <i class="material-icons">warning</i>
-                                        {% if app.user.beneficiary.membership.beneficiaries | length %}Votre{% else %}Ton{% endif %} adhésion a expirée le {{ "now" | date_modify((app.user.beneficiary.membership | remainder | date("%R%a"))~" days")| date_fr_long }}
-                                    </p>
-                                    <a href="{{ path("user_self_register") }}" class="waves-effect waves-light light-green btn">
-                                        <i class="material-icons left">card_membership</i>Ré-adhèrer en ligne
-                                    </a>
-                                {% elseif not app.user.beneficiary.membership | uptodate %}
-                                    <p>
-                                        <i class="material-icons">warning</i>
-                                        Il est temps d'adhérer.
-                                    </p>
-                                    <a href="{{ path("user_self_register") }}" class="waves-effect waves-light light-green btn">
-                                        <i class="material-icons left">card_membership</i>Adhèrer en ligne
-                                    </a>
-                                {% else %}
-                                    <div>
-                                        <a href="{{ path("fos_user_profile_show") }}" class="waves-effect waves-light blue-grey btn">
-                                            <i class="material-icons left">settings</i>Gérer mon compte
-                                        </a>
-                                        {% if display_freeze_account %}
-                                            {% include "member/_partial/frozen.html.twig" with { member: app.user.beneficiary.membership } %}
-                                        {% endif %}
-                                    </div>
-                                {% endif %}
-                            </div>
-                        </div>
-                        <div class="homebox">
-                            <h5><span class="white">En ce moment à {{ project_name }}</span></h5>
-                            <a href="{{ path("schedule") }}" class="waves-effect waves-light btn teal darken-1">
-                                <i class="material-icons left">schedule</i>Planning
-                            </a>
-                            <br />
-                            <br />
-                            {% if profile_display_task_list %}
-                                <a href="{{ path("tasks_list") }}" class="waves-effect waves-light btn blue-grey">
-                                    <i class="material-icons left">list</i>Tâches en cours
-                                </a>
-                                <br />
-                            {% endif %}
-                            <a href="{{ path("process_update_list") }}" class="btn blue-grey" id="news_home_button" style="position: relative">
-                                <i class="material-icons left" >info</i>Les nouveautés
-                                <span class="bubble_counter red white-text" style="display:none;">{{ app.user.beneficiary | last_shift_date | count_updates_list_from_date }}</span>
-                            </a>
-                            <script>
-                                defer(function () {
-                                    var cookie_data = myCookieInit({'last_processupdates_check' : "{{ app.user.beneficiary | last_shift_date | date_w3c }}".replace('+','_')});
-                                    jQuery.ajax(process_update_count_unread_url,{
-                                        data: {date: cookie_data.last_processupdates_check.replace('_','+')},
-                                        method: "post",
-                                        dataType: "json"
-                                    }).done(function (data, textStatus, jqXHR) {
-                                    if (textStatus == "success"){
-                                      if (data.count > 0){
-                                          $('#news_home_button').find('.bubble_counter').html(data.count).show();
-                                          $('head title').prepend('('+data.count+') ');
-                                      }
-                                    }
-                                    });
-                                });
-                            </script>
-
-                            <div class="row">
-                                {% if events | length > 0 %}
-                                    <h5>Les événements</h5>
-                                    {% for event in events %}
-                                        {% include "default/event/_event.html.twig" with { event: event } %}
-                                    {% endfor %}
-                                {% endif %}
-                            </div>
-                        </div>
-                    </div>
-                {% endif %}
-                {% if app.user.beneficiary and app.user.beneficiary.membership | uptodate %}
-                    <div class="col s12">
-                        {{ render(controller("AppBundle:Booking:homepageShifts")) }}{# use include instead?#}
-                    </div>
-                    <div class="col offset-xl3 xl6 m8 offset-m2 s12">
-                        <div class="homebox">
-                            <h5><span class="white"><i class="material-icons">build</i>&nbsp;Action</span></h5>
-
-                            {{ render(controller("AppBundle:Code:homepageDashboard")) }}{# use include instead?#}
-
-                            {% if app.user.beneficiary and app.user.beneficiary.ownedCommissions | length %}
-                                <h5>Mes commissions</h5>
-                                {% for com in app.user.beneficiary.ownedCommissions %}
-                                    <a href="{{ path("commission_edit",{'id': com.id }) }}" class="waves-effect waves-light btn blue-grey">
-                                        Gérer la commission {{ com.name }}
-                                    </a>
-                                {% endfor %}
-                            {% endif %}
-                        </div>
-                    </div>
-                {% endif %}
-            </div>
+            </h4>
         </div>
-    {% else %}
-        <div class="container">
-            <br>
-            <br>
-            <h3 class="header center orange-text">Mon compte à {{ project_name }}</h3>
-            <div class="row center">
-                <p class="col s12 light">Bienvenue sur l'espace membre</p>
-            </div>
-            <div class="row center">
-                <a href="{{ path('fos_user_security_login') }}" class="btn-large waves-effect waves-light">
-                    <i class="material-icons left">lock_outline</i>Se connecter
-                </a>
-            </div>
-            <div class="row center">
-                <p class=" col s12 light"> Pas encore d'identifiant ?
-                    <a href="{{ path('find_me') }}" class="orange-text">Créer mon compte</a>
+        {% if is_granted("ROLE_SUPER_ADMIN") %}
+            <div class="col s12">
+                <p>
+                    <span class="orange-text">&lt;warning&gt;</span>
+                    <span>With great power comes great responsibility</span>
+                    <span class="orange-text">&lt;/warning&gt;</span>
                 </p>
             </div>
-        </div>
-        {% include "booking/_partial/list.html.twig" with { bucketsByDay: bucketsByDay } %}
-    {% endif %}
+        {% endif %}
+        {% if app.user.beneficiary %}
+            <div class="col s12">
+                <p>
+                    Bienvenue sur ton espace personnel à {{ project_name }}
+                    {% if app.user.beneficiary.membership.beneficiaries | length %}
+                    <br />Tu partages ton compte avec {% for beneficiary in app.user.beneficiary.membership.beneficiaries %}{% if beneficiary != app.user.beneficiary %}{{ beneficiary.firstname }}{% endif %}{% endfor %}
+                    {% endif %}
+                </p>
+                {% if app.user.beneficiary.membership | uptodate and app.user.beneficiary.membership | can_register %}
+                    <a href="{{ path("user_self_register") }}" class="waves-effect waves-light light-green btn"><i class="material-icons left">card_membership</i>Je ré-adhère en ligne</a>
+                    <br />
+                    <br />
+                {% endif %}
+            </div>
+        {% endif %}
     </div>
+
+    <div class="row center">
+        {% if app.user.beneficiary %}
+            {% if app.user.beneficiary.membership | uptodate %}
+                <div class="col s12 l6">
+                    <div class="homebox">
+                        <h5><span class="white">Mon Bénévolat</span></h5>
+                        {% include "booking/home_dashboard.html.twig" %}{# with { beneficiary: app.user.beneficiary } #}
+                    </div>
+                </div>
+            {% else %}
+                <div class="col show-on-xl-only xl3"></div>
+            {% endif %}
+            <div class="col s12 l6">
+                <div class="homebox">
+                    <h5><span class="white">Mon compte</span></h5>
+                    <div>
+                        {% if (app.user.beneficiary.membership.registrations | length) and not app.user.beneficiary.membership | uptodate %}
+                            <p>
+                                <i class="material-icons">warning</i>
+                                {% if app.user.beneficiary.membership.beneficiaries | length %}Votre{% else %}Ton{% endif %} adhésion a expirée le {{ "now" | date_modify((app.user.beneficiary.membership | remainder | date("%R%a"))~" days")| date_fr_long }}
+                            </p>
+                            <a href="{{ path("user_self_register") }}" class="waves-effect waves-light light-green btn">
+                                <i class="material-icons left">card_membership</i>Ré-adhèrer en ligne
+                            </a>
+                        {% elseif not app.user.beneficiary.membership | uptodate %}
+                            <p>
+                                <i class="material-icons">warning</i>
+                                Il est temps d'adhérer.
+                            </p>
+                            <a href="{{ path("user_self_register") }}" class="waves-effect waves-light light-green btn">
+                                <i class="material-icons left">card_membership</i>Adhèrer en ligne
+                            </a>
+                        {% else %}
+                            <div>
+                                <a href="{{ path("fos_user_profile_show") }}" class="waves-effect waves-light blue-grey btn">
+                                    <i class="material-icons left">settings</i>Gérer mon compte
+                                </a>
+                                {% if display_freeze_account %}
+                                    {% include "member/_partial/frozen.html.twig" with { member: app.user.beneficiary.membership } %}
+                                {% endif %}
+                            </div>
+                        {% endif %}
+                    </div>
+                </div>
+                <div class="homebox">
+                    <h5><span class="white">En ce moment à {{ project_name }}</span></h5>
+                    <a href="{{ path("schedule") }}" class="waves-effect waves-light btn teal darken-1">
+                        <i class="material-icons left">schedule</i>Planning
+                    </a>
+                    <br />
+                    <br />
+                    {% if profile_display_task_list %}
+                        <a href="{{ path("tasks_list") }}" class="waves-effect waves-light btn blue-grey">
+                            <i class="material-icons left">list</i>Tâches en cours
+                        </a>
+                        <br />
+                    {% endif %}
+                    <a href="{{ path("process_update_list") }}" class="btn blue-grey" id="news_home_button" style="position: relative">
+                        <i class="material-icons left" >info</i>Les nouveautés
+                        <span class="bubble_counter red white-text" style="display:none;">{{ app.user.beneficiary | last_shift_date | count_updates_list_from_date }}</span>
+                    </a>
+                    <script>
+                        defer(function () {
+                            var cookie_data = myCookieInit({'last_processupdates_check' : "{{ app.user.beneficiary | last_shift_date | date_w3c }}".replace('+','_')});
+                            jQuery.ajax(process_update_count_unread_url,{
+                                data: {date: cookie_data.last_processupdates_check.replace('_','+')},
+                                method: "post",
+                                dataType: "json"
+                            }).done(function (data, textStatus, jqXHR) {
+                            if (textStatus == "success"){
+                                if (data.count > 0){
+                                    $('#news_home_button').find('.bubble_counter').html(data.count).show();
+                                    $('head title').prepend('('+data.count+') ');
+                                }
+                            }
+                            });
+                        });
+                    </script>
+
+                    <div class="row">
+                        {% if events | length > 0 %}
+                            <h5>Les événements</h5>
+                            {% for event in events %}
+                                {% include "default/event/_event.html.twig" with { event: event } %}
+                            {% endfor %}
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
+        {% endif %}
+        {% if app.user.beneficiary and app.user.beneficiary.membership | uptodate %}
+            <div class="col s12">
+                {{ render(controller("AppBundle:Booking:homepageShifts")) }}{# use include instead?#}
+            </div>
+            <div class="col offset-xl3 xl6 m8 offset-m2 s12">
+                <div class="homebox">
+                    <h5><span class="white"><i class="material-icons">build</i>&nbsp;Action</span></h5>
+
+                    {{ render(controller("AppBundle:Code:homepageDashboard")) }}{# use include instead?#}
+
+                    {% if app.user.beneficiary and app.user.beneficiary.ownedCommissions | length %}
+                        <h5>Mes commissions</h5>
+                        {% for com in app.user.beneficiary.ownedCommissions %}
+                            <a href="{{ path("commission_edit",{'id': com.id }) }}" class="waves-effect waves-light btn blue-grey">
+                                Gérer la commission {{ com.name }}
+                            </a>
+                        {% endfor %}
+                    {% endif %}
+                </div>
+            </div>
+        {% endif %}
+    </div>
+{% else %}
+    <br>
+    <br>
+    <h3 class="header center orange-text">Mon compte à {{ project_name }}</h3>
+    <div class="row center">
+        <p class="col s12 light">Bienvenue sur l'espace membre</p>
+    </div>
+    <div class="row center">
+        <a href="{{ path('fos_user_security_login') }}" class="btn-large waves-effect waves-light">
+            <i class="material-icons left">lock_outline</i>Se connecter
+        </a>
+    </div>
+    <div class="row center">
+        <p class=" col s12 light"> Pas encore d'identifiant ?
+            <a href="{{ path('find_me') }}" class="orange-text">Créer mon compte</a>
+        </p>
+    </div>
+    {% include "booking/_partial/list.html.twig" with { bucketsByDay: bucketsByDay } %}
+{% endif %}
 {% endblock %}
 
 {% block stylesheets %}
 {% endblock %}
 
 {% block javascripts %}
-    <script>
-        jQuery(function () {
-            $(".collapsible .modal-trigger").on('click', function (e) {
-                e.preventDefault();
-            });
-        })
-        {% if not is_granted("IS_AUTHENTICATED_REMEMBERED") %}
-            var barcode_submit_url = "{{ path('check') }}";
-        {% endif %}
-    </script>
+<script>
+    jQuery(function () {
+        $(".collapsible .modal-trigger").on('click', function (e) {
+            e.preventDefault();
+        });
+    })
     {% if not is_granted("IS_AUTHENTICATED_REMEMBERED") %}
-        <script src="{{ asset('bundles/app/js/barcode.js') }}"></script>
+        var barcode_submit_url = "{{ path('check') }}";
     {% endif %}
+</script>
+{% if not is_granted("IS_AUTHENTICATED_REMEMBERED") %}
+    <script src="{{ asset('bundles/app/js/barcode.js') }}"></script>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
### Quoi ?

- réduire les padding sur les cotés, pour élargir le contenu visible sur la page principale (comment ? il y un `container` en trop)
- réduit les breakpoint des colonnes, de `l12 xl6` à `l6`
- mis chaque section dans son propre div/row

### Pourquoi ?

Pour éviter de scroller sur écrans moyens/grands

### Captures d'écran

Sur écran "moyen" : ~1150px de large

|Avant|Après|
|---|---|
|![Screenshot from 2022-11-14 12-56-36](https://user-images.githubusercontent.com/7147385/201654677-2c2fd920-04ef-4498-b102-b139ae967067.png)|![Screenshot from 2022-11-14 12-55-18](https://user-images.githubusercontent.com/7147385/201654686-997b3e71-8396-4d78-a96a-2d5c39d5130d.png)|
