### PR TITLE
Gel / Fermeture : utiliser la méthode POST pour les formulaires

### DIFF
--- a/app/Resources/views/member/_partial/frozen.html.twig
+++ b/app/Resources/views/member/_partial/frozen.html.twig
@@ -8,12 +8,12 @@
             <i class="material-icons left">cancel</i>Annuler le gel de mon compte
         </a>
     {% else %}
-        <a class="waves-effect waves-light btn modal-trigger blue" href="#pause">
+        <a class="waves-effect waves-light btn modal-trigger blue" href="#freeze">
             <i class="material-icons left">ac_unit</i>Geler mon compte
         </a>
 
         <!-- Modal Structure -->
-        <div class="modal" id="pause">
+        <div class="modal" id="freeze">
             <div class="modal-content">
                 <h5>
                     <i class="material-icons small">ac_unit</i>&nbsp;Gel de compte

--- a/app/Resources/views/member/show.html.twig
+++ b/app/Resources/views/member/show.html.twig
@@ -233,11 +233,11 @@
                     {% endif %}
                     {% if is_granted("freeze", member) %}
                         {% if not member.frozen %}
-                            <a href="#pause" class="waves-effect waves-light btn modal-trigger deep-purple lighten-2">
+                            <a href="#freeze" class="waves-effect waves-light btn modal-trigger deep-purple lighten-2">
                                 <i class="material-icons left">paused</i><i class="material-icons left">timer_off</i>Geler le compte immédiatement
                             </a>
                             {{ form_start(freeze_form) }}
-                            <div id="pause" class="modal">
+                            <div id="freeze" class="modal">
                                 <div class="modal-content">
                                     <h5>
                                         <i class="material-icons left small">pause_circle_filled</i>Gel immédiat du compte
@@ -260,10 +260,11 @@
                             </div>
                             {{ form_end(freeze_form) }}
                         {% else %}
-                            <a href="#unpause" class="waves-effect waves-light btn modal-trigger purple lighten-3">
+                            <a href="#unfreeze" class="waves-effect waves-light btn modal-trigger purple lighten-3">
                                 <i class="material-icons left">play_arrow</i><i class="material-icons left">timer_off</i> Dégeler le compte immédiatement
                             </a>
-                            <div id="unpause" class="modal">
+                            {{ form_start(unfreeze_form) }}
+                            <div id="unfreeze" class="modal">
                                 <div class="modal-content">
                                     <h5>
                                         <i class="material-icons left small">play_arrow</i>Dégel immédiat du compte
@@ -273,11 +274,12 @@
                                 </div>
                                 <div class="modal-footer">
                                     <a href="#!" class="modal-action modal-close waves-effect waves-green btn-flat green-text">Retour à la raison</a>
-                                    <a class="btn waves-effect waves-light orange" href="{{ path('member_unfreeze', { 'id' : member.id }) }}">
+                                    <button type="submit" class="btn waves-effect waves-light orange">
                                         <i class="material-icons left">check</i>Je sais ce que je fais !
-                                    </a>
+                                    </button>
                                 </div>
                             </div>
+                            {{ form_end(unfreeze_form) }}
                         {% endif %}
                     {% endif %}
                 </div>

--- a/app/Resources/views/member/show.html.twig
+++ b/app/Resources/views/member/show.html.twig
@@ -326,6 +326,7 @@
                         <a href="#reopen-member" class="modal-trigger waves-effect waves-light btn teal">
                             <i class="material-icons left">check</i>Ré-ouvrir le compte
                         </a>
+                        {{ form_start(open_form) }}
                         <div id="reopen-member" class="modal">
                             <div class="modal-content">
                                 <h5>
@@ -335,11 +336,12 @@
                             </div>
                             <div class="modal-footer">
                                 <a href="#!" class="modal-action modal-close waves-effect waves-green btn-flat green-text">Retour à la raison</a>
-                                <a class="btn waves-effect waves-light orange" href="{{ path('member_open',{ 'id' : member.id }) }}">
+                                <button type="submit" class="btn waves-effect waves-light orange">
                                     <i class="material-icons left">check</i>Je sais ce que je fais !
-                                </a>
+                                </button>
                             </div>
                         </div>
+                        {{ form_end(open_form) }}
                     {% endif %}
                 </div>
             </li>

--- a/app/Resources/views/member/show.html.twig
+++ b/app/Resources/views/member/show.html.twig
@@ -209,27 +209,29 @@
                 </div>
                 <div class="collapsible-body white">
                     {% if is_granted("freeze_change", member) %}
