### PR TITLE
Créneaux type : améliorations cosmétiques & d'url

### DIFF
--- a/app/Resources/views/admin/period/edit.html.twig
+++ b/app/Resources/views/admin/period/edit.html.twig
@@ -47,7 +47,7 @@
                             </div>
                             <div class="collapsible-body">
                                 Créneau fixe réservé le <i>{{ position.bookedTime | date_fr_with_time }}</i> par {% if position.booker and position.booker.beneficiary %}<a href="{{ path("member_show",{ 'member_number': position.booker.beneficiary.membership.memberNumber }) }}">{{ position.booker.beneficiary }}</a>{% else %}{{ position.booker }}{% endif %}.
-                                <form action="{{ path('free_position_from_period', {'id' : position.id }) }}" method="post" id="free_position_{{ position.id }}">
+                                <form action="{{ path('free_position_from_period', {'id': period.id, 'position' : position.id }) }}" method="post" id="free_position_{{ position.id }}">
                                     <button type="submit" class="btn orange">
                                         <i class="material-icons left">lock_open</i>Libérer
                                     </button>

--- a/app/Resources/views/admin/period/edit.html.twig
+++ b/app/Resources/views/admin/period/edit.html.twig
@@ -20,9 +20,25 @@
     {{ form_end(form) }}
 
     {% if is_granted("ROLE_ADMIN") %}
-        <a href="#remove-period" class="modal-trigger btn waves-effect waves-light red" title="supprimer le créneau type">
+        <a href="#remove-period-confirmation-modal" class="modal-trigger btn waves-effect waves-light red" title="supprimer le créneau type">
             Supprimer
         </a>
+        {{ form_start(delete_form) }}
+        <div id="remove-period-confirmation-modal" class="modal">
+            <div class="modal-content">
+                <h5><i class="material-icons left small">remove_circle_outline</i>Supprimer le créneau type</h5>
+                <p>Attention, cela va aussi supprimer tous les postes de ce créneau type.</p>
+            </div>
+            <div class="modal-footer">
+                <a href="#!" class="modal-action modal-close waves-effect waves-green btn-flat green-text">
+                    Retour à la raison
+                </a>
+                <button type="submit" class="btn waves-effect waves-light orange">
+                    <i class="material-icons left">check</i>Je sais ce que je fais !
+                </button>
+            </div>
+        </div>
+        {{ form_end(delete_form) }}
     {% endif %}
 
     <h5>Postes disponibles</h5>
@@ -46,7 +62,7 @@
                                 </div>
                             </div>
                             <div class="collapsible-body">
-                                Créneau fixe réservé pour <a href="{{ path("member_show",{ 'member_number': position.shifter.membership.memberNumber }) }}">{{ position.shifter }}</a> le <i>{{ position.bookedTime | date_fr_with_time }}</i> par {% if position.booker and position.booker.beneficiary %}<a href="{{ path("member_show",{ 'member_number': position.booker.beneficiary.membership.memberNumber }) }}">{{ position.booker.beneficiary }}</a>{% else %}{{ position.booker }}{% endif %}.
+                                Créneau fixe réservé pour <a href="{{ path("member_show", { 'member_number': position.shifter.membership.memberNumber }) }}">{{ position.shifter }}</a> le <i>{{ position.bookedTime | date_fr_with_time }}</i> par {% if position.booker and position.booker.beneficiary %}<a href="{{ path("member_show", { 'member_number': position.booker.beneficiary.membership.memberNumber }) }}">{{ position.booker.beneficiary }}</a>{% else %}{{ position.booker }}{% endif %}.
                                 <form action="{{ path('free_position_from_period', {'id': period.id, 'position' : position.id }) }}" method="post" id="free_position_{{ position.id }}">
                                     <button type="submit" class="btn orange">
                                         <i class="material-icons left">lock_open</i>Libérer
@@ -71,23 +87,23 @@
                                 </div>
                             </div>
                             <div class="collapsible-body">
-                                {{ form_start(pp_book_forms[position.id]) }}
+                                {{ form_start(positions_book_forms[position.id]) }}
                                 <div class="row">
                                     <div class="col s7 input-field">
