### PR TITLE
Homogéniser et généraliser l'affichage de "libre"

### DIFF
--- a/app/Resources/views/admin/booking/_partial/bucket_card.html.twig
+++ b/app/Resources/views/admin/booking/_partial/bucket_card.html.twig
@@ -2,28 +2,26 @@
 {% set nbShifts = (bucket.shifts() | length) %}
 
 <div data-offset="{{ (((bucket.start|date('G')-start)*60 + bucket.start|date('i'))/60) }}" data-length="{{ (100/(end-start+1)) }}"
-    style="padding: 0 1px;width:{{ (bucket.duration / 60) * (100/(end-start+1)) }}%;position: absolute;left:{{ (((bucket.start|date('G')-start)*60 + bucket.start|date('i'))/60)*(100/(end-start+1)) }}%;top: {{ line*10 }}px;">
+    style="padding: 0 1px;width:{{ (bucket.duration / 60) * (100/(end-start+1)) }}%;position: absolute;left: {{ (((bucket.start|date('G')-start)*60 + bucket.start|date('i'))/60)*(100/(end-start+1)) }}%;top: {{ line*10 }}px;">
     <a href="#modal-bucket" data-source="{{ path('shift_show', { 'id': bucket.first.id }) }}" class="modal-trigger tooltipped" data-position="top" data-delay="100" data-tooltip="{{ bucket.first.job.name }}">
         <div class="z-depth-1 {% if bucket.first.locked %}blue-grey white-text{% else %}{{ bucket.first.job.color }} lighten-5 black-text{% endif %}" style="position: relative;height: 70px;">
-            <div style="height:2px; width: 100%;position: absolute;">
+            <div style="height:2px; width: 100%; position: absolute;">
                 {% if nbBookableShifts < nbShifts %}
                     {% for shifter in 1..(nbShifts - nbBookableShifts) %}
                         <div class="green lighten-3 left" style="height:100%; width: {{ 100/(nbShifts) }}%"></div>
                     {% endfor %}
                 {% endif %}
             </div>
-            <div style="position: absolute;width:60px;height: 70px;top: 0;left: 4px;transform: rotate(-90deg);text-align: center;font-size: 9px;">{{ bucket.start|date('G\\hi') }}
-                &nbsp;{{ bucket.end|date('G\\hi') }}
+            <div style="position: absolute;width:60px;height: 70px;top: 0;left: 4px;transform: rotate(-90deg);text-align: center;font-size: 9px;">
+                {{ bucket.start|date('G\\hi') }}&nbsp;{{ bucket.end|date('G\\hi') }}
             </div>
             <ul style="font-size: 9px; padding-left: 15px;">
                 {% set shiftercount = 0 %}
                 {% for shift in bucket.sortedShifts() %}
