### PR TITLE
Ordonnancer l'affichage des créneaux des membres

### DIFF
--- a/app/Resources/views/booking/home_booked_shifts.html.twig
+++ b/app/Resources/views/booking/home_booked_shifts.html.twig
@@ -34,9 +34,8 @@
                 </div>
             </li>
         {% endif %}
-        {% for cycle in 0..1 %}
-            {% set shiftsOfCycle = member.getShiftsOfCycle(cycle) %}
-            {% if shiftsOfCycle | length > 0 %}
+        {% for cycle, shiftsOfCycle in shiftsByCycle %}
+            {% if (cycle in [0, 1]) and (shiftsOfCycle | length > 0) %}
                 <li class="active">
                     <div class="collapsible-header">
                         <i class="material-icons">date_range</i>{% if member.beneficiaries | length > 1 %}Vos{% else %}Mes{% endif %} créneaux pour le cycle {% if cycle == 0 %}courant{% else %}suivant{% endif %} (du {{ member.startOfCycle(cycle) | date_fr_long }} au {{ member.endOfCycle(cycle) | date_fr_long }})
@@ -64,7 +63,7 @@
                         {% for cycle in -1..-2 %}
                             {% if shift_service.hasCycle(member, cycle) %}
                                 <div class="col s12 m6 l4">
-                                    {% set previousShifts = member.getShiftsOfCycle(cycle) %}
+                                    {% set previousShifts = shiftsByCycle[cycle] %}
                                     <h6>Cycle précédent (du {{ member.startOfCycle(cycle) | date('d/m/y') }} au {{ member.endOfCycle(cycle) | date('d/m/y') }})</h6>
                                     {% if previousShifts|length == 0 %}
                                         Pas de créneau

--- a/app/Resources/views/member/_partial/shifts.html.twig
+++ b/app/Resources/views/member/_partial/shifts.html.twig
@@ -1,7 +1,4 @@
 {% set firstShiftDate = member.firstShiftDate %}
-{% set previousShifts = member.getShiftsOfCycle(-1) %}
-{% set currentShifts = member.getShiftsOfCycle() %}
-{% set nextShifts = member.getShiftsOfCycle(1) %}
 
 {% if use_fly_and_fixed %}
     <div class="row">
@@ -18,40 +15,27 @@
     </div>
 {% endif %}
 
-<div class="row">
-    <h6>Cycle précédent (du {{ member.startOfCycle(-1) | date_fr_long }} au {{ member.endOfCycle(-1) | date_fr_long }})</h6>
-    {% if previousShifts | length == 0 %}
-        Pas de créneau
-    {% endif %}
-    {% for shift in previousShifts %}
-        <div class="col s12 m6 l4">
-            {% include "user/_partial/shift_card.html.twig" with { shift: shift } %}
-        </div>
-    {% endfor %}
-</div>
-
-<div class="row">
-    <h6>Cycle en cours (du {{ member.startOfCycle | date_fr_long }} au {{ member.endOfCycle | date_fr_long }})</h6>
-    {% if currentShifts | length == 0 %}
-        Pas de créneau
-    {% endif %}
-    {% for shift in currentShifts %}
-        <div class="col s12 m6 l4">
-            {% include "user/_partial/shift_card.html.twig" with { shift: shift } %}
-        </div>
-    {% endfor %}
-</div>
-
-<div class="row">
-    <h6>Prochain cycle (du {{ member.startOfCycle(1) | date_fr_long }} au {{ member.endOfCycle(1) | date_fr_long }})</h6>
-    {% if nextShifts | length == 0 %}
-        Pas de créneau
-    {% endif %}
-    {% for shift in nextShifts %}
-        <div class="col s12 m6 l4">
-            {% include "user/_partial/shift_card.html.twig" with { shift: shift } %}
-        </div>
-    {% endfor %}
-</div>
+{% for cycle, shifts in shifts_by_cycle %}
+    <div class="row">
+        <h6>
+            {% if cycle == -1 %}
+                Cycle précédent
+            {% elseif cycle == 0 %}
+                Cycle en cours
+            {% elseif cycle == 1 %}
+                Prochain cycle
+            {% endif %}
+            (du {{ member.startOfCycle(cycle) | date_fr_long }} au {{ member.endOfCycle(cycle) | date_fr_long }})
+        </h6>
+        {% if shifts | length == 0 %}
+            Pas de créneau
+        {% endif %}
+        {% for shift in shifts %}
+            <div class="col s12 m6 l4">
+                {% include "user/_partial/shift_card.html.twig" with { shift: shift } %}
+            </div>
+        {% endfor %}
+    </div>
+{% endfor %}
 
 <p>Date du tout premier créneau : {% if firstShiftDate %}{{ firstShiftDate|date_fr_full }}{% else %}Néant{% endif %}</p>

