### PR TITLE
Ajustements sur le suivi des pré-adhésions

### DIFF
--- a/app/Resources/views/admin/pre_user/list.html.twig
+++ b/app/Resources/views/admin/pre_user/list.html.twig
@@ -75,9 +75,16 @@
                 </td>
 
                 <td>
-                    {% if is_granted("ROLE_USER_MANAGER") %}
-                        <a href="{{ path('user_quick_new_recall', { 'id' : anonymousBeneficiary.id }) }}" class="btn waves-effect waves-light green darken-2"><i class="material-icons left">redo</i> Relancer</a>
-                        <br> <a href="{{ path('pre_user_delete', { 'id': anonymousBeneficiary.id }) }}" class="btn red"><i class="material-icons left">delete</i>Supprimer</a>
+                    {% if is_granted("ROLE_USER_VIEWER") %}
+                        <a href="{{ path('user_quick_new_recall', { 'id' : anonymousBeneficiary.id }) }}" class="btn waves-effect waves-light green darken-2">
+                            <i class="material-icons left">redo</i>Relancer
+                        </a>
+                    {% endif %}
+                    {% if is_granted("ROLE_ADMIN") %}
+                        <br />
+                        <a href="{{ path('pre_user_delete', { 'id': anonymousBeneficiary.id }) }}" class="btn red">
+                            <i class="material-icons left">delete</i>Supprimer
+                        </a>
                     {% endif %}
                 </td>
             </tr>

--- a/app/Resources/views/admin/pre_user/list.html.twig
+++ b/app/Resources/views/admin/pre_user/list.html.twig
@@ -76,7 +76,7 @@
 
                 <td>
                     {% if is_granted("ROLE_USER_VIEWER") %}
-                        <a href="{{ path('user_quick_new_recall', { 'id' : anonymousBeneficiary.id }) }}" class="btn waves-effect waves-light green darken-2">
+                        <a href="{{ path('pre_user_recall', { 'id' : anonymousBeneficiary.id }) }}" class="btn waves-effect waves-light green darken-2">
                             <i class="material-icons left">redo</i>Relancer
                         </a>
                     {% endif %}

--- a/app/Resources/views/registrations/list.html.twig
+++ b/app/Resources/views/registrations/list.html.twig
@@ -137,7 +137,7 @@
                             {% else %}
                                 Jamais relancé
                             {% endif %}&nbsp;
-                            <a href="{{ path('user_quick_new_recall', { 'id' : registration.id[2:] }) }}" class="btn waves-effect waves-light green darken-2">
+                            <a href="{{ path('pre_user_recall', { 'id' : registration.id[2:] }) }}" class="btn waves-effect waves-light green darken-2">
                                 <i class="material-icons left">redo</i>Relancer
                             </a>
                         </div>

--- a/app/Resources/views/registrations/list.html.twig
+++ b/app/Resources/views/registrations/list.html.twig
@@ -137,7 +137,9 @@
                             {% else %}
                                 Jamais relancé
                             {% endif %}&nbsp;
-                            <a href="{{ path('user_quick_new_recall', { 'id' : registration.id[2:] }) }}" class="btn waves-effect waves-light green darken-2"><i class="material-icons left">redo</i> Relancer</a>
+                            <a href="{{ path('user_quick_new_recall', { 'id' : registration.id[2:] }) }}" class="btn waves-effect waves-light green darken-2">
+                                <i class="material-icons left">redo</i>Relancer
+                            </a>
                         </div>
                     </div>
                 {% endif %}

