### PR TITLE
Homogéniser l'affichage des membres

### DIFF
--- a/app/Resources/views/admin/booking/_partial/bucket_card.html.twig
+++ b/app/Resources/views/admin/booking/_partial/bucket_card.html.twig
@@ -25,7 +25,7 @@
                                 {% if use_card_reader_to_validate_shifts and shift.isPastOrCurrent %}
                                     <span class="{% if shift.wasCarriedOut %}green-text{% else %}red-text{% endif %}">&#9673;</span>&nbsp;
                                 {% endif %}
-                                {{ shift.shifter.firstname|lower|capitalize }}&nbsp;{{ shift.shifter.lastname|first|upper }}
+                                {{ shift.shifter.publicDisplayName }}
                                 {% if shift.formation %}</b>{% endif %}
                                 {% if not shift.formation and shift.shifter.formations | length > 0 %}&nbsp;<b class="orange-text">(q)</b>{% endif %}
                             </li>

--- a/app/Resources/views/admin/booking/_partial/bucket_modal.html.twig
+++ b/app/Resources/views/admin/booking/_partial/bucket_modal.html.twig
@@ -21,7 +21,7 @@ It use the materialize modal class https://materializecss.com/modals.html
                             {% if use_card_reader_to_validate_shifts and shift.isPastOrCurrent %}
                                 <span class="{% if shift.wasCarriedOut %}green-text{% else %}red-text{% endif %}">&#9673;</span>&nbsp;
                             {% endif %}
-                            #{{ shift.shifter.membership.memberNumber }}&nbsp;{{ shift.shifter.firstname }}&nbsp;{{ shift.shifter.lastname }}
+                            {{ shift.shifter.displayNameWithMemberNumber }}
                             {% if shift.formation %}&nbsp;({{ shift.formation.name }}){% endif %}
                             {% if not shift.formation and shift.shifter.formations | length > 0 %}&nbsp;<b class="orange-text">({{ shift.shifter.formations | join(', ') }})</b>{% endif %}
                             {% if shift.isDismissed() %}<div class="red-text" style="padding-left: 5px">(en attente de reprise)</div>{% endif %}

--- a/app/Resources/views/admin/booking/_partial/bucket_modal.html.twig
+++ b/app/Resources/views/admin/booking/_partial/bucket_modal.html.twig
@@ -74,7 +74,7 @@ It use the materialize modal class https://materializecss.com/modals.html
                         <div class="col {% if not shift.lastShifter %}s11{% else %}s12{% endif %}">
                             <b>
                                 <span style="font-style: italic">
-                                    {% if shift.lastShifter %}réservé à {{ shift.lastShifter.displayName }}
+                                    {% if shift.lastShifter %}réservé à {{ shift.lastShifter.displayNameWithMemberNumber }}
                                     {% else %}libre
                                     {% endif %}
                                 </span>

