### PR TITLE
Gel / Fermeture : indiquer les créneaux à venir

### DIFF
--- a/app/Resources/views/Profile/show_content.html.twig
+++ b/app/Resources/views/Profile/show_content.html.twig
@@ -48,7 +48,7 @@
         {% if display_swipe_cards_settings %}
             <li>
                 <div class="collapsible-header">
-                    <i class="material-icons">credit_card</i>Badge{% if beneficiary.swipeCards | length > 1%}s{% endif %}
+                    <i class="material-icons">credit_card</i>Badge{% if beneficiary.swipeCards | length > 1 %}s{% endif %}
                 </div>
                 <div class="collapsible-body">
                     {% include "member/_partial/swipe_card.html.twig" with { member: member, showBadgeImage: true } %}

--- a/app/Resources/views/member/show.html.twig
+++ b/app/Resources/views/member/show.html.twig
@@ -245,9 +245,9 @@
                                     <p>De plus, à la fin du cycle, les heures effectuées ne seront pas décomptées.</p>
                                     <ul>
                                         {% if use_fly_and_fixed %}
-                                            <li>Ce membre a {{ period_positions | length }} créneau fixe.</li>
+                                            <li>Ce membre a {{ period_positions | length }} créneau{% if period_positions | length > 1 %}x{% endif %} fixe.</li>
                                         {% endif %}
-                                        <li>Ce membre a {{ in_progress_and_upcoming_shifts | length }} créneaux à venir.</li>
+                                        <li>Ce membre a {{ in_progress_and_upcoming_shifts | length }} créneau{% if in_progress_and_upcoming_shifts | length > 1 %}x{% endif %} à venir.</li>
                                     </ul>
                                 </div>
                                 <div class="modal-footer">
@@ -300,9 +300,9 @@
                                 <p>Attention, vous êtes sur le point de fermer le compte du membre.</p>
                                 <ul>
                                     {% if use_fly_and_fixed %}
-                                        <li>Ce membre a {{ period_positions | length }} créneau fixe.</li>
+                                        <li>Ce membre a {{ period_positions | length }} créneau{% if period_positions | length > 1 %}x{% endif %} fixe.</li>
                                     {% endif %}
-                                    <li>Ce membre a {{ in_progress_and_upcoming_shifts | length }} créneaux à venir.</li>
+                                    <li>Ce membre a {{ in_progress_and_upcoming_shifts | length }} créneau{% if in_progress_and_upcoming_shifts | length > 1 %}x{% endif %} à venir.</li>
                                 </ul>
                             </div>
                             <div class="modal-footer">

--- a/app/Resources/views/member/show.html.twig
+++ b/app/Resources/views/member/show.html.twig
@@ -241,8 +241,14 @@
                                     <h5>
                                         <i class="material-icons left small">pause_circle_filled</i>Gel immédiat du compte
                                     </h5>
-                                    <p>Attention, le gel immédiat sera effectif dés aujourd'hui, interdisant l'accès au magasin</p>
+                                    <p>Attention, le gel immédiat sera effectif dés aujourd'hui, interdisant l'accès au magasin.</p>
                                     <p>De plus, à la fin du cycle, les heures effectuées ne seront pas décomptées.</p>
+                                    <ul>
+                                        {% if use_fly_and_fixed %}
+                                            <li>Ce membre a {{ period_positions | length }} créneau fixe.</li>
+                                        {% endif %}
+                                        <li>Ce membre a {{ in_progress_and_upcoming_shifts | length }} créneaux à venir.</li>
+                                    </ul>
                                 </div>
                                 <div class="modal-footer">
                                     <a href="#!" class="modal-action modal-close waves-effect waves-green btn-flat green-text">Retour à la raison</a>

--- a/app/Resources/views/member/show.html.twig
+++ b/app/Resources/views/member/show.html.twig
@@ -292,6 +292,12 @@
                                     <i class="material-icons left small">remove_circle_outline</i>Fermeture du compte membre
                                 </h5>
                                 <p>Attention, vous êtes sur le point de fermer le compte du membre.</p>
+                                <ul>
+                                    {% if use_fly_and_fixed %}
+                                        <li>Ce membre a {{ period_positions | length }} créneau fixe.</li>
+                                    {% endif %}
+                                    <li>Ce membre a {{ in_progress_and_upcoming_shifts | length }} créneaux à venir.</li>
+                                </ul>
                             </div>
                             <div class="modal-footer">
                                 <a href="#!" class="modal-action modal-close waves-effect waves-green btn-flat green-text">Retour à la raison</a>

--- a/src/AppBundle/Controller/MembershipController.php
+++ b/src/AppBundle/Controller/MembershipController.php
@@ -168,6 +168,7 @@ class MembershipController extends Controller
             'delete_form' => $deleteForm->createView(),
             'time_log_form' => $timeLogForm->createView(),
             'period_positions' => $period_positions,
+            'in_progress_and_upcoming_shifts' => $member->getInProgressAndUpcomingShifts(),
         ));
     }
 

--- a/src/AppBundle/Entity/Membership.php
+++ b/src/AppBundle/Entity/Membership.php
@@ -486,6 +486,8 @@ class Membership
 
     /**
      * Get all shifts for all beneficiaries
+     * @param bool $excludeDismissed
+     * @return ArrayCollection|\Doctrine\Common\Collections\Collection
      */
     public function getAllShifts($excludeDismissed = false)
     {
@@ -505,6 +507,19 @@ class Membership
     }
 
     /**
+     * Get all in progress & upcoming shifts for all beneficiaries
+     * @param bool $excludeDismissed
+     * @return ArrayCollection|\Doctrine\Common\Collections\Collection
+     */
+    public function getInProgressAndUpcomingShifts($excludeDismissed = false)
+    {
+        $now = new DateTime('now');
+        return $this->getAllShifts($excludeDismissed)->filter(function($shift) use ($now) {
+            return $shift->getStart() > $now;
+        });
+    }
+
+    /**
      * Get all reserved shifts for all beneficiaries
      */
     public function getReservedShifts()
@@ -517,7 +532,6 @@ class Membership
         }
         return $shifts;
     }
-
 
     /**
      * Get shifts of a specific cycle


### PR DESCRIPTION
Lors des actions "Gel immédiat" et "Fermeture de compte", il y a une modale de confirmation.

On rajoute ici les infos du membre concernant : 
- ses créneaux fixe (si `use_fly_and_fixed=true`)
- ses créneaux à venir

Prochaine étape (autre PR) : pouvoir automatiquement libérer ces créneaux