-                                        {{ form_label(pp_book_forms[position.id].shifter) }}
-                                        {{ form_errors(pp_book_forms[position.id].shifter) }}
-                                        {{ form_widget(pp_book_forms[position.id].shifter) }}
+                                        {{ form_label(positions_book_forms[position.id].shifter) }}
+                                        {{ form_errors(positions_book_forms[position.id].shifter) }}
+                                        {{ form_widget(positions_book_forms[position.id].shifter) }}
                                     </div>
                                     <div class="col s3">
                                         <button type="submit" class="btn waves-effect waves-light"><i class="material-icons left">add</i>Ajouter</button>
                                     </div>
                                 </div>
-                                {{ form_end(pp_book_forms[position.id]) }}
+                                {{ form_end(positions_book_forms[position.id]) }}
                                 <div class="row">
-                                    {{ form_start(positions_delete_form[position.id]) }}
-                                    {{ form_widget(positions_delete_form[position.id]) }}
+                                    {{ form_start(positions_delete_forms[position.id]) }}
+                                    {{ form_widget(positions_delete_forms[position.id]) }}
                                     <a href="#" class="btn waves-effect waves-light red" onclick="var r = confirm('Supprimer ce poste ?!'); if (r == true) {$(this).closest('form').submit();}; event.stopPropagation();" title="Supprimer ce poste" class="red-text">Supprimer</a>
-                                    {{ form_end(positions_delete_form[position.id]) }}
+                                    {{ form_end(positions_delete_forms[position.id]) }}
                                 </div>
                             </div>
                         </li>
@@ -97,14 +113,14 @@
         {% endfor %}
     {% else %}
         {% for week, positions in period.positionsperweekcycle %}
-            <h6>Semaine {{week}}</h6>
+            <h6>Semaine {{ week }}</h6>
             <ul>
             {% for position in positions %}
                 <li>
-                    {{ form_start(positions_delete_form[position.id]) }}
-                    {{ form_widget(positions_delete_form[position.id]) }}
+                    {{ form_start(positions_delete_forms[position.id]) }}
+                    {{ form_widget(positions_delete_forms[position.id]) }}
                     {{ position }} <a href="#" onclick="$(this).closest('form').submit()" title="supprimer" class="red-text">&cross;</a>
-                    {{ form_end(positions_delete_form[position.id]) }}
+                    {{ form_end(positions_delete_forms[position.id]) }}
                 </li>
             {% endfor %}
             </ul>
@@ -130,21 +146,4 @@
         </div>
     </div>
     {{ form_end(position_form) }}
-
-    {{ form_start(delete_form) }}
-    <div id="remove-period" class="modal">
-        <div class="modal-content">
-            <h5><i class="material-icons left small">remove_circle_outline</i>Supprimer le créneau type</h5>
-            <p>Attention, cela va aussi supprimer tous les postes de ce créneau type.</p>
-        </div>
-        <div class="modal-footer">
-            <a href="#!" class="modal-action modal-close waves-effect waves-green btn-flat green-text">
-                Retour à la raison
-            </a>
-            <button type="submit" class="btn waves-effect waves-light orange">
-                <i class="material-icons left">check</i>Je sais ce que je fais !
-            </button>
-        </div>
-    </div>
-    {{ form_end(delete_form) }}
 {% endblock %}

--- a/app/Resources/views/admin/period/edit.html.twig
+++ b/app/Resources/views/admin/period/edit.html.twig
@@ -46,7 +46,7 @@
                                 </div>
                             </div>
                             <div class="collapsible-body">
-                                Créneau fixe réservé le <i>{{ position.bookedTime | date_fr_with_time }}</i> par {% if position.booker and position.booker.beneficiary %}<a href="{{ path("member_show",{ 'member_number': position.booker.beneficiary.membership.memberNumber }) }}">{{ position.booker.beneficiary }}</a>{% else %}{{ position.booker }}{% endif %}.
+                                Créneau fixe réservé pour <a href="{{ path("member_show",{ 'member_number': position.shifter.membership.memberNumber }) }}">{{ position.shifter }}</a> le <i>{{ position.bookedTime | date_fr_with_time }}</i> par {% if position.booker and position.booker.beneficiary %}<a href="{{ path("member_show",{ 'member_number': position.booker.beneficiary.membership.memberNumber }) }}">{{ position.booker.beneficiary }}</a>{% else %}{{ position.booker }}{% endif %}.
                                 <form action="{{ path('free_position_from_period', {'id': period.id, 'position' : position.id }) }}" method="post" id="free_position_{{ position.id }}">
                                     <button type="submit" class="btn orange">
                                         <i class="material-icons left">lock_open</i>Libérer