--- a/src/AppBundle/Command/CycleHalfCommand.php
+++ b/src/AppBundle/Command/CycleHalfCommand.php
@@ -43,7 +43,8 @@ class CycleHalfCommand extends ContainerAwareCommand
         $members_with_half_cycle = $em->getRepository('AppBundle:Membership')->findWithHalfCyclePast($date);
         $count = 0;
         foreach ($members_with_half_cycle as $member) {
-            $dispatcher->dispatch(MemberCycleHalfEvent::NAME, new MemberCycleHalfEvent($member, $date));
+            $currentCycleShifts = $em->getRepository('AppBundle:Shift')->findShiftsOfCycle($member);
+            $dispatcher->dispatch(MemberCycleHalfEvent::NAME, new MemberCycleHalfEvent($member, $date, $currentCycleShifts));
             $message = 'Generate ' . MemberCycleHalfEvent::NAME . ' event for member #' . $member->getMemberNumber();
             $output->writeln($message);
             $count++;

--- a/src/AppBundle/Command/FixTimeLogCommand.php
+++ b/src/AppBundle/Command/FixTimeLogCommand.php
@@ -28,9 +28,7 @@ class FixTimeLogCommand extends ContainerAwareCommand
         foreach ($members as $member) {
             if ($member->getFirstShiftDate()) {
 
-                $lastCycleShifts = $member->getShiftsOfCycle(-1, true)->toArray();
-                $currentCycleShifts = $member->getShiftsOfCycle(0, true)->toArray();
-                $shifts = array_merge($lastCycleShifts, $currentCycleShifts);
+                $shifts = $em->getRepository('AppBundle:Shift')->findShiftsOfCycle($member, -1, 0, true);
                 foreach ($shifts as $shift) {
 
                     $logs = $member->getTimeLogs()->filter(function ($log) use ($shift) {

--- a/src/AppBundle/Command/InitTimeLogCommand.php
+++ b/src/AppBundle/Command/InitTimeLogCommand.php
@@ -37,9 +37,7 @@ class InitTimeLogCommand extends ContainerAwareCommand
         foreach ($members as $member) {
             if ($member->getFirstShiftDate()) {
 
-                $lastCycleShifts = $member->getShiftsOfCycle(-1, true)->toArray();
-                $currentCycleShifts = $member->getShiftsOfCycle(0, true)->toArray();
-                $shifts = array_merge($lastCycleShifts, $currentCycleShifts);
+                $shifts = $em->getRepository('AppBundle:Shift')->findShiftsOfCycle($member, -1, 0, true);
                 foreach ($shifts as $shift) {
                     $this->createShiftLog($em, $shift, $member);
                     $countShiftLogs++;

--- a/src/AppBundle/Controller/BookingController.php
+++ b/src/AppBundle/Controller/BookingController.php
@@ -66,14 +66,17 @@ class BookingController extends Controller
             ->add('shift_id', HiddenType::class)
             ->getForm();
 
-        $beneficiaries = $this->getUser()->getBeneficiary()->getMembership()->getBeneficiaries();
+        $membership = $this->getUser()->getBeneficiary()->getMembership();
+        $beneficiaries = $membership->getBeneficiaries();
 
         $em = $this->getDoctrine()->getManager();
+        $shiftsByCycle = $em->getRepository('AppBundle:Shift')->findShiftsByCycles($membership, -2, 1);
         $period_positions = $em->getRepository('AppBundle:PeriodPosition')->findByBeneficiaries($beneficiaries);
 
         return $this->render('booking/home_booked_shifts.html.twig', array(
             'shift_undismiss_form' => $shiftUndismissForm->createView(),
             'period_positions' => $period_positions,
+            'shiftsByCycle' => $shiftsByCycle,
         ));
     }
 

--- a/src/AppBundle/Controller/MembershipController.php
+++ b/src/AppBundle/Controller/MembershipController.php
@@ -160,6 +160,7 @@ class MembershipController extends Controller
 
         $em = $this->getDoctrine()->getManager();
         $period_positions = $em->getRepository('AppBundle:PeriodPosition')->findByBeneficiaries($member->getBeneficiaries());
+        $shifts_by_cycle = $em->getRepository('AppBundle:Shift')->findShiftsByCycles($member, -1, 1);
 
         return $this->render('member/show.html.twig', array(
             'member' => $member,
@@ -181,6 +182,7 @@ class MembershipController extends Controller
             'time_log_form' => $timeLogForm->createView(),
             'period_positions' => $period_positions,
             'in_progress_and_upcoming_shifts' => $member->getInProgressAndUpcomingShifts(),
+            'shifts_by_cycle' => $shifts_by_cycle,
         ));
     }
 

--- a/src/AppBundle/Entity/Membership.php
+++ b/src/AppBundle/Entity/Membership.php
@@ -497,47 +497,6 @@ class Membership
         return false;
     }
 
-    /**
-     * Get total shift duration for current cycle
-     */
-    public function getCycleShiftsDuration($cycleOffset = 0, $excludeDismissed = false)
-    {
-        $duration = 0;
-        foreach ($this->getShiftsOfCycle($cycleOffset, $excludeDismissed) as $shift) {
-            $duration += $shift->getDuration();
-        }
-        return $duration;
-    }
-
-    /**
-     * Get all shifts for all beneficiaries
-     * @param bool $excludeDismissed
-     * @return ArrayCollection|\Doctrine\Common\Collections\Collection
-     */
-    public function getAllShifts($excludeDismissed = false)
-    {
-        $shifts = new ArrayCollection();
-        foreach ($this->getBeneficiaries() as $beneficiary) {
-            foreach ($beneficiary->getShifts() as $shift) {
-                $shifts->add($shift);
-            }
-        }
-        // merge shifts of multiple beneficiaries
-        if ($this->getBeneficiaries()->count() > 1) {
-            $iterator = $shifts->getIterator();
-            $iterator->uasort(function ($a, $b) {
-                return $a->getStart() < $b->getStart();  // DESC (default $beneficiary->shifts order)
-            });
-            $shifts = new ArrayCollection(iterator_to_array($iterator));
-        }
-        if ($excludeDismissed) {
-            return $shifts->filter(function($shift) {
-                return !$shift->getIsDismissed();
-            });
-        } else {
-            return $shifts;
-        }
-    }
 
     /**
      * Get all in progress & upcoming shifts for all beneficiaries
@@ -566,19 +525,6 @@ class Membership
         return $shifts;
     }
 
-    /**
-     * Get shifts of a specific cycle
-     * @param $cycleOffset int to chose a cycle (0 for current cycle, 1 for next, -1 for previous)
-     * @param bool $excludeDismissed
-     * @return ArrayCollection|\Doctrine\Common\Collections\Collection
-     */
-    public function getShiftsOfCycle($cycleOffset = 0, $excludeDismissed = false)
-    {
-        return $this->getAllShifts($excludeDismissed)->filter(function($shift) use ($cycleOffset) {
-            return $shift->getStart() > $this->startOfCycle($cycleOffset) &&
-                $shift->getEnd() < $this->endOfCycle($cycleOffset);
-        });
-    }
 
     /**
      * Get start date of current cycle

--- a/src/AppBundle/Entity/Membership.php
+++ b/src/AppBundle/Entity/Membership.php
@@ -522,6 +522,14 @@ class Membership
                 $shifts->add($shift);
             }
         }
+        // merge shifts of multiple beneficiaries
+        if ($this->getBeneficiaries()->count() > 1) {
+            $iterator = $shifts->getIterator();
+            $iterator->uasort(function ($a, $b) {
+                return $a->getStart() < $b->getStart();  // DESC (default $beneficiary->shifts order)
+            });
+            $shifts = new ArrayCollection(iterator_to_array($iterator));
+        }
         if ($excludeDismissed) {
             return $shifts->filter(function($shift) {
                 return !$shift->getIsDismissed();

--- a/src/AppBundle/Event/MemberCycleHalfEvent.php
+++ b/src/AppBundle/Event/MemberCycleHalfEvent.php
@@ -11,11 +11,13 @@ class MemberCycleHalfEvent extends Event
 
     private $membership;
     private $date;
+    private $currentCycleShifts;
 
-    public function __construct(Membership $membership, \DateTime $date)
+    public function __construct(Membership $user, \DateTime $date, $currentCycleShifts)
     {
-        $this->membership = $membership;
+        $this->membership = $user;
         $this->date = $date;
+        $this->currentCycleShifts = $currentCycleShifts;
     }
 
     /**
@@ -32,6 +34,14 @@ class MemberCycleHalfEvent extends Event
     public function getDate()
     {
         return $this->date;
+    }
+
+    /**
+     * @return array
+     */
+    public function getCurrentCycleShifts()
+    {
+        return $this->currentCycleShifts;
     }
 
 }

--- a/src/AppBundle/Event/MemberCycleStartEvent.php
+++ b/src/AppBundle/Event/MemberCycleStartEvent.php
@@ -11,11 +11,13 @@ class MemberCycleStartEvent extends Event
 
     private $membership;
     private $date;
+    private $currentCycleShifts;
 
-    public function __construct(Membership $user, \DateTime $date)
+    public function __construct(Membership $user, \DateTime $date, $currentCycleShifts)
     {
         $this->membership = $user;
         $this->date = $date;
+        $this->currentCycleShifts = $currentCycleShifts;
     }
 
     /**
@@ -32,6 +34,14 @@ class MemberCycleStartEvent extends Event
     public function getDate()
     {
         return $this->date;
+    }
+
+    /**
+     * @return array
+     */
+    public function getCurrentCycleShifts()
+    {
+        return $this->currentCycleShifts;
     }
 
 }

--- a/src/AppBundle/EventListener/EmailingEventListener.php
+++ b/src/AppBundle/EventListener/EmailingEventListener.php
@@ -298,12 +298,18 @@ class EmailingEventListener
 
         $membership = $event->getMembership();
         $date = $event->getDate();
+        $currentCycleShifts = $event->getCurrentCycleShifts();
 
         $router = $this->container->get('router');
         $home_url = $router->generate('homepage', array(), UrlGeneratorInterface::ABSOLUTE_URL);
 
+        // Compute cycleShiftsDuration
+        $cycleShiftsDuration = 0;
+        foreach ($currentCycleShifts as $shift) {
+            $cycleShiftsDuration += $shift->getDuration();
+        }
         // member wont be frozen for this cycle && not a fresh new member && member still have to book
-        if (!$membership->getFrozen() && $membership->getFirstShiftDate() < $date && $membership->getCycleShiftsDuration() < $this->due_duration_by_cycle) {
+        if (!$membership->getFrozen() && $membership->getFirstShiftDate() < $date && $cycleShiftsDuration < $this->due_duration_by_cycle) {
             foreach ($membership->getBeneficiaries() as $beneficiary){
                 $mail = (new \Swift_Message('[ESPACE MEMBRES] Début de ton cycle, réserve tes créneaux'))
                     ->setFrom($this->shiftEmail['address'], $this->shiftEmail['from_name'])
@@ -331,11 +337,17 @@ class EmailingEventListener
 
         $membership = $event->getMembership();
         $date = $event->getDate();
+        $currentCycleShifts = $event->getCurrentCycleShifts();
 
         $router = $this->container->get('router');
         $home_url = $router->generate('homepage', array(), UrlGeneratorInterface::ABSOLUTE_URL);
 
-        if ($membership->getFirstShiftDate() < $date && $membership->getCycleShiftsDuration() < $this->due_duration_by_cycle) { //only if member still have to book
+        // Compute cycleShiftsDuration
+        $cycleShiftsDuration = 0;
+        foreach ($currentCycleShifts as $shift) {
+            $cycleShiftsDuration += $shift->getDuration();
+        }
+        if ($membership->getFirstShiftDate() < $date && $cycleShiftsDuration < $this->due_duration_by_cycle) { //only if member still have to book
             $mail = (new \Swift_Message('[ESPACE MEMBRES] déjà la moitié de ton cycle, un tour sur ton espace membre ?'))
                 ->setFrom($this->shiftEmail['address'], $this->shiftEmail['from_name'])
                 ->setTo($membership->getMainBeneficiary()->getEmail())

--- a/src/AppBundle/EventListener/TimeLogEventListener.php
+++ b/src/AppBundle/EventListener/TimeLogEventListener.php
@@ -143,7 +143,8 @@ class TimeLogEventListener
 
         $dispatcher = $this->container->get('event_dispatcher');
         if (!$member->getFrozen()) {
-            $dispatcher->dispatch(MemberCycleStartEvent::NAME, new MemberCycleStartEvent($member, $date));
+            $currentCycleShifts = $this->em->getRepository('AppBundle:Shift')->findShiftsOfCycle($member);
+            $dispatcher->dispatch(MemberCycleStartEvent::NAME, new MemberCycleStartEvent($member, $date, $currentCycleShifts));
         }
     }
 

--- a/src/AppBundle/Repository/PeriodPositionRepository.php
+++ b/src/AppBundle/Repository/PeriodPositionRepository.php
@@ -20,7 +20,10 @@ class PeriodPositionRepository extends \Doctrine\ORM\EntityRepository
     {
         $qb = $this->createQueryBuilder('pp');
         $qb->where('pp.shifter = :shifter')
-            ->setParameter('shifter', $beneficiary);
+            ->setParameter('shifter', $beneficiary)
+            ->leftJoin('pp.period', 'p')
+            ->addOrderBy('p.dayOfWeek', 'ASC')
+            ->addOrderBy('p.start', 'ASC');
 
         return $qb->getQuery()->getResult();
     }
@@ -36,7 +39,10 @@ class PeriodPositionRepository extends \Doctrine\ORM\EntityRepository
         $qb->where('pp.shifter IN (:shiftersId)')
             ->setParameter('shiftersId', array_map(function(Beneficiary $beneficiary) {
                 return $beneficiary->getId();
-            }, $beneficiaries->toArray()));
+            }, $beneficiaries->toArray()))
+            ->leftJoin('pp.period', 'p')
+            ->addOrderBy('p.dayOfWeek', 'ASC')
+            ->addOrderBy('p.start', 'ASC');
 
         return $qb->getQuery()->getResult();
     }

--- a/src/AppBundle/Security/CodeVoter.php
+++ b/src/AppBundle/Security/CodeVoter.php
@@ -119,21 +119,23 @@ class CodeVoter extends Voter
         }
 
         if ($user->getBeneficiary()) {
-            if ($this->container->get("shift_service")->isBeginner($user->getBeneficiary())) // not for beginner
+            if ($this->container->get("shift_service")->isBeginner($user->getBeneficiary())) { // not for beginner
                 return false;
-            $shifts = $user->getBeneficiary()->getMembership()->getShiftsOfCycle(0);
-            $y = new \DateTime('Yesterday');
-            $y->setTime(23, 59, 59);
-            $some_time_ago = new \DateTime();
-            $in_some_time = new \DateTime();
-            $some_time_ago->sub(new \DateInterval("PT2H")); //time - 120min TODO put in conf
-            $in_some_time->add(new \DateInterval("PT1H")); //time + 60min TODO put in conf
-            foreach ($shifts as $shift) {
-                if (($shift->getStart() < $in_some_time) && // dans une heure il sera commencé
-                    $shift->getStart() > $y && // le début est aujourd'hui (après hier 23h59:59)
-                    ($shift->getEnd() > $some_time_ago)) { // il y a deux heure il n'était pas fini
-                    return true;
-                }
+            }
+
+            $start_after = new \DateTime('Yesterday');
+            $start_after->setTime(23, 59, 59);
+            $start_before = new \DateTime();
+            $start_before->sub(new \DateInterval("PT2H")); //time - 120min TODO put in conf
+            $end_before = new \DateTime();
+            $end_before->add(new \DateInterval("PT1H")); //time + 60min TODO put in conf
+
+            if (!$this->container->get("shift_service")->isBeneficiaryHasShifts($user->getBeneficiary(),
+                $start_before,
+                $start_after,
+                $end_before)
+            ) {
+                return false;
             }
         }
 

--- a/src/AppBundle/Service/ShiftService.php
+++ b/src/AppBundle/Service/ShiftService.php
@@ -449,4 +449,21 @@ class ShiftService
         return $buckets;
     }
 
+
+    /**
+     * Check if the beneficiary has shifts that match parameters
+     * @param Beneficiary $beneficiary
+     * @param Datetime $start_before
+     * @param Datetime $start_after
+     * @param Datetime $end_before
+     * @return bool
+     */
+    public function isBeneficiaryHasShifts(Beneficiary $beneficiary, \Datetime $start_before, \Datetime $start_after, \Datetime $end_before)
+    {
+        return count($this->em->getRepository('AppBundle:Shift')->findShifts($beneficiary,
+                $start_before,
+                $start_after,
+                $end_before)) > 0;
+    }
+
 }


### PR DESCRIPTION
### Quoi ?

Lorsqu'un bénéficiaire souhaite afficher ses créneaux, ils sont ordonnés par le "plus récent d'abord".

Mais : 
- si un membre a plusieurs bénéficiaires, l'ordre d'affichage de ses créneaux est mélangé entre les bénéficiaires
- les créneaux fixe n'ont pas d'ordre particulier

### Captures d'écran

||Avant|Après|
|---|---|---|
|Créneaux cycles|![Screenshot from 2022-11-17 18-23-05](https://user-images.githubusercontent.com/7147385/202528952-e4eaf425-6e74-45c4-a2ae-975635b2ca88.png)|![Screenshot from 2022-11-17 18-33-52](https://user-images.githubusercontent.com/7147385/202528976-fe709059-e43a-4d52-a9ba-fc277837d31d.png)|
|Créneaux fixe|![Screenshot from 2022-11-17 19-26-10](https://user-images.githubusercontent.com/7147385/202529140-50f89714-632a-41a4-9174-169f9f38d1f9.png)|![Screenshot from 2022-11-17 19-25-20](https://user-images.githubusercontent.com/7147385/202529119-16a29ba9-8317-44fd-91d3-b9a34fedfd09.png)|

