### PR TITLE
Afficher le bénéficiaire principal en premier

### DIFF
--- a/app/Resources/views/member/show.html.twig
+++ b/app/Resources/views/member/show.html.twig
@@ -22,7 +22,7 @@
     </h4>
 
     <div class="row">
-        {% for beneficiary in member.beneficiaries %}
+        {% for beneficiary in member.beneficiariesWithMainInFirstPosition %}
             {% include "beneficiary/_partial/beneficiary_card.html.twig" with { beneficiary: beneficiary, detach_form: detach_beneficiary_forms[beneficiary.id], delete_form: delete_beneficiary_forms[beneficiary.id] } %}
         {% endfor %}
     </div>

--- a/src/AppBundle/Entity/Membership.php
+++ b/src/AppBundle/Entity/Membership.php
@@ -253,6 +253,25 @@ class Membership
     }
 
     /**
+     * Get beneficiaries (with main in first position)
+     * Why? because beneficiaries are ordered by id ASC
+     *
+     * @return \Doctrine\Common\Collections\Collection
+     */
+    public function getBeneficiariesWithMainInFirstPosition()
+    {
+        $beneficiaries[] = $this->getMainBeneficiary();
+        if ($this->getBeneficiaries()->count() > 1) {
+            foreach ($this->getBeneficiaries() as $beneficiary) {
+                if ($beneficiary !== $this->getMainBeneficiary()) {
+                    $beneficiaries[] = $beneficiary;
+                }
+            }
+        }
+        return $beneficiaries;
+    }
+
+    /**
      * Set mainBeneficiary
      *
      * @param \AppBundle\Entity\Beneficiary $mainBeneficiary


### PR DESCRIPTION
### Quoi ?

Pour les comptes avec plusieurs bénéficiaires, solution très simple (et très moche :upside_down_face: ) pour pouvoir forcer l'affichage du bénéficiaire principal (à gauche)

### Pourquoi ?

Par défaut les bénéficiaires sont ordonnés par beneficiary_id ASC

### Capture d'écran

|Avant|Après|
|---|---|
|![Screenshot from 2022-11-21 19-42-32](https://user-images.githubusercontent.com/7147385/203134995-4ec70c5f-f56a-47bb-b1b9-1ab92d57be90.png)|![Screenshot from 2022-11-21 19-41-55](https://user-images.githubusercontent.com/7147385/203135018-341a2ca0-5046-452c-a17a-b767cb3319bb.png)|

### Extra

Il y a d'autres endroits où cette modif d'affichage pourrait être intéressante, par exemple la page admin "Liste des membres"