--- a/app/Resources/views/admin/booking/index.html.twig
+++ b/app/Resources/views/admin/booking/index.html.twig
@@ -108,17 +108,17 @@
             .trigger('change');
             $('.modal').modal({
                 onCloseEnd: function() {
-                    $( ".modal-content" ).html('');
+                    $('.modal-content').html('');
                 },
                 onOpenStart: function(modal, trigger) {
                     var url = $(trigger).attr('data-source');
-                    $.get( url, function( data ) {
-                        $( ".modal-content" ).html(data);
+                    $.get(url, function( data ) {
+                        $('.modal-content').html(data);
                         $('.collapsible').collapsible();
                         $('input.autocomplete').autocomplete({
                             data: {
                                 {% for beneficiary in beneficiaries %}
-                                    "{{ beneficiary.autocompleteLabel }}": null,
+                                    "{{ beneficiary.displayNameWithMemberNumber }}": null,
                                 {% endfor %}
                             },
                             limit: 10,

--- a/app/Resources/views/admin/commission/edit.html.twig
+++ b/app/Resources/views/admin/commission/edit.html.twig
@@ -84,8 +84,8 @@
             Référents :
             {% for beneficiary in commission.owners %}
                 <div class="chip black-text {% if not commission.beneficiaries.contains(beneficiary) %}red{% endif %}">
-                    <img src="{{ gravatar(beneficiary.email) }}" alt="{{ beneficiary.displayname }}">
-                    {{ beneficiary.firstname }} {{ beneficiary.lastname }}
+                    <img src="{{ gravatar(beneficiary.email) }}" alt="{{ beneficiary.displayNameWithMemberNumber }}">
+                    {{ beneficiary.displayName }}
                 </div>
             {% endfor %}
         {% endif %}

--- a/app/Resources/views/admin/commission/list.html.twig
+++ b/app/Resources/views/admin/commission/list.html.twig
@@ -24,7 +24,7 @@
                         <a href="mailto:{{ commission.email | email_encode | raw }}"><i class="material-icons left">email</i></a>
                         {% for owner in commission.owners %}
                             <a class="chip black-text" href="{{ path("member_show",{member_number:owner.user.beneficiary.membership.memberNumber}) }}" style="font-size: 9px;">
-                                <img src="{{ gravatar(owner.email) }}" alt="{{ owner.displayname }}">
+                                <img src="{{ gravatar(owner.email) }}" alt="{{ owner.displayNameWithMemberNumber }}">
                                 {{ owner.firstname }}
                             </a>
                         {% endfor %}

--- a/app/Resources/views/admin/mail/edit.html.twig
+++ b/app/Resources/views/admin/mail/edit.html.twig
@@ -64,7 +64,7 @@
                             data: [
                                 {% for beneficiary in to %}
                                 {
-                                tag: "{{ beneficiary.autocompleteLabel }}",
+                                tag: "{{ beneficiary.displayNameWithMemberNumber }}",
                             },{% endfor %} ],
                             autocompleteOptions: {
                                 data: dataUsers,

--- a/app/Resources/views/admin/member/join.html.twig
+++ b/app/Resources/views/admin/member/join.html.twig
@@ -40,7 +40,7 @@
                 data: {
                     {% for member in members %}
                         {% if member.mainBeneficiary %}
-                            "#{{ member.memberNumber }} {{ member.mainBeneficiary.firstname }} {{ member.mainBeneficiary.lastname }}": null,
+                            "{{ member.mainBeneficiary.displayNameWithMemberNumber }}": null,
                         {% endif %}
                     {% endfor %}
                 },

--- a/app/Resources/views/admin/period/edit.html.twig
+++ b/app/Resources/views/admin/period/edit.html.twig
@@ -43,7 +43,7 @@
                             <div class="collapsible-header">
                                 <div class="col s12">
                                     {% if position.formation %}<b data-formation="{{ position.formation.name }}">{% endif %}
-                                    #{{ position.shifter.membership.memberNumber }}&nbsp;{{ position.shifter.firstname }}&nbsp;{{ position.shifter.lastname }}
+                                    {{ position.shifter.displayNameWithMemberNumber }}
                                     {% if position.formation %}</b>&nbsp;({{ position.formation.name }}){% endif %}
                                     {% if not position.formation and position.shifter.formations | length > 0 %}&nbsp;<b class="orange-text">({{ position.shifter.formations | join(', ') }})</b>{% endif %}
                                 </div>
@@ -138,7 +138,7 @@
             $('input.autocomplete').autocomplete({
                 data: {
                     {% for beneficiary in beneficiaries %}
-                        "{{ beneficiary.autocompleteLabel }}" : null,
+                        "{{ beneficiary.displayNameWithMemberNumber }}" : null,
                     {% endfor %}
                 },
                 limit: 10, // The max amount of results that can be shown at once. Default: Infinity.

--- a/app/Resources/views/admin/period/index.html.twig
+++ b/app/Resources/views/admin/period/index.html.twig
@@ -66,7 +66,7 @@
             {# sombody is registered to this period #}
             {% set warning = shifter.isFlying or shifter.getMembership.getFrozen or shifter.getMembership.getWithdrawn %}
             <a href="{{ path('member_show', { 'member_number': shifter.membership.memberNumber }) }}"
-               class="black-text tooltipped editable-box truncate" data-position="bottom" data-tooltip="{{ shifter.getDisplayNameWithStatusIcon() | raw }} &#013;&#010; ({{ formation }})">
+               class="black-text tooltipped editable-box truncate" data-position="bottom" data-tooltip="{{ shifter.getDisplayNameWithMemberNumberAndStatusIcon() | raw }} &#013;&#010; ({{ formation }})">
                 {% if warning %}
                     <i class="red-text material-icons warning-animation">warning</i>
                 {% else %}

--- a/app/Resources/views/beneficiary/_partial/chip.html.twig
+++ b/app/Resources/views/beneficiary/_partial/chip.html.twig
@@ -1,7 +1,7 @@
 <div class="chip black-text">
-    <img src="{{ gravatar(beneficiary.email) }}" alt="{{ beneficiary.displayname }}">
-    {{ beneficiary.firstname }} {{ beneficiary.lastname }}
-    {% if close is defined and close  %}
-    <i class="close material-icons" data-target="{{ beneficiary.id }}">close</i>
+    <img src="{{ gravatar(beneficiary.email) }}" alt="{{ beneficiary.displayNameWithMemberNumber }}">
+    {{ beneficiary.displayName }}
+    {% if close is defined and close %}
+        <i class="close material-icons" data-target="{{ beneficiary.id }}">close</i>
     {% endif %}
 </div>

--- a/app/Resources/views/beneficiary/confirm.html.twig
+++ b/app/Resources/views/beneficiary/confirm.html.twig
@@ -24,7 +24,7 @@
                 {% else %}
                     {% if is_granted("IS_AUTHENTICATED_REMEMBERED") %}
                         {% if user.isEnabled %}
-                            Le compte de l'adhérent #{{ member.memberNumber }} <b>{{ beneficiary.firstname }} {{ beneficiary.lastname|first|upper }}</b> est déjà actif.
+                            Le compte de l'adhérent <b>{{ beneficiary.publicDisplayNameWithMemberNumber }}</b> est déjà actif.
                             <br>
                             Il est lié à l'adresse courriel {{ user.anonymousEmail }}<br>
                             <form action="{{ path('fos_user_resetting_send_email') }}" method="POST" class="fos_user_resetting_request">
@@ -39,7 +39,7 @@
                                 </div>
                             </form>
                         {% else %}
-                            C'est <b>{{ beneficiary.firstname }} {{ beneficiary.lastname|first|upper }}</b> !
+                            C'est <b>{{ beneficiary.publicDisplayName }}</b> !
                             {% if not member.lastRegistration %}
                                 <div>Oups, erreur de saisie, nous n'avons pas enregistré d'adhésion pour ce compte. <br/>Il ne peux donc pas être activé.</div>
                                 <div class="center-align">
@@ -75,7 +75,7 @@
                         {% endif %}
                     {% else %}
                         {% if user.isEnabled %}
-                            Le compte de l'adhérent #{{ member.memberNumber }} <b>{{ beneficiary.firstname }} {{ beneficiary.lastname|first|upper }}</b> est déjà actif.
+                            Le compte de l'adhérent <b>{{ beneficiary.publicDisplayNameWithMemberNumber }}</b> est déjà actif.
                             <br>
                             Il est lié à l'adresse courriel {{ user.anonymousEmail }}
                             <br>
@@ -95,7 +95,7 @@
                                 </div>
                             </div>
                         {% else %}
-                            Bonjour <b>{{ beneficiary.firstname }} {{ beneficiary.lastname|first|upper }}</b> !
+                            Bonjour <b>{{ beneficiary.publicDisplayName }}</b> !
                             {% if not member.lastRegistration %}
                                 <div class="text-orange">Oups, erreur de saisie, nous n'avons pas enregistré ton adhésion cette année. Ton compte ne peut pas être activé.</div>
                             {% else %}

--- a/app/Resources/views/beneficiary/edit_beneficiary.html.twig
+++ b/app/Resources/views/beneficiary/edit_beneficiary.html.twig
@@ -6,7 +6,7 @@
 <a href="{{ path('homepage') }}"><i class="material-icons">home</i></a><i class="material-icons">chevron_right</i>
 <a href="{{ path('admin') }}"><i class="material-icons">build</i>&nbsp;Administration</a><i class="material-icons">chevron_right</i>
 <a href="{{ path('user_office_tools') }}"><i class="material-icons">folder_shared</i>&nbsp;Adhésion et ré-adhésion</a><i class="material-icons">chevron_right</i>
-<a href="{{ path('member_show', { 'member_number': beneficiary.membership.memberNumber }) }}"><i class="material-icons">person</i>&nbsp;{{ beneficiary.membership.autocompleteLabel }}</a><i class="material-icons">chevron_right</i>
+<a href="{{ path('member_show', { 'member_number': beneficiary.membership.memberNumber }) }}"><i class="material-icons">person</i>&nbsp;{{ beneficiary.membership.displayMemberNumber }}</a><i class="material-icons">chevron_right</i>
 <i class="material-icons">edit</i>&nbsp;Editer un bénéficiaire
 {% endblock %}
 

--- a/app/Resources/views/beneficiary/find_member_number.html.twig
+++ b/app/Resources/views/beneficiary/find_member_number.html.twig
@@ -34,7 +34,7 @@
             <div class="collection">
                 {% for beneficiary in beneficiaries %}
                     <form action="{{ path(return_path, { (routeParam): beneficiary.id } | merge(params)) }}" method="post" class="collection-item">
-                        <a href="#" onclick="$(this).closest('form').submit()" >#{{ beneficiary.memberNumber }} {{ beneficiary.firstname }} {{ beneficiary.lastname | first | upper }}{% if beneficiary.membership.lastRegistration %} - {{ beneficiary.membership.lastRegistration.date | date('d F Y') }}{% endif %}</a>
+                        <a href="#" onclick="$(this).closest('form').submit()" >{{ beneficiary.publicDisplayNameWithMemberNumber }}{% if beneficiary.membership.lastRegistration %} - {{ beneficiary.membership.lastRegistration.date | date('d F Y') }}{% endif %}</a>
                     </form>
                 {% endfor %}
             </div>

--- a/app/Resources/views/booking/_partial/home_shift_contactform.html.twig
+++ b/app/Resources/views/booking/_partial/home_shift_contactform.html.twig
@@ -37,7 +37,7 @@
         $("#contactform{{ shift.id }} input[name='form[to]']").val(JSON.stringify(ids));
     }
     function toto{{ shift.id }}() {
-        var allMembers = [{% for shift in coShifts %}"#{{shift.shifter.id}} {{ shift.shifter.firstname|lower|capitalize }} {{ shift.shifter.lastname|first|upper }}",{% endfor %}];
+        var allMembers = [{% for shift in coShifts %}"{{ shift.shifter.publicDisplayNameWithMemberNumber }}",{% endfor %}];
         $('#to{{ shift.id }}').chips({
             autocompleteOptions: {
                 data: allMembers.reduce(function(map, obj) {

--- a/app/Resources/views/default/card_reader.html.twig
+++ b/app/Resources/views/default/card_reader.html.twig
@@ -12,7 +12,6 @@
     </nav>
 
     <div class="row">
-
         <div class="col s6">
             <h5>Créneaux à venir</h5>
 
@@ -50,7 +49,18 @@
                                             </span>&nbsp;
                                         {% endif %}
                                         {% if shift.shifter %}
-                                            <span style="margin-right: 5px; font-size: 16px">{{ shift.shifter.publicDisplayName }}</span>
+                                            {% if use_card_reader_to_validate_shifts %}
+                                                <span class="{% if shift.wasCarriedOut %}green-text{% endif %}">
+                                                    &#9673;
+                                                </span>
+                                            {% endif %}
+                                            <span style="margin-right: 5px; font-size: 16px">{{ shift.shifter.publicDisplayNameWithMemberNumber }}</span>
+                                            {% if shift.formation %}
+                                                <span class="chip" style="margin-left: 5px"><b>{{ shift.formation }}</b></span>
+                                            {% endif %}
+                                            {% if shift.shifter.shifts | length == 1 %}
+                                                <span class="chip red white-text" style="margin-left: 5px">Premier créneau</span>
+                                            {% endif %}
                                         {% else %}
                                             <strong><i>libre</i></strong>
                                         {% endif %}
@@ -70,7 +80,6 @@
         </div>
 
         <div class="col s6">{{ dynamicContent | markdown | raw }}</div>
-
     </div>
 {% endblock %}
 
@@ -85,8 +94,8 @@
     </script>
     <script src="{{ asset('bundles/app/js/barcode.js') }}"></script>
     <script type="text/javascript">
-        setTimeout(function(){
+        setTimeout(function() {
             location.reload();
-        },60000);
+        }, 60 * 1000);  // page reload every 60 seconds
     </script>
 {% endblock %}

--- a/app/Resources/views/default/task/list.html.twig
+++ b/app/Resources/views/default/task/list.html.twig
@@ -48,8 +48,8 @@
                                 <td>
                                     {% for owner in task.owners %}
                                         <span class="chip truncate">
-                                            <img src="{{ gravatar(owner.email) }}" alt="{{ owner.displayname }}">
-                                            {{ owner.firstname }}&nbsp;{{ owner.lastname }}
+                                            <img src="{{ gravatar(owner.email) }}" alt="{{ owner.displayNameWithMemberNumber }}">
+                                            {{ owner.displayName }}
                                         </span>
                                     {% endfor %}
                                 </td>

--- a/app/Resources/views/emails/dismissed_shift.html.twig
+++ b/app/Resources/views/emails/dismissed_shift.html.twig
@@ -1,3 +1,3 @@
-Le bénévole {{ beneficiary.displayName }} a annulé le créneau {{ shift.job.name }} du {{ shift.start | date('d-m-Y') }} de {{ shift.start | date('G\\hi') }} à {{ shift.end | date('G\\hi') }}<br />
-Raison renseigné par le bénévole:<br />
+Le bénévole {{ beneficiary.displayNameWithMemberNumber }} a annulé le créneau {{ shift.job.name }} du {{ shift.start | date('d-m-Y') }} de {{ shift.start | date('G\\hi') }} à {{ shift.end | date('G\\hi') }}<br />
+Raison renseignée par le bénévole :<br />
 {{ reason }}

--- a/app/Resources/views/member/show.html.twig
+++ b/app/Resources/views/member/show.html.twig
@@ -1,6 +1,6 @@
 {% extends 'layout.html.twig' %}
 
-{% block title %}{{ member.autocompleteLabel }} - {{ site_name }}{% endblock %}
+{% block title %}{{ member.displayMemberNumber }} - {{ site_name }}{% endblock %}
 
 {% block breadcrumbs %}
 <a href="{{ path('homepage') }}"><i class="material-icons">home</i></a><i class="material-icons">chevron_right</i>
@@ -10,7 +10,7 @@
 {% else %}
     <a href="{{ path('user_office_tools') }}"><i class="material-icons">folder_shared</i>&nbsp;Adhésion et ré-adhésion</a><i class="material-icons">chevron_right</i>
 {% endif %}
-<i class="material-icons">person</i>&nbsp;{{ member.autocompleteLabel }}
+<i class="material-icons">person</i>&nbsp;{{ member.displayMemberNumber }}
 {% endblock %}
 
 {% block content %}

--- a/src/AppBundle/Entity/Beneficiary.php
+++ b/src/AppBundle/Entity/Beneficiary.php
@@ -150,7 +150,7 @@ class Beneficiary
 
     public function __toString()
     {
-        return $this->getDisplayName();
+        return $this->getDisplayNameWithMemberNumber();
     }
 
     /**
@@ -219,22 +219,32 @@ class Beneficiary
         return $this;
     }
 
-    public function getDisplayName()
+    public function getDisplayName(): string
     {
-        return '#' . $this->getMemberNumber() . ' ' . $this->getFirstname() . ' ' . $this->getLastname();
+        return $this->getFirstname() . ' ' . $this->getLastname();
     }
 
-    public function getDisplayNameWithStatusIcon(): string
+    public function getDisplayNameWithMemberNumber(): string
     {
-        $label = '#' . $this->getMembership()->getMemberNumber();
+        return '#' . $this->getMemberNumber() . ' ' . $this->getDisplayName();
+    }
+
+    public function getDisplayNameWithMemberNumberAndStatusIcon(): string
+    {
+        $label = '#' . $this->getMemberNumber();
         $label .= $this->getStatusIcon(true);
-        $label .=  ' ' . $this->getFirstname() . ' ' . $this->getLastname();
+        $label .=  ' ' . $this->getDisplayName();
         return $label;
     }
 
-    public function getPublicDisplayName()
+    public function getPublicDisplayName(): string
     {
-        return '#' . $this->getMemberNumber() . ' ' . $this->getFirstname() . ' ' . $this->getLastname()[0];
+        return $this->getFirstname() . ' ' . $this->getLastname()[0];
+    }
+
+    public function getPublicDisplayNameWithMemberNumber(): string
+    {
+        return '#' . $this->getMemberNumber() . ' ' . $this->getPublicDisplayName();
     }
 
     /**
@@ -617,7 +627,7 @@ class Beneficiary
 
     public function getAutocompleteLabelFull(): string
     {
-        $label = '#' . $this->getMembership()->getMemberNumber();
+        $label = '#' . $this->getMemberNumber();
 
         if($this->getMembership()->getWithdrawn()){
             $label .= " [&#x26A0;]";

--- a/src/AppBundle/Entity/Membership.php
+++ b/src/AppBundle/Entity/Membership.php
@@ -137,7 +137,7 @@ class Membership
 
     public function __toString()
     {
-        return '#'.$this->getMemberNumber();
+        return $this->getDisplayMemberNumber();
     }
 
     /**
@@ -663,8 +663,9 @@ class Membership
         return $this->given_proxies;
     }
 
-    public function getAutocompleteLabel(){
-        return '#'.$this->getMemberNumber();
+    public function getDisplayMemberNumber()
+    {
+        return '#' . $this->getMemberNumber();
     }
 
     /**

--- a/src/AppBundle/Monolog/MonologUserProcessor.php
+++ b/src/AppBundle/Monolog/MonologUserProcessor.php
@@ -23,7 +23,7 @@ class MonologUserProcessor
             $text = $user->getId();
             $beneficiary = $user->getBeneficiary();
             if ($beneficiary) {
-                $text .= ' (' . $beneficiary->getDisplayName() . ')';
+                $text .= ' (' . $beneficiary->getDisplayNameWithMemberNumber() . ')';
             }
             $record['extra']['user'] = $text;
         } else if ($user) {


### PR DESCRIPTION
Généraliser l'usage des méthodes suivantes : 
- `Beneficiary.getDisplayName()` & `Beneficiary.getDisplayNameWithMemberNumber()`
- `Beneficiary.getPublicDisplayName()` & `Beneficiary.getPublicDisplayNameWithMemberNumber()`
- renommé `displayName` en `displayNameWithMemberNumber`
- remplacé `autocompleteLabel` par `displayNameWithMemberNumber`