@@ -58,7 +58,7 @@
                         <li id="position{{ position.id }}">
                             <div class="collapsible-header">
                                 <div class="row" style="margin-bottom: 0; width: 100%;">
-                                    <div class="col s11">
+                                    <div class="col s12">
                                         <b>
                                             <span style="font-style: italic">libre</span>
                                         </b>
@@ -67,12 +67,6 @@
                                         {% else %}
                                             &nbsp;(sans formation particulière)
                                         {% endif %}
-                                    </div>
-                                    <div class="col s1 right-align">
-                                        {{ form_start(positions_delete_form[position.id]) }}
-                                        {{ form_widget(positions_delete_form[position.id]) }}
-                                        <a href="#" onclick="var r = confirm('Supprimer ce poste ?!'); if (r == true) {$(this).closest('form').submit();}; event.stopPropagation();" title="Supprimer ce poste" class="red-text">✗</a>
-                                        {{ form_end(positions_delete_form[position.id]) }}
                                     </div>
                                 </div>
                             </div>
@@ -89,6 +83,12 @@
                                     </div>
                                 </div>
                                 {{ form_end(pp_book_forms[position.id]) }}
+                                <div class="row">
+                                    {{ form_start(positions_delete_form[position.id]) }}
+                                    {{ form_widget(positions_delete_form[position.id]) }}
+                                    <a href="#" class="btn waves-effect waves-light red" onclick="var r = confirm('Supprimer ce poste ?!'); if (r == true) {$(this).closest('form').submit();}; event.stopPropagation();" title="Supprimer ce poste" class="red-text">Supprimer</a>
+                                    {{ form_end(positions_delete_form[position.id]) }}
+                                </div>
                             </div>
                         </li>
                     {% endif %}

--- a/app/Resources/views/admin/period/edit.html.twig
+++ b/app/Resources/views/admin/period/edit.html.twig
@@ -20,12 +20,9 @@
     {{ form_end(form) }}
 
     {% if is_granted("ROLE_ADMIN") %}
-    {{ form_start(delete_form) }}
-    {{ form_widget(delete_form) }}
-    <div>
-        <button type="submit" class="btn waves-effect waves-light red">Supprimer</button>
-    </div>
-    {{ form_end(delete_form) }}
+        <a href="#remove-period" class="modal-trigger btn waves-effect waves-light red" title="supprimer le créneau type">
+            Supprimer
+        </a>
     {% endif %}
 
     <h5>Postes disponibles</h5>
@@ -133,4 +130,21 @@
         </div>
     </div>
     {{ form_end(position_form) }}
+
+    {{ form_start(delete_form) }}
+    <div id="remove-period" class="modal">
+        <div class="modal-content">
+            <h5><i class="material-icons left small">remove_circle_outline</i>Supprimer le créneau type</h5>
+            <p>Attention, cela va aussi supprimer tous les postes de ce créneau type.</p>
+        </div>
+        <div class="modal-footer">
+            <a href="#!" class="modal-action modal-close waves-effect waves-green btn-flat green-text">
+                Retour à la raison
+            </a>
+            <button type="submit" class="btn waves-effect waves-light orange">
+                <i class="material-icons left">check</i>Je sais ce que je fais !
+            </button>
+        </div>
+    </div>
+    {{ form_end(delete_form) }}
 {% endblock %}

--- a/app/Resources/views/beneficiary/edit_beneficiary.html.twig
+++ b/app/Resources/views/beneficiary/edit_beneficiary.html.twig
@@ -11,7 +11,7 @@
 {% endblock %}
 
 {% block content %}