+                        {{ form_start(freeze_change_form) }}
                         {% if not member.frozen %}
                             {% if member.frozenChange %}
-                                <a href="{{ path("member_freeze_change",{"id":member.id}) }}" class="waves-effect waves-light btn orange">
+                                <button type="submit" class="btn waves-effect waves-light orange">
                                     <i class="material-icons left">cancel</i>Annuler la demande de gel du compte
-                                </a>
+                                </button>
                             {% else %}
-                                <a href="{{ path("member_freeze_change",{"id":member.id}) }}" class="waves-effect waves-light btn deep-purple">
+                                <button type="submit" class="btn waves-effect waves-light deep-purple">
                                     <i class="material-icons left">paused</i>Geler le compte à la fin du cycle
-                                </a>
+                                </button>
                             {% endif %}
                         {% else %}
                             {% if member.frozenChange %}
-                                <a href="{{ path("member_freeze_change",{"id":member.id}) }}" class="waves-effect waves-light btn orange">
+                                <button type="submit" class="btn waves-effect waves-light orange">
                                     <i class="material-icons left">cancel</i>Annuler la demande de dégel du compte
-                                </a>
+                                </button>
                             {% else %}
-                                <a href="{{ path("member_freeze_change",{"id":member.id}) }}" class="waves-effect waves-light btn waves-purple purple lighten-2">
+                                <button type="submit" class="btn waves-effect waves-light deep-purple lighten-2">
                                     <i class="material-icons left">play_arrow</i>Dégeler le compte à la fin du cycle
-                                </a>
+                                </button>
                             {% endif %}
                         {% endif %}
+                        {{ form_end(freeze_change_form) }}
                     {% endif %}
                     {% if is_granted("freeze", member) %}
                         {% if not member.frozen %}

--- a/app/Resources/views/member/show.html.twig
+++ b/app/Resources/views/member/show.html.twig
@@ -252,7 +252,7 @@
                                 </div>
                                 <div class="modal-footer">
                                     <a href="#!" class="modal-action modal-close waves-effect waves-green btn-flat green-text">Retour à la raison</a>
-                                    <a class="btn waves-effect waves-light orange" href="{{ path('member_freeze',{ 'id' : member.id }) }}">
+                                    <a class="btn waves-effect waves-light orange" href="{{ path('member_freeze', { 'id' : member.id }) }}">
                                         <i class="material-icons left">check</i>Je sais ce que je fais !
                                     </a>
                                 </div>
@@ -271,7 +271,7 @@
                                 </div>
                                 <div class="modal-footer">
                                     <a href="#!" class="modal-action modal-close waves-effect waves-green btn-flat green-text">Retour à la raison</a>
-                                    <a class="btn waves-effect waves-light orange" href="{{ path('member_unfreeze',{ 'id' : member.id }) }}">
+                                    <a class="btn waves-effect waves-light orange" href="{{ path('member_unfreeze', { 'id' : member.id }) }}">
                                         <i class="material-icons left">check</i>Je sais ce que je fais !
                                     </a>
                                 </div>
@@ -292,6 +292,7 @@
                         <a href="#close-member" class="modal-trigger waves-effect waves-light btn red">
                             <i class="material-icons left">close</i>Fermer le compte
                         </a>
+                        {{ form_start(close_form) }}
                         <div id="close-member" class="modal">
                             <div class="modal-content">
                                 <h5>
@@ -307,17 +308,18 @@
                             </div>
                             <div class="modal-footer">
                                 <a href="#!" class="modal-action modal-close waves-effect waves-green btn-flat green-text">Retour à la raison</a>
-                                <a class="btn waves-effect waves-light orange" href="{{ path('member_close',{ 'id' : member.id }) }}">
+                                <button type="submit" class="btn waves-effect waves-light orange">
                                     <i class="material-icons left">check</i>Je sais ce que je fais !
-                                </a>
+                                </button>
                             </div>
                         </div>
+                        {{ form_end(close_form) }}
                     {% else %}
                         {% if member.withdrawnDate %}
                             <p>
                                 Compte fermé le <i>{{ member.withdrawnDate | date('d F Y H:i') }}</i>
                                 {% if member.withdrawnBy %}
