### PR TITLE
Joindre deux comptes : rajout de vérifications

### DIFF
--- a/app/Resources/views/admin/member/join.html.twig
+++ b/app/Resources/views/admin/member/join.html.twig
@@ -11,8 +11,14 @@
 {% block content %}
     <h4>Joindre deux comptes</h4>
 
-    <p class="red-text"><i class="material-icons">warning</i>Attention, le compte choisi en première position va être <b>détruit</b> et les bénéficiaires ajoutés au compte choisi en deuxième
-        <br>
+    <p>Nombre maximum de bénéficiaires par compte : {{ maximum_nb_of_beneficiaries_in_membership }}</p>
+
+    <p class="red-text">
+        <i class="material-icons">warning</i>
+        Attention, le compte choisi à gauche va être <b>détruit</b>.
+        <br />
+        Il sera rajouté en tant que bénéficiaire du compte choisi à droite.
+        <br />
         <b>Cette opération ne peut pas être annulée.</b>
     </p>
 


### PR DESCRIPTION
Actuellement il n'y a pas beaucoup de vérifications sur l'action "joindre deux comptes".

J'ai rajouté quelques checks pour éviter : 
- de joindre un compte à un même compte
- de joindre des comptes qui ont déjà le nombre maximum de bénéficiaires
- que le compte final dépasse le nombre maximal de bénéficiaires

J'ai aussi clarifié le message en rouge sur cette page.