--- a/src/AppBundle/Controller/UserController.php
+++ b/src/AppBundle/Controller/UserController.php
@@ -188,31 +188,6 @@ class UserController extends Controller
     }
 
     /**
-     * Recall new unconfirmed user.
-     *
-     * @Route("/quick_new/{id}/recall", name="user_quick_new_recall")
-     * @Security("has_role('ROLE_USER_VIEWER')")
-     * @Method({"GET"})
-     */
-    public function quickNewRecallAction(Request $request,AnonymousBeneficiary $anonymousBeneficiary)
-    {
-        $dispatcher = $this->get('event_dispatcher');
-        $dispatcher->dispatch(AnonymousBeneficiaryRecallEvent::NAME, new AnonymousBeneficiaryRecallEvent($anonymousBeneficiary));
-
-        $anonymousBeneficiary->setRecallDate(new \DateTime());
-        $em = $this->getDoctrine()->getManager();
-        $em->persist($anonymousBeneficiary);
-        $em->flush();
-
-        $session = new Session();
-        $session->getFlashBag()->add('success', 'La relance a été envoyée !');
-
-        $referer = $request->headers->get('referer');
-
-        return new RedirectResponse($referer);
-    }
-
-    /**
      * remove role of user
      *
      * @Route("/{id}/removeRole/{role}", name="user_remove_role")
@@ -362,6 +337,8 @@ class UserController extends Controller
     }
 
     /**
+     * List all unconfirmed users.
+     *
      * @Route("/pre_users", name="pre_user_index")
      * @Method({"GET"})
      * @Security("has_role('ROLE_USER_VIEWER')")
@@ -373,12 +350,40 @@ class UserController extends Controller
             [],
             ['createdAt' => 'DESC']
         );
+
         return $this->render('admin/pre_user/list.html.twig', array(
             'anonymousBeneficiaries' => $anonymousBeneficiaries,
         ));
     }
 
     /**
+     * Recall unconfirmed user.
+     *
+     * @Route("/pre_users/{id}/recall", name="pre_user_recall")
+     * @Security("has_role('ROLE_USER_VIEWER')")
+     * @Method({"GET"})
+     */
+    public function quickNewRecallAction(Request $request, AnonymousBeneficiary $anonymousBeneficiary)
+    {
+        $dispatcher = $this->get('event_dispatcher');
+        $dispatcher->dispatch(AnonymousBeneficiaryRecallEvent::NAME, new AnonymousBeneficiaryRecallEvent($anonymousBeneficiary));
+
+        $anonymousBeneficiary->setRecallDate(new \DateTime());
+        $em = $this->getDoctrine()->getManager();
+        $em->persist($anonymousBeneficiary);
+        $em->flush();
+
+        $session = new Session();
+        $session->getFlashBag()->add('success', 'La relance a été envoyée !');
+
+        $referer = $request->headers->get('referer');
+
+        return new RedirectResponse($referer);
+    }
+
+    /**
+     * Delete unconfirmed user.
+     * 
      * @Route("/pre_users/{id}/delete", name="pre_user_delete")
      * @Security("has_role('ROLE_USER_MANAGER')")
      * @Method({"GET"})

--- a/src/AppBundle/Controller/UserController.php
+++ b/src/AppBundle/Controller/UserController.php
@@ -383,12 +383,12 @@ class UserController extends Controller
      * @Security("has_role('ROLE_USER_MANAGER')")
      * @Method({"GET"})
      */
-    public function preUsersDeleteAction(AnonymousBeneficiary $beneficiary, SessionInterface $session)
+    public function preUsersDeleteAction(AnonymousBeneficiary $anonymousBeneficiary, SessionInterface $session)
     {
-        $this->getDoctrine()->getManager()->remove($beneficiary);
+        $this->getDoctrine()->getManager()->remove($anonymousBeneficiary);
         $this->getDoctrine()->getManager()->flush();
 
-        $session->getFlashBag()->add('success', "L'adhésion a bien été supprimée");
+        $session->getFlashBag()->add('success', "La pré-adhésion a bien été supprimée");
 
         return $this->redirectToRoute('pre_user_index');
     }

--- a/src/AppBundle/Controller/UserController.php
+++ b/src/AppBundle/Controller/UserController.php
@@ -191,7 +191,7 @@ class UserController extends Controller
      * Recall new unconfirmed user.
      *
      * @Route("/quick_new/{id}/recall", name="user_quick_new_recall")
-     * @Security("has_role('ROLE_ADMIN')")
+     * @Security("has_role('ROLE_USER_VIEWER')")
      * @Method({"GET"})
      */
     public function quickNewRecallAction(Request $request,AnonymousBeneficiary $anonymousBeneficiary)

--- a/src/AppBundle/Entity/AnonymousBeneficiary.php
+++ b/src/AppBundle/Entity/AnonymousBeneficiary.php
@@ -66,7 +66,6 @@ class AnonymousBeneficiary
      */
     private $mode;
 
-
     /**
      * @ORM\ManyToOne(targetEntity="User")
      * @ORM\JoinColumn(name="registrar_id", referencedColumnName="id", onDelete="SET NULL")


### PR DESCRIPTION
Dans la partie admin de l'espace membre, dans la section "Adhésion / Ré-adhésion", il existe un bouton "Suivre les pré-adhésions"

Modifications apportées : 
- permettre aux ROLE_USER_VIEWER (ceux qui créent déjà les pré-adhésions) de relancer
- renommer la route en `pre_user_recall` pour homogénéiser
- quelques mini modifications (success message, alignement, ...)