-                                    par {% if member.withdrawnBy.beneficiary %}<a href="{{ path("member_show",{ 'member_number': member.withdrawnBy.beneficiary.membership.memberNumber }) }}">{{ member.withdrawnBy.beneficiary }}</a>{% else %}{{ member.withdrawnBy }}{% endif %}
+                                    par {% if member.withdrawnBy.beneficiary %}<a href="{{ path("member_show", { 'member_number': member.withdrawnBy.beneficiary.membership.memberNumber }) }}">{{ member.withdrawnBy.beneficiary }}</a>{% else %}{{ member.withdrawnBy }}{% endif %}
                                 {% endif %}
                             </p>
                         {% endif %}

--- a/app/Resources/views/member/show.html.twig
+++ b/app/Resources/views/member/show.html.twig
@@ -329,11 +329,11 @@
                                 {% endif %}
                             </p>
                         {% endif %}
-                        <a href="#reopen-member" class="modal-trigger waves-effect waves-light btn teal">
+                        <a href="#open-member" class="modal-trigger waves-effect waves-light btn teal">
                             <i class="material-icons left">check</i>Ré-ouvrir le compte
                         </a>
                         {{ form_start(open_form) }}
-                        <div id="reopen-member" class="modal">
+                        <div id="open-member" class="modal">
                             <div class="modal-content">
                                 <h5>
                                     <i class="material-icons left small">info_outline</i>Ré-ouverture du compte membre

--- a/app/Resources/views/member/show.html.twig
+++ b/app/Resources/views/member/show.html.twig
@@ -236,12 +236,13 @@
                             <a href="#pause" class="waves-effect waves-light btn modal-trigger deep-purple lighten-2">
                                 <i class="material-icons left">paused</i><i class="material-icons left">timer_off</i>Geler le compte immédiatement
                             </a>
+                            {{ form_start(freeze_form) }}
                             <div id="pause" class="modal">
                                 <div class="modal-content">
                                     <h5>
                                         <i class="material-icons left small">pause_circle_filled</i>Gel immédiat du compte
                                     </h5>
-                                    <p>Attention, le gel immédiat sera effectif dés aujourd'hui, interdisant l'accès au magasin.</p>
+                                    <p>Attention, le gel immédiat sera effectif dès aujourd'hui, interdisant l'accès au magasin.</p>
                                     <p>De plus, à la fin du cycle, les heures effectuées ne seront pas décomptées.</p>
                                     <ul>
                                         {% if use_fly_and_fixed %}
@@ -252,11 +253,12 @@
                                 </div>
                                 <div class="modal-footer">
                                     <a href="#!" class="modal-action modal-close waves-effect waves-green btn-flat green-text">Retour à la raison</a>
-                                    <a class="btn waves-effect waves-light orange" href="{{ path('member_freeze', { 'id' : member.id }) }}">
+                                    <button type="submit" class="btn waves-effect waves-light orange">
                                         <i class="material-icons left">check</i>Je sais ce que je fais !
-                                    </a>
+                                    </button>
                                 </div>
                             </div>
+                            {{ form_end(freeze_form) }}
                         {% else %}
                             <a href="#unpause" class="waves-effect waves-light btn modal-trigger purple lighten-3">
                                 <i class="material-icons left">play_arrow</i><i class="material-icons left">timer_off</i> Dégeler le compte immédiatement

--- a/src/AppBundle/Controller/MembershipController.php
+++ b/src/AppBundle/Controller/MembershipController.php
@@ -71,7 +71,7 @@ class MembershipController extends Controller
     /**
      * Finds and displays a membership entity.
      *
-     * @Route("/show/{member_number}", name="member_show")
+     * @Route("/{member_number}", name="member_show")
      * @Method("GET")
      * @param Membership $member
      * @return \Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\Response
@@ -504,7 +504,7 @@ class MembershipController extends Controller
             $em->persist($member);
             $em->flush();
 
-            $session->getFlashBag()->add('success', 'Compte fermé');
+            $session->getFlashBag()->add('success', 'Compte fermé !');
         }
 
         return $this->redirectToShow($member);
@@ -535,7 +535,7 @@ class MembershipController extends Controller
             $em->persist($member);
             $em->flush();
 
-            $session->getFlashBag()->add('success', 'Compte reouvert');
+            $session->getFlashBag()->add('success', 'Compte ré-ouvert !');
         }
 
         return $this->redirectToShow($member);

--- a/src/AppBundle/Controller/MembershipController.php
+++ b/src/AppBundle/Controller/MembershipController.php
@@ -87,6 +87,7 @@ class MembershipController extends Controller
         $user = $member->getMainBeneficiary()->getUser(); // FIXME
 
         $freezeForm = $this->createFreezeForm($member);
+        $unfreezeForm = $this->createUnfreezeForm($member);
         $closeForm = $this->createCloseForm($member);
         $openForm = $this->createOpenForm($member);
         $deleteForm = $this->createDeleteForm($member);
@@ -169,6 +170,7 @@ class MembershipController extends Controller
             'detach_beneficiary_forms' => $detachBeneficiaryForms,
             'delete_beneficiary_forms' => $deleteBeneficiaryForms,
             'freeze_form' => $freezeForm->createView(),
+            'unfreeze_form' => $unfreezeForm->createView(),
             'close_form' => $closeForm->createView(),
             'open_form' => $openForm->createView(),
             'delete_form' => $deleteForm->createView(),
@@ -548,6 +550,7 @@ class MembershipController extends Controller
      *
      * @Route("/{id}/freeze", name="member_freeze")
      * @Method({"POST"})
+     * @param Request $request
      * @param Membership $member
      * @return \Symfony\Component\HttpFoundation\RedirectResponse
      */
