### PR TITLE
Répare les droits d'accès au contenu dynamique

### DIFF
--- a/app/Resources/views/admin/content/list.html.twig
+++ b/app/Resources/views/admin/content/list.html.twig
@@ -23,7 +23,7 @@
                         </div>
                         <div class="card-action">
                             <div class="left">
-                                <a href="{{ path("dynamic_content_edit",{'id':dynamicContent.id}) }}"><i class="material-icons left">edit</i>Editer</a>
+                                <a href="{{ path("dynamic_content_edit", { 'id': dynamicContent.id }) }}"><i class="material-icons left">edit</i>Editer</a>
                             </div>
                         </div>
                     </div>

--- a/src/AppBundle/Controller/DynamicContentController.php
+++ b/src/AppBundle/Controller/DynamicContentController.php
@@ -62,8 +62,6 @@ class DynamicContentController extends Controller
      */
     public function dynamicContentEditAction(Request $request, DynamicContent $dynamicContent)
     {
-        $this->denyAccessUnlessGranted('edit', $dynamicContent);
-
         $form = $this->createForm('AppBundle\Form\DynamicContentType', $dynamicContent);
         $form->handleRequest($request);
 
@@ -75,9 +73,9 @@ class DynamicContentController extends Controller
             }
             $em->persist($dynamicContent);
             $em->flush();
+
             $session->getFlashBag()->add('success', 'Contenu dynamique édité');
             return $this->redirectToRoute('dynamic_content_list');
-
         }
 
         return $this->render('admin/content/edit.html.twig', array(


### PR DESCRIPTION
Suite à la PR https://github.com/elefan-grenoble/gestion-compte/pull/502 les utilisateurs ayant le rôle ROLE_PROCESS_MANAGER peuvent maintenant accéder à d'avantage de boutons, dont "Contenus Dynamique".

Mais il ne peuvent toujours pas modifier ce contenu. Bug résolu :ok_hand: 