-    <h4>Editer un beneficiaire</h4>
+    <h4>Editer un bénéficiaire</h4>
 
     {{ form_start(edit_form) }}
     {% include "beneficiary/_partial/beneficiary_form.html.twig" with { form: edit_form } %}

--- a/src/AppBundle/Controller/PeriodController.php
+++ b/src/AppBundle/Controller/PeriodController.php
@@ -178,11 +178,11 @@ class PeriodController extends Controller
     }
 
     /**
-     * @Route("/edit/{id}", name="period_edit")
+     * @Route("/{id}/edit", name="period_edit")
      * @Security("has_role('ROLE_SHIFT_MANAGER')")
      * @Method({"GET", "POST"})
      */
-    public function editAction(Request $request,Period $period)
+    public function editAction(Request $request, Period $period)
     {
         $session = new Session();
 
@@ -215,7 +215,7 @@ class PeriodController extends Controller
         $positionsDeleteForm = array();
         foreach($period->getPositions() as $position){
             $positionsDeleteForm[$position->getId()] = $this->createFormBuilder()
-                ->setAction($this->generateUrl('remove_position_from_period', array('period' => $period->getId(),'position' => $position->getId())))
+                ->setAction($this->generateUrl('remove_position_from_period', array('id' => $period->getId(), 'position_id' => $position->getId())))
                 ->setMethod('DELETE')
                 ->getForm()->createView();
         }
@@ -246,11 +246,11 @@ class PeriodController extends Controller
     }
 
     /**
-     * @Route("/{id}/add_position/", name="add_position_to_period")
+     * @Route("/{id}/position/add", name="add_position_to_period")
      * @Security("has_role('ROLE_SHIFT_MANAGER')")
      * @Method({"POST"})
      */
-    public function addPositionToPeriodAction(Request $request,Period $period)
+    public function addPositionToPeriodAction(Request $request, Period $period)
     {
         $session = new Session();
 
@@ -280,16 +280,16 @@ class PeriodController extends Controller
     }
 
     /**
-     * @Route("/{period}/remove_position/{position}", name="remove_position_from_period")
+     * @Route("/{id}/position/{position_id}", name="remove_position_from_period")
      * @Security("has_role('ROLE_SHIFT_MANAGER')")
      * @Method({"DELETE"})
      */
-    public function removePositionToPeriodAction(Request $request,Period $period,PeriodPosition $position)
+    public function removePositionToPeriodAction(Request $request, Period $period, PeriodPosition $position)
     {
         $session = new Session();
 
         $form = $this->createFormBuilder()
-            ->setAction($this->generateUrl('remove_position_from_period', array('period' => $period->getId(),'position' => $position->getId())))
+            ->setAction($this->generateUrl('remove_position_from_period', array('id' => $period->getId(), 'position_id' => $position->getId())))
             ->setMethod('DELETE')
             ->getForm();
         $form->handleRequest($request);
@@ -298,7 +298,7 @@ class PeriodController extends Controller
             $em = $this->getDoctrine()->getManager();
             $em->remove($position);
             $em->flush();
-            $session->getFlashBag()->add('success', 'La position '.$position.' a bien été supprimée');
+            $session->getFlashBag()->add('success', 'La position '.$position.' a bien été supprimée !');
             return $this->redirectToRoute('period_edit',array('id'=>$period->getId()));
         }
 