@@ -578,20 +581,31 @@ class MembershipController extends Controller
      * Unfreeze member
      *
      * @Route("/{id}/unfreeze", name="member_unfreeze")
-     * @Method({"GET"})
+     * @Method({"POST"})
+     * @param Request $request
      * @param Membership $member
      * @return \Symfony\Component\HttpFoundation\RedirectResponse
      */
-    public function unfreezeAction(Membership $member)
+    public function unfreezeAction(Request $request, Membership $member)
     {
         $this->denyAccessUnlessGranted('freeze', $member);
+
+        $current_user = $this->get('security.token_storage')->getToken()->getUser();
         $session = new Session();
-        $em = $this->getDoctrine()->getManager();
-        $member->setFrozen(false);
-        $member->setFrozenChange(false);
-        $em->persist($member);
-        $em->flush();
-        $session->getFlashBag()->add('success', 'Compte dégelé');
+
+        $form = $this->createUnfreezeForm($member);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $em = $this->getDoctrine()->getManager();
+            $member->setFrozen(false);
+            $member->setFrozenChange(false);
+            $em->persist($member);
+            $em->flush();
+
+            $session->getFlashBag()->add('success', 'Compte dégelé !');
+        }
+
         return $this->redirectToShow($member);
     }
 
@@ -1032,6 +1046,34 @@ class MembershipController extends Controller
     }
 
     /**
+     * Creates a form to freeze a member entity.
+     *
+     * @param Membership $member
+     * @return \Symfony\Component\Form\FormInterface
+     */
+    private function createFreezeForm(Membership $member)
+    {
+        return $this->createFormBuilder()
+            ->setAction($this->generateUrl('member_freeze', array('id' => $member->getId())))
+            ->setMethod('POST')
+            ->getForm();
+    }
+
+    /**
+     * Creates a form to unfreeze a member entity.
+     *
+     * @param Membership $member
+     * @return \Symfony\Component\Form\FormInterface
+     */
+    private function createUnfreezeForm(Membership $member)
+    {
+        return $this->createFormBuilder()
+            ->setAction($this->generateUrl('member_unfreeze', array('id' => $member->getId())))
+            ->setMethod('POST')
+            ->getForm();
+    }
+
+    /**
      * Creates a form to close a member entity.
      *
      * @param Membership $member
@@ -1055,20 +1097,6 @@ class MembershipController extends Controller
     {
         return $this->createFormBuilder()
             ->setAction($this->generateUrl('member_open', array('id' => $member->getId())))
-            ->setMethod('POST')
-            ->getForm();
-    }
-
-    /**
-     * Creates a form to freeze a member entity.
-     *
-     * @param Membership $member
-     * @return \Symfony\Component\Form\FormInterface
-     */
-    private function createFreezeForm(Membership $member)
-    {
-        return $this->createFormBuilder()
-            ->setAction($this->generateUrl('member_freeze', array('id' => $member->getId())))
             ->setMethod('POST')
             ->getForm();
     }


### PR DESCRIPTION
Suite de #640 

### Quoi ? 

- créer de vrais formulaires + utiliser la méthode POST pour les actions de gel / dégel / fermeture / ré-ouverture
- renommer l'url GET `/member/show/<id>` en `/member/<id>`

### Pourquoi ?

Pourquoi POST au lieu de GET ?
- on modifie la base de données
- ca permettra de pouvoir passer un input dans le formulaire (e.g. pour savoir si l'on souhaite automatiquement supprimer les créneaux du membre - prochaine PR) 