### PR TITLE
Répare le bug sur la recherche de bénéficiaire via l'autocomplete

### DIFF
--- a/app/Resources/views/admin/booking/_partial/bucket_modal.html.twig
+++ b/app/Resources/views/admin/booking/_partial/bucket_modal.html.twig
@@ -35,7 +35,7 @@ It use the materialize modal class https://materializecss.com/modals.html
                         {% else %}
                             Réservé
                         {% endif %}
-                        le <i>{{ shift.bookedTime | date_fr_with_time }}</i> par {% if shift.booker and shift.booker.beneficiary %}<a href="{{ path("member_show",{'member_number': shift.booker.beneficiary.membership.memberNumber}) }}">{{ shift.booker.beneficiary }}</a>{% else %}{{shift.booker}}{% endif %}.
+                        le <i>{{ shift.bookedTime | date_fr_with_time }}</i> par {% if shift.booker and shift.booker.beneficiary %}<a href="{{ path("member_show",{'member_number': shift.booker.beneficiary.membership.memberNumber}) }}">{{ shift.booker.beneficiary }}</a>{% else %}{{ shift.booker }}{% endif %}.
                     </p>
                     {% if is_granted('free',shift) %}
                         {% if use_card_reader_to_validate_shifts and shift.isPastOrCurrent %}
@@ -101,8 +101,8 @@ It use the materialize modal class https://materializecss.com/modals.html
                         <input id="form__token" type="hidden" name="form[_token]" value="{{ csrf_token('form') }}">
                         <div class="row">
                             <div class="col {% if use_fly_and_fixed %}s7{% else %}s9{% endif %} input-field">
-                                <label for="appbundle_shift_booker{{ shift.id}}">Bénéficiaire</label>
-                                <input id="appbundle_shift_booker{{ shift.id }}" name="form[booker]" type="text" class="autocomplete" />
+                                <label for="appbundle_shift_shifter{{ shift.id }}">Bénéficiaire</label>
+                                <input id="appbundle_shift_shifter{{ shift.id }}" name="form[shifter]" type="text" class="autocomplete" />
                             </div>
                             {% if use_fly_and_fixed %}
                                 <div class="col s2">

