### PR TITLE
Mini-ajustements sur l'affichage admin des membres si max_beneficiary = 1

### DIFF
--- a/app/Resources/views/beneficiary/_partial/beneficiary_card.html.twig
+++ b/app/Resources/views/beneficiary/_partial/beneficiary_card.html.twig
@@ -38,7 +38,7 @@
                     </div>
                 {% endif %}
                 {% if is_granted("ROLE_ADMIN") %}
-                    {% if not beneficiary.isMain %}
+                    {% if not beneficiary.isMain and detach_form is defined %}
                         <div class="card-btn">
                             <a href="#detach-beneficiary-{{ beneficiary.id }}" class="modal-trigger btn btn-floating waves-effect waves-light red" title="séparer le bénéficiaire">
                                 <i class="material-icons">call_split</i>
@@ -60,7 +60,7 @@
                             </a>
                         </div>
                     {% endif %}
-                    {% if delete_form is defined and not beneficiary.isMain %}
+                    {% if not beneficiary.isMain and delete_form is defined %}
                         <div class="card-btn">
                             <a href="#remove-beneficiary-{{ beneficiary.id }}" class="modal-trigger btn btn-floating waves-effect waves-light red" title="supprimer le bénéficiaire">
                                 <i class="material-icons">remove</i>

--- a/app/Resources/views/beneficiary/_partial/beneficiary_card.html.twig
+++ b/app/Resources/views/beneficiary/_partial/beneficiary_card.html.twig
@@ -30,7 +30,7 @@
                         <button type="submit" class="btn btn-floating waves-effect waves-light" title="éditer"><i class="material-icons">mode_edit</i></button>
                     </form>
                 </div>
-                {% if not beneficiary.isMain %}
+                {% if not beneficiary.isMain %}{# implies that maximum_nb_of_beneficiaries_in_membership > 1 #}
                     <div class="card-btn">
                         <a href="{{ path('beneficiary_set_main', { 'id': beneficiary.id }) }}" class="modal-trigger btn btn-floating waves-effect waves-light purple" title="mettre en bénéficiaire principal">
                             <i class="material-icons">flag</i>

--- a/app/Resources/views/beneficiary/_partial/info.html.twig
+++ b/app/Resources/views/beneficiary/_partial/info.html.twig
@@ -1,7 +1,7 @@
 <div class="card-title">
     <img src="{{ gravatar(beneficiary.email,40) }}" alt="{{ beneficiary.firstname | lower | capitalize }}" class="circle responsive-img" />
     {{ beneficiary.firstname | lower | capitalize }} {{ beneficiary.lastname | upper }}
-    {% if beneficiary.isMain %}
+    {% if beneficiary.isMain and maximum_nb_of_beneficiaries_in_membership > 1 %}
         <span class="teal white-text badge">⚐ principal</span>
     {% endif %}
     {% if beneficiary.membership.withdrawn %}

--- a/app/Resources/views/default/index.html.twig
+++ b/app/Resources/views/default/index.html.twig
@@ -44,7 +44,8 @@
                 <p>
                     Bienvenue sur ton espace personnel à {{ project_name }}
                     {% if app.user.beneficiary.membership.beneficiaries | length > 1 %}
-                    <br />Tu partages ton compte avec {% for beneficiary in app.user.beneficiary.membership.beneficiaries %}{% if beneficiary != app.user.beneficiary %}<strong>{{ beneficiary.firstname }}</strong>{% endif %}{% endfor %}
+                        <br />
+                        Tu partages ton compte avec {% for beneficiary in app.user.beneficiary.membership.beneficiaries %}{% if beneficiary != app.user.beneficiary %}<strong>{{ beneficiary.firstname }}</strong>{% endif %}{% endfor %}
                     {% endif %}
                 </p>
                 {% if app.user.beneficiary.membership | uptodate and app.user.beneficiary.membership | can_register %}

--- a/app/Resources/views/member/show.html.twig
+++ b/app/Resources/views/member/show.html.twig
@@ -40,7 +40,7 @@
         </div>
     {% endif %}
 
-    {% if is_granted("beneficiary_add", member) and member.beneficiaries|length < maximum_nb_of_beneficiaries_in_membership %}
+    {% if is_granted("beneficiary_add", member) and member.beneficiaries | length < maximum_nb_of_beneficiaries_in_membership %}
         <ul class="collapsible">
             <li>
                 <div class="collapsible-header"><i class="material-icons">person_add</i>Ajouter un bénéficiaire</div>

--- a/app/Resources/views/member/show.html.twig
+++ b/app/Resources/views/member/show.html.twig
@@ -40,7 +40,7 @@
         </div>
     {% endif %}
 
-    {% if is_granted("beneficiary_add", member) and member.beneficiaries|length < 2 %}{#todo put this value in conf#}
+    {% if is_granted("beneficiary_add", member) and member.beneficiaries|length < maximum_nb_of_beneficiaries_in_membership %}
         <ul class="collapsible">
             <li>
                 <div class="collapsible-header"><i class="material-icons">person_add</i>Ajouter un bénéficiaire</div>


### PR DESCRIPTION
Il y a eu quelques modifications récemment pour bien distinguer les bénéficiaires principales et secondaires, mais c'est dans un cas où `maximum_nb_of_beneficiaries_in_membership > 1`

Quelques modifications pour cacher ces infos si `maximum_nb_of_beneficiaries_in_membership == 1`