@@ -314,7 +314,6 @@ class PeriodController extends Controller
      */
     public function bookPositionToPeriodAction(Request $request, PeriodPosition $position): Response
     {
-
         $session = new Session();
         $period = $position->getPeriod();
 
@@ -355,7 +354,7 @@ class PeriodController extends Controller
     /**
      * free a position.
      *
-     * @Route("/free/{id}", name="free_position_from_period")
+     * @Route("/{id}/free", name="free_position_from_period")
      * @Security("has_role('ROLE_SHIFT_MANAGER')")
      * @Method("POST")
      */
@@ -375,7 +374,7 @@ class PeriodController extends Controller
     /**
      * Deletes a period entity.
      *
-     * @Route("/period/{id}", name="period_delete")
+     * @Route("/{id}", name="period_delete")
      * @Security("has_role('ROLE_ADMIN')")
      * @Method("DELETE")
      */

--- a/src/AppBundle/Controller/PeriodController.php
+++ b/src/AppBundle/Controller/PeriodController.php
@@ -215,7 +215,7 @@ class PeriodController extends Controller
         $positionsDeleteForm = array();
         foreach($period->getPositions() as $position){
             $positionsDeleteForm[$position->getId()] = $this->createFormBuilder()
-                ->setAction($this->generateUrl('remove_position_from_period', array('id' => $period->getId(), 'position_id' => $position->getId())))
+                ->setAction($this->generateUrl('remove_position_from_period', array('id' => $period->getId(), 'position' => $position->getId())))
                 ->setMethod('DELETE')
                 ->getForm()->createView();
         }
@@ -280,7 +280,7 @@ class PeriodController extends Controller
     }
 
     /**
-     * @Route("/{id}/position/{position_id}", name="remove_position_from_period")
+     * @Route("/{id}/position/{position}", name="remove_position_from_period")
      * @Security("has_role('ROLE_SHIFT_MANAGER')")
      * @Method({"DELETE"})
      */
@@ -289,7 +289,7 @@ class PeriodController extends Controller
         $session = new Session();
 
         $form = $this->createFormBuilder()
-            ->setAction($this->generateUrl('remove_position_from_period', array('id' => $period->getId(), 'position_id' => $position->getId())))
+            ->setAction($this->generateUrl('remove_position_from_period', array('id' => $period->getId(), 'position' => $position->getId())))
             ->setMethod('DELETE')
             ->getForm();
         $form->handleRequest($request);
@@ -308,14 +308,13 @@ class PeriodController extends Controller
     /**
      * Book a period.
      *
-     * @Route("/book/{id}", name="book_position_from_period")
+     * @Route("/{id}/position/{position}/book", name="book_position_from_period")
      * @Security("has_role('ROLE_SHIFT_MANAGER')")
      * @Method("POST")
      */
-    public function bookPositionToPeriodAction(Request $request, PeriodPosition $position): Response
+    public function bookPositionToPeriodAction(Request $request, Period $period, PeriodPosition $position): Response
     {
         $session = new Session();
-        $period = $position->getPeriod();
 
         $form = $this->createBookForm($position);
         $form->handleRequest($request);
@@ -354,11 +353,11 @@ class PeriodController extends Controller
     /**
      * free a position.
      *
-     * @Route("/{id}/free", name="free_position_from_period")
+     * @Route("/{id}/position/{position}/free", name="free_position_from_period")
      * @Security("has_role('ROLE_SHIFT_MANAGER')")
      * @Method("POST")
      */
-    public function freePositionToPeriodAction(Request $request, PeriodPosition $position)
+    public function freePositionToPeriodAction(Request $request, Period $period, PeriodPosition $position)
     {
         $session = new Session();
 

--- a/src/AppBundle/Entity/Period.php
+++ b/src/AppBundle/Entity/Period.php
@@ -184,7 +184,7 @@ class Period
     /**
      * Add periodPosition
      *
-     * @param \AppBundle\Entity\PeriodPosition $periodPosition
+     * @param \AppBundle\Entity\PeriodPosition $position
      *
      * @return Period
      */


### PR DESCRIPTION
Modifications apportées : 
- ajout d'une modal de confirmation lors de la suppression d'un créneau type (le bouton est parfois confondu avec la suppression d'un poste)
- bougé le bouton de suppression d'un poste de créneau type dans le `collapsible-body`
- refonte du mapping des URL pour être plus 'CRUD' 

|route|Avant|Après|commentaire|
|---|---|---|---|
|period_edit|/period/edit/{id}|/period/{id}/edit||
|add_position_to_period|/period/{id}/add_position/|/period/{id}/position/add|dans l'absolu ca devrait être `/period/{id}/position` ^^|
|remove_position_from_period|/period/{period}/remove_position/{position}|period/{id}/position/{position}||
|book_position_from_period|/period/book/{id}|/period/{id}/position/{position}/book||
|free_position_from_period|/period/free/{id}|/period/{id}/position/{position}/free||
|period_delete|/period/period/{id}|/period/{id}||