--- a/app/Resources/views/admin/period/edit.html.twig
+++ b/app/Resources/views/admin/period/edit.html.twig
@@ -138,7 +138,7 @@
             $('input.autocomplete').autocomplete({
                 data: {
                     {% for beneficiary in beneficiaries %}
-                        "{{ beneficiary.displayNameWithMemberNumber }}" : null,
+                        "{{ beneficiary.displayNameWithMemberNumber }}": null,
                     {% endfor %}
                 },
                 limit: 10, // The max amount of results that can be shown at once. Default: Infinity.

--- a/src/AppBundle/Controller/BookingController.php
+++ b/src/AppBundle/Controller/BookingController.php
@@ -732,7 +732,7 @@ class BookingController extends Controller
         $session = new Session();
 
         $form = $this->createFormBuilder()
-            ->add('booker', TextType::class)
+            ->add('shifter', TextType::class)
             ->add('fixe', RadioType::class)
             ->getForm();
 
@@ -745,9 +745,11 @@ class BookingController extends Controller
             }
 
             $fixe = $form->get("fixe")->getData();
-            $str = $form->get("booker")->getData();
+            $str = $form->get("shifter")->getData();
             $em = $this->getDoctrine()->getManager();
-            $beneficiary = $em->getRepository('AppBundle:Beneficiary')->findFromAutoComplete($str);
+            // $membership = $em->getRepository('AppBundle:Membership')->findOneFromAutoComplete($str);
+            // $beneficiary = $membership->getBeneficiaries()->findOneFromAutoComplete($str);
+            $beneficiary = $em->getRepository('AppBundle:Beneficiary')->findOneFromAutoComplete($str);
 
             if (!$beneficiary) {
                 $session->getFlashBag()->add("error", "Impossible de trouve ce béneficiaire 😕");

--- a/src/AppBundle/Controller/PeriodController.php
+++ b/src/AppBundle/Controller/PeriodController.php
@@ -319,7 +319,7 @@ class PeriodController extends Controller
         $str = $content->beneficiary;
 
         $em = $this->getDoctrine()->getManager();
-        $beneficiary = $em->getRepository('AppBundle:Beneficiary')->findFromAutoComplete($str);
+        $beneficiary = $em->getRepository('AppBundle:Beneficiary')->findOneFromAutoComplete($str);
 
         if (!$beneficiary) {
             $session->getFlashBag()->add("error", "Impossible de trouve ce béneficiaire 😕");

--- a/src/AppBundle/Repository/BeneficiaryRepository.php
+++ b/src/AppBundle/Repository/BeneficiaryRepository.php
@@ -10,6 +10,12 @@ namespace AppBundle\Repository;
  */
 class BeneficiaryRepository extends \Doctrine\ORM\EntityRepository
 {
+    /**
+     * findOneFromAutoComplete
+     *
+     * We consider that the $str will have the following format:
+     * "<Membership.member_number> <Beneficiary.firstname> <Beneficiary.lastname>"
+     */
     public function findOneFromAutoComplete($str)
     {
         $reId = '/^#([0-9]+).*/';

--- a/src/AppBundle/Repository/BeneficiaryRepository.php
+++ b/src/AppBundle/Repository/BeneficiaryRepository.php
@@ -10,13 +10,22 @@ namespace AppBundle\Repository;
  */
 class BeneficiaryRepository extends \Doctrine\ORM\EntityRepository
 {
-    public function findFromAutoComplete($str)
+    public function findOneFromAutoComplete($str)
     {
-        $re = '/^#([0-9]+).*/';
-        preg_match_all($re, $str, $matches, PREG_SET_ORDER, 0);
-        if (count($matches) == 1) {
-            $beneficiaryId = $matches[0][1];
-            return $this->find($beneficiaryId);
+        $reId = '/^#([0-9]+).*/';
+        $reFirstname = '/(?<=\s)(.*?)(?=\s)/';
+        preg_match_all($reId, $str, $matchesId, PREG_SET_ORDER, 0);
+        preg_match_all($reFirstname, $str, $matchesFirstname, PREG_SET_ORDER, 0);
+        if ((count($matchesId) == 1) && (count($matchesFirstname) == 1)) {
+            $qb = $this->createQueryBuilder('b');
+
+            $qb->leftJoin('b.membership', 'm')
+                ->where('m.member_number = :membernumber')
+                ->andWhere('b.firstname = :firstname')
+                ->setParameter('membernumber', $matchesId[0][1])
+                ->setParameter('firstname', $matchesFirstname[0][1]);
+
+            return $qb->getQuery()->getSingleResult();
         }
         return null;
     }
@@ -32,11 +41,10 @@ class BeneficiaryRepository extends \Doctrine\ORM\EntityRepository
 
         $qb = $this->createQueryBuilder('beneficiary');
 
-
         $qb->select('beneficiary, membership')
             ->join('beneficiary.user', 'user')
             ->join('beneficiary.membership', 'membership')
-            ->where('membership.withdrawn=0');
+            ->where('membership.withdrawn = 0');
 
         return $qb->getQuery()->getResult();
     }

--- a/src/AppBundle/Repository/MembershipRepository.php
+++ b/src/AppBundle/Repository/MembershipRepository.php
@@ -12,7 +12,12 @@ use Doctrine\ORM\Query\Expr\Join;
  */
 class MembershipRepository extends \Doctrine\ORM\EntityRepository
 {
-
+    /**
+     * findOneFromAutoComplete
+     *
+     * We consider that the $str will have the following format:
+     * "<Membership.member_number> <Beneficiary.firstname> <Beneficiary.lastname>"
+     */
     public function findOneFromAutoComplete($str)
     {
         $re = '/^#([0-9]+).*/';


### PR DESCRIPTION
@petitalb la solution trouvée est un peu un hack, il y aura quelques rares cas particuliers non gérés je pense... 
- par exemple si Beneficiary.firstname a plusieurs mots (genre "Jean François")
- ou si le Membership a plusieurs bénéficiaires **et** deux d'entre eux ont le même prénom...

Une meilleure solution serait de passer le Beneficiary id somehow, mais l'autocomplete qu'on utilise n'a pas l'air de pouvoir passer des value autre que le label affiché..