-                    {% if (shift.shifter) %}{# is booked #}
-                        {% if (shiftercount < 4) %}
+                    {% if (shiftercount < 4) %}
+                        {% if (shift.shifter) %}{# is booked #}
                             <li class="{% if shift.isDismissed() %}red-text{% endif %}">
-                                {% if shift.formation %}
-                                    <b data-formation="{{ shift.formation.name }}">
-                                {% endif %}
+                                {% if shift.formation %}<b data-formation="{{ shift.formation.name }}">{% endif %}
                                 {% if use_card_reader_to_validate_shifts and shift.isPastOrCurrent %}
                                     <span class="{% if shift.wasCarriedOut %}green-text{% else %}red-text{% endif %}">&#9673;</span>&nbsp;
                                 {% endif %}
@@ -32,10 +30,19 @@
                                 {% if not shift.formation and shift.shifter.formations | length > 0 %}&nbsp;<b class="orange-text">(q)</b>{% endif %}
                             </li>
                             {% set shiftercount = shiftercount + 1 %}
-                        {% elseif shiftercount == 4 %}
-                            <li>( ... )</li>
-                            {% set shiftercount = shiftercount + 1 %}
+                        {% else %}
+                            <li>
+                                <b>
+                                    {% if use_card_reader_to_validate_shifts and shift.isPastOrCurrent %}
+                                        <span class="{% if shift.wasCarriedOut %}green-text{% else %}red-text{% endif %}">&#9673;</span>&nbsp;
+                                    {% endif %}
+                                    <i>libre</i>
+                                </b>
+                            </li>
                         {% endif %}
+                    {% elseif shiftercount == 4 %}
+                        <li>( ... )</li>
+                        {% set shiftercount = shiftercount + 1 %}
                     {% endif %}
                 {% endfor %}
             </ul>

--- a/app/Resources/views/admin/period/index.html.twig
+++ b/app/Resources/views/admin/period/index.html.twig
@@ -76,7 +76,8 @@
             </a>
         {% else %}
             <div class="tooltipped truncate black-text" data-position="bottom" data-tooltip="{{ formation }}">
-                <i class="material-icons">person</i> Libre
+                <i class="material-icons">person</i>
+                <strong><i>libre</i></strong>
             </div>
         {% endif %}
     {% endmacro one_line_shifter %}

--- a/app/Resources/views/default/card_reader.html.twig
+++ b/app/Resources/views/default/card_reader.html.twig
@@ -20,8 +20,22 @@
                 {% set nbShifts = (bucket.shifts() | length) %}
                 {% set shiftercount = 0 %}
 
+                {# calculate the number of shifters on this shift #}
+                {% for shift in bucket.shifts %}
+                    {% if shift.shifter %}
+                        {% set shiftercount = shiftercount + 1 %}
+                    {% endif %}
+                {% endfor %}
+
                 <div class="card sticky-action">
                     <div class="card-content {{ bucket.job.color }} lighten-4">
+                        {% if (shiftercount == 0) %}
+                            <div class="red-text" style="height: 30px">
+                                <i class="material-icons tiny">warning</i>
+                                Personne n'est inscrit sur ce créneau
+                                <i class="material-icons tiny">warning</i>
+                            </div>
+                        {% endif %}
                         <div class="card-title activator">
                             <b class="{{ bucket.job.color }}-text">{{ bucket.job.name }}</b> /
                             <b>{{ bucket.start | date('H:i') }} à {{ bucket.end | date('H:i') }}</b>
@@ -36,7 +50,6 @@
                                             </span>&nbsp;
                                         {% endif %}
                                         {% if shift.shifter %}
-                                            {% set shiftercount = shiftercount + 1 %}
                                             <span style="margin-right: 5px; font-size: 16px">{{ shift.shifter.publicDisplayName }}</span>
                                         {% else %}
                                             <strong><i>libre</i></strong>
@@ -50,15 +63,6 @@
                                     </div>
                                 </li>
                             {% endfor %}
-                            {% if (shiftercount == 0) %}
-                                <li style="height: 30px">
-                                    <span class="red-text" style="margin-right: 5px; font-size: 16px">
-                                        <i class="material-icons tiny">warning</i>
-                                        Personne n'est inscrit sur ce créneau
-                                        <i class="material-icons tiny">warning</i>
-                                    </span>
-                                </li>
-                            {% endif %}
                         </ul>
                     </div>
                 </div>

--- a/app/Resources/views/default/card_reader.html.twig
+++ b/app/Resources/views/default/card_reader.html.twig
@@ -17,6 +17,8 @@
             <h5>Créneaux à venir</h5>
 
             {% for bucket in buckets %}
+                {% set nbShifts = (bucket.shifts() | length) %}
+                {% set shiftercount = 0 %}
 
                 <div class="card sticky-action">
                     <div class="card-content {{ bucket.job.color }} lighten-4">
@@ -28,25 +30,35 @@
                             {% for shift in bucket.shifts %}
                                 <li style="height: 30px">
                                     <div>
+                                        {% if use_card_reader_to_validate_shifts %}
+                                            <span class="{% if shift.wasCarriedOut %}green-text{% endif %}">
+                                                &#9673;
+                                            </span>&nbsp;
+                                        {% endif %}
                                         {% if shift.shifter %}
-                                            {% if use_card_reader_to_validate_shifts %}
-                                                <span class="{% if shift.wasCarriedOut %}green-text{% endif %}">
-                                                    &#9673;
-                                                </span>&nbsp;
-                                            {% endif %}
+                                            {% set shiftercount = shiftercount + 1 %}
                                             <span style="margin-right: 5px; font-size: 16px">{{ shift.shifter.publicDisplayName }}</span>
-                                            {% if shift.formation %}
-                                                <span class="chip" style="margin-left: 5px"><b>{{ shift.formation }}</b></span>
-                                            {% endif %}
-                                            {% if shift.shifter.shifts | length == 1 %}
-                                                <span class="chip red white-text" style="margin-left: 5px">Premier créneau</span>
-                                            {% endif %}
                                         {% else %}
-                                            <span style="margin-right: 5px; font-size: 16px">&#10071&#10071 Personne n'est inscrit sur ce créneau &#10071&#10071</span>
+                                            <strong><i>libre</i></strong>
+                                        {% endif %}
+                                        {% if shift.formation %}
+                                            <span class="chip" style="margin-left: 5px"><b>{{ shift.formation }}</b></span>
+                                        {% endif %}
+                                        {% if shift.shifter and shift.shifter.shifts | length == 1 %}
+                                            <span class="chip red white-text" style="margin-left: 5px">Premier créneau</span>
                                         {% endif %}
                                     </div>
                                 </li>
                             {% endfor %}
+                            {% if (shiftercount == 0) %}
+                                <li style="height: 30px">
+                                    <span class="red-text" style="margin-right: 5px; font-size: 16px">
+                                        <i class="material-icons tiny">warning</i>
+                                        Personne n'est inscrit sur ce créneau
+                                        <i class="material-icons tiny">warning</i>
+                                    </span>
+                                </li>
+                            {% endif %}
                         </ul>
                     </div>
                 </div>

--- a/src/AppBundle/Controller/DefaultController.php
+++ b/src/AppBundle/Controller/DefaultController.php
@@ -198,7 +198,7 @@ class DefaultController extends Controller
         $em = $this->getDoctrine()->getManager();
         $shifts = $em->getRepository('AppBundle:Shift')->findRemainingToday();
         $buckets = $this->get('shift_service')->generateShiftBuckets($shifts);
-        $buckets = $this->get('shift_service')->removeEmptyShift($buckets);
+        // $buckets = $this->get('shift_service')->removeEmptyShift($buckets);
 
         $dynamicContent = $em->getRepository('AppBundle:DynamicContent')->findOneByCode('CARD_READER')->getContent();
 


### PR DESCRIPTION
### Quoi ?

Modifications apportées : 
- Admin > Gérer les créneaux > visibiliser les créneaux qui sont "libre"
- Admin > Semaine type > homogéniser l'affichage de "libre" (avec son affichage ailleurs)

### Captures d'écran

||Avant|Après|
|---|---|---|
|Gérer les créneaux (créneau à venir)|![Screenshot from 2022-11-17 13-29-10](https://user-images.githubusercontent.com/7147385/202446672-5568aa16-c1cb-469c-8323-b28badd9d4c5.png)|![Screenshot from 2022-11-17 13-28-54](https://user-images.githubusercontent.com/7147385/202446695-0817aa52-b9b5-4e61-9bb3-e426095b7a81.png)|
|Gérer les créneaux (créneau passé)|![Screenshot from 2022-11-17 13-29-20](https://user-images.githubusercontent.com/7147385/202446792-72891672-7d53-47f1-ae08-54a238991a6d.png)|![Screenshot from 2022-11-17 13-28-18](https://user-images.githubusercontent.com/7147385/202446926-e0309921-c959-44ec-9144-62c035b55364.png)|
|Semaine type|![Screenshot from 2022-11-17 13-24-34](https://user-images.githubusercontent.com/7147385/202446181-0a7a6675-7459-4f08-8eab-81e99645b7ca.png)|![Screenshot from 2022-11-17 13-24-08](https://user-images.githubusercontent.com/7147385/202446193-cf536a8c-ad38-455a-943b-d5ef0152ce6b.png)|
|/cardReader|![Screenshot from 2022-11-17 13-48-09](https://user-images.githubusercontent.com/7147385/202450760-df701592-02f8-4677-b285-7eba804967b5.png)|![Screenshot from 2022-11-17 13-47-32](https://user-images.githubusercontent.com/7147385/202450809-7b8bcf35-28fe-4894-aece-8175531e97d0.png)|