### PR TITLE
Add command to send late beneficiaries by e-mail

### DIFF
--- a/app/Resources/views/emails/shift_late_alerts_default.html.twig
+++ b/app/Resources/views/emails/shift_late_alerts_default.html.twig
@@ -1,5 +1,5 @@
 {% for membership_late_alert in membership_late_alerts %}
-<strong>Compteur de
-  {{ membership_late_alert.beneficiaries | map(b => b.displayNameWithMemberNumber) | join(', ') }} :
-  {{ membership_late_alert.timeCount | duration_from_minutes }}</strong><br>
+{% set beneficiaries = membership_late_alert.beneficiaries | map(b => b.displayNameWithMemberNumber) | join(', ') %}
+{% set timeCount = membership_late_alert.timeCount | duration_from_minutes %}
+- Compteur de {{ beneficiaries }} : {{ timeCount }}
 {% endfor %}

--- a/app/Resources/views/emails/shift_late_alerts_default.html.twig
+++ b/app/Resources/views/emails/shift_late_alerts_default.html.twig
@@ -1,0 +1,5 @@
+{% for membership_late_alert in membership_late_alerts %}
+<strong>Compteur de
+  {{ membership_late_alert.beneficiaries | map(b => b.displayNameWithMemberNumber) | join(', ') }} :
+  {{ membership_late_alert.timeCount | duration_from_minutes }}</strong><br>
+{% endfor %}

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -181,6 +181,9 @@ services:
             arguments:
                 - "@doctrine.orm.entity_manager"
                 - '@membership_service'
+    search_user_form_helper:
+            class: AppBundle\Service\SearchUserFormHelper
+            public: true
 
     logger.user_processor:
             class: AppBundle\Monolog\MonologUserProcessor

--- a/src/AppBundle/Command/AmbassadorShiftTimeLogCommand.php
+++ b/src/AppBundle/Command/AmbassadorShiftTimeLogCommand.php
@@ -25,7 +25,12 @@ class AmbassadorShiftTimeLogCommand extends ContainerAwareCommand
     {
         $email_template = $input->getOption('emailTemplate');
 
-        $alerts = $this->computeAlerts();
+        $time_after_which_members_are_late_with_shifts = $this->getContainer()->getParameter('time_after_which_members_are_late_with_shifts');
+
+        $em = $this->getContainer()->get('doctrine')->getManager();
+        $alerts = $em
+          ->getRepository("AppBundle:Membership")
+          ->findLateShifters($time_after_which_members_are_late_with_shifts);
         $nbAlerts = count($alerts);
         if ($nbAlerts > 0) {
             $output->writeln('<fg=cyan;>Found ' . $nbAlerts . ' alerts to send</>');

--- a/src/AppBundle/Command/AmbassadorShiftTimeLogCommand.php
+++ b/src/AppBundle/Command/AmbassadorShiftTimeLogCommand.php
@@ -28,9 +28,8 @@ class AmbassadorShiftTimeLogCommand extends ContainerAwareCommand
         $time_after_which_members_are_late_with_shifts = $this->getContainer()->getParameter('time_after_which_members_are_late_with_shifts');
 
         $em = $this->getContainer()->get('doctrine')->getManager();
-        $alerts = $em
-          ->getRepository("AppBundle:Membership")
-          ->findLateShifters($time_after_which_members_are_late_with_shifts);
+        $alerts = $em->getRepository("AppBundle:Membership")
+                     ->findLateShifters($time_after_which_members_are_late_with_shifts);
         $nbAlerts = count($alerts);
         if ($nbAlerts > 0) {
             $output->writeln('<fg=cyan;>Found ' . $nbAlerts . ' alerts to send</>');
@@ -46,13 +45,12 @@ class AmbassadorShiftTimeLogCommand extends ContainerAwareCommand
         $recipients = $input->getOption('emails') ? explode(',', $input->getOption('emails')) : null;
         if ($recipients) {
             setlocale(LC_TIME, 'fr_FR.UTF8');
-            $subject = '[ALERTE RETARDS] Membres en retard de shifts';
-
+            $subject = '[ALERTE RETARDS] Membres en retard de créneaux';
             $shiftEmail = $this->getContainer()->getParameter('emails.shift');
 
             $em = $this->getContainer()->get('doctrine')->getManager();
             $dynamicContent = $em->getRepository('AppBundle:DynamicContent')->findOneByCode($template);
-            $template = null;
+
             if ($dynamicContent) {
                 $template = $this->getContainer()->get('twig')->createTemplate($dynamicContent->getContent());
             } else {
@@ -67,7 +65,7 @@ class AmbassadorShiftTimeLogCommand extends ContainerAwareCommand
                         $template,
                         array('membership_late_alerts' => $alerts)
                     ),
-                    'text/html'
+                    'text/plain'
                 );
             $mailer->send($email);
             $output->writeln('<fg=cyan;>Email(s) sent</>');

--- a/src/AppBundle/Command/AmbassadorShiftTimeLogCommand.php
+++ b/src/AppBundle/Command/AmbassadorShiftTimeLogCommand.php
@@ -35,17 +35,6 @@ class AmbassadorShiftTimeLogCommand extends ContainerAwareCommand
         }
     }
 
-    private function computeAlerts() {
-        $time_after_which_members_are_late_with_shifts = $this->getContainer()->getParameter('time_after_which_members_are_late_with_shifts');
-
-        $em = $this->getContainer()->get('doctrine')->getManager();
-        $formHelper = $this->getContainer()->get('search_user_form_helper');
-        return $em
-          ->getRepository("AppBundle:Membership")
-          ->findLateShifters($formHelper, $time_after_which_members_are_late_with_shifts)
-          ->getQuery()
-          ->getResult();
-    }
 
     private function sendAlertsByEmail(InputInterface $input, OutputInterface $output, $alerts, $template) {
         $mailer = $this->getContainer()->get('mailer');

--- a/src/AppBundle/Command/AmbassadorShiftTimeLogCommand.php
+++ b/src/AppBundle/Command/AmbassadorShiftTimeLogCommand.php
@@ -1,0 +1,91 @@
+<?php
+// src/AppBundle/Command/AmbassadorShiftTimeLogCommand.php
+namespace AppBundle\Command;
+
+use Swift_Message;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Doctrine\ORM\Query\Expr\Join;
+
+class AmbassadorShiftTimeLogCommand extends ContainerAwareCommand
+{
+    protected function configure()
+    {
+        $this
+          ->setName('app:shift:send_late_shifters')
+          ->setDescription('Send shifters which are too late')
+          ->setHelp('This command allows you to send alerts for shifters that are too late')
+            ->addOption('emails', null, InputOption::VALUE_OPTIONAL, 'Email recipients (comma separated)')
+            ->addOption('emailTemplate', null, InputOption::VALUE_OPTIONAL, 'Template used in email alerts', 'SHIFT_LATE_ALERT_EMAIL');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $email_template = $input->getOption('emailTemplate');
+
+        $alerts = $this->computeAlerts();
+        $nbAlerts = count($alerts);
+        if ($nbAlerts > 0) {
+            $output->writeln('<fg=cyan;>Found ' . $nbAlerts . ' alerts to send</>');
+            $this->sendAlertsByEmail($input, $output, $alerts, $email_template);
+        } else {
+            $output->writeln('<fg=cyan;>No shift alert to send</>');
+        }
+    }
+
+    private function computeAlerts() {
+        $time_after_which_members_are_late_with_shifts = $this->getContainer()->getParameter('time_after_which_members_are_late_with_shifts');
+
+        $em = $this->getContainer()->get('doctrine')->getManager();
+        $qb = $em->getRepository("AppBundle:Membership")->createQueryBuilder('o');
+        $qb = $qb->leftJoin("o.beneficiaries", "b")
+            ->leftJoin("b.user", "u")
+            ->leftJoin("o.registrations", "r")->addSelect("r");
+        $qb = $qb->andWhere('o.member_number > 0'); //do not include admin user
+        $qb = $qb->leftJoin("o.registrations", "lr", Join::WITH,'lr.date > r.date')->addSelect("lr")
+            ->where('lr.id IS NULL') //registration is the last one registere
+            ->leftJoin("o.timeLogs", "c")->addSelect("c")
+            ->addSelect("(SELECT SUM(ti.time) FROM AppBundle\Entity\TimeLog ti WHERE ti.membership = o.id) AS HIDDEN time");
+        $qb = $qb->andWhere('o.withdrawn = 0');
+        $qb = $qb->andWhere('o.frozen = 0');
+        $qb = $qb->andWhere('b.membership IN (SELECT IDENTITY(t.membership) FROM AppBundle\Entity\TimeLog t GROUP BY t.membership HAVING SUM(t.time) < :compteurlt * 60)')
+            ->setParameter('compteurlt', $time_after_which_members_are_late_with_shifts);
+        $alerts = $qb->getQuery()->getResult();
+        return $alerts;
+    }
+
+    private function sendAlertsByEmail(InputInterface $input, OutputInterface $output, $alerts, $template) {
+        $mailer = $this->getContainer()->get('mailer');
+        $recipients = $input->getOption('emails') ? explode(',', $input->getOption('emails')) : null;
+        if ($recipients) {
+            setlocale(LC_TIME, 'fr_FR.UTF8');
+            $subject = '[ALERTE RETARDS] Membres en retard de shifts';
+
+            $shiftEmail = $this->getContainer()->getParameter('emails.shift');
+
+            $em = $this->getContainer()->get('doctrine')->getManager();
+            $dynamicContent = $em->getRepository('AppBundle:DynamicContent')->findOneByCode($template);
+            $template = null;
+            if ($dynamicContent) {
+                $template = $this->getContainer()->get('twig')->createTemplate($dynamicContent->getContent());
+            } else {
+                $template = 'emails/shift_late_alerts_default.html.twig';
+            }
+
+            $email = (new Swift_Message($subject))
+                ->setFrom($shiftEmail['address'], $shiftEmail['from_name'])
+                ->setTo($recipients)
+                ->setBody(
+                    $this->getContainer()->get('twig')->render(
+                        $template,
+                        array('membership_late_alerts' => $alerts)
+                    ),
+                    'text/html'
+                );
+            $mailer->send($email);
+            $output->writeln('<fg=cyan;>Email(s) sent</>');
+        }
+    }
+}

--- a/src/AppBundle/Controller/AmbassadorController.php
+++ b/src/AppBundle/Controller/AmbassadorController.php
@@ -126,7 +126,11 @@ class AmbassadorController extends Controller
 
         $action = $form->get('action')->getData();
 
-        $em = $this->getDoctrine()->getManager();
+        $qb = $formHelper->initSearchQuery($this->getDoctrine()->getManager());
+        $qb = $qb->leftJoin("o.registrations", "lr", Join::WITH,'lr.date > r.date')->addSelect("lr")
+            ->where('lr.id IS NULL') //registration is the last one registere
+            ->leftJoin("o.timeLogs", "c")->addSelect("c")
+            ->addSelect("(SELECT SUM(ti.time) FROM AppBundle\Entity\TimeLog ti WHERE ti.membership = o.id) AS HIDDEN time");
 
         $page = $request->get('page');
         if (!intval($page))
@@ -136,27 +140,30 @@ class AmbassadorController extends Controller
 
         $session = new Session();
 
-        if (!$form->isSubmitted()) {
-            $form->get('sort')->setData($sort);
-            $form->get('dir')->setData($order);
-            $form->get('compteurlt')->setData($this->timeAfterWhichMembersAreLateWithShifts);
-            $form->get('withdrawn')->setData(1);
-            $form->get('frozen')->setData(1);
+        if ($form->isSubmitted() && $form->isValid()) {
+            if ($form->get('page')->getData() > 0) {
+                $page = $form->get('page')->getData();
+            }
+            if ($form->get('sort')->getData()) {
+                $sort = $form->get('sort')->getData();
+            }
+            if ($form->get('dir')->getData()) {
+                $order = $form->get('dir')->getData();
+            }
+            $formHelper->processSearchFormAmbassadorData($form, $qb, $session, "shifttimelog");
+        }else{
+            if (!$form->isSubmitted()) {
+                $form->get('sort')->setData($sort);
+                $form->get('dir')->setData($order);
+                $form->get('compteurlt')->setData($this->timeAfterWhichMembersAreLateWithShifts);
+                $form->get('withdrawn')->setData(1);
+                $form->get('frozen')->setData(1);
+            }
+            $qb = $qb->andWhere('o.withdrawn = 0');
+            $qb = $qb->andWhere('o.frozen = 0');
+            $qb = $qb->andWhere('b.membership IN (SELECT IDENTITY(t.membership) FROM AppBundle\Entity\TimeLog t GROUP BY t.membership HAVING SUM(t.time) < :compteurlt * 60)')
+                ->setParameter('compteurlt', $this->timeAfterWhichMembersAreLateWithShifts);
         }
-
-        if ($form->get('page')->getData() > 0) {
-            $page = $form->get('page')->getData();
-        }
-        if ($form->get('sort')->getData()) {
-            $sort = $form->get('sort')->getData();
-        }
-        if ($form->get('dir')->getData()) {
-            $order = $form->get('dir')->getData();
-        }
-
-        $qb = $em
-          ->getRepository("AppBundle:Membership")
-          ->findLateShifters($formHelper, null, $form, $session); 
 
         $limit = 25;
         $qb2 = clone $qb;

--- a/src/AppBundle/Repository/MembershipRepository.php
+++ b/src/AppBundle/Repository/MembershipRepository.php
@@ -99,14 +99,15 @@ class MembershipRepository extends \Doctrine\ORM\EntityRepository
     public function findLateShifters($time_after_which_members_are_late_with_shifts = null)
     {
         $qb = $this->createQueryBuilder('m')
-           ->leftJoin("m.beneficiaries", "b")->addSelect("b")                                                                     
-            ->andWhere('m.member_number > 0') //do not include admin user                                                                       
+           ->leftJoin("m.beneficiaries", "b")->addSelect("b")
+            ->andWhere('m.member_number > 0') //do not include admin user
             ->andWhere('m.withdrawn = 0')
             ->andWhere('m.frozen = 0')
             ->andWhere('m IN (SELECT IDENTITY(t.membership) FROM AppBundle\Entity\TimeLog t GROUP BY t.membership HAVING SUM(t.time) < :compteurlt * 60)')
             ->setParameter('compteurlt', $time_after_which_members_are_late_with_shifts);
-        return $qb                                                                                                      
-              ->getQuery()                                                                                                
-              ->getResult(); 
+        return $qb
+              ->getQuery()
+              ->getResult();
+    }
 
 }

--- a/src/AppBundle/Repository/MembershipRepository.php
+++ b/src/AppBundle/Repository/MembershipRepository.php
@@ -96,5 +96,29 @@ class MembershipRepository extends \Doctrine\ORM\EntityRepository
         return $qb->getQuery()->getResult();
     }
 
+    public function findLateShifters($formHelper, $time_after_which_members_are_late_with_shifts = null, $form = null, $session = null)
+    {
+        $qb = $formHelper->initSearchQuery($this->_em);
+
+        $qb = $qb->leftJoin("o.registrations", "lr", Join::WITH,'lr.date > r.date')->addSelect("lr")
+            ->where('lr.id IS NULL') //registration is the last one registere
+            ->leftJoin("o.timeLogs", "c")->addSelect("c")
+            ->addSelect("(SELECT SUM(ti.time) FROM AppBundle\Entity\TimeLog ti WHERE ti.membership = o.id) AS HIDDEN time");
+
+        if ($form === null) {
+            $qb = $qb->andWhere('o.withdrawn = 0');
+            $qb = $qb->andWhere('o.frozen = 0');
+            $qb = $qb->andWhere('b.membership IN (SELECT IDENTITY(t.membership) FROM AppBundle\Entity\TimeLog t GROUP BY t.membership HAVING SUM(t.time) < :compteurlt * 60)');
+        } else {
+            $formHelper->processSearchFormAmbassadorData($form, $qb, $session, "shifttimelog");
+        }
+
+        if ($time_after_which_members_are_late_with_shifts !== null) {
+            // avoid any surprise if $form overrides it: the explicit function argument wins
+            $qb = $qb->setParameter('compteurlt', $time_after_which_members_are_late_with_shifts);
+        }
+
+        return $qb;
+    }
 
 }


### PR DESCRIPTION
This PR adds a new command that permit to send a report with beneficiaries that are late in their shift (similar result as https://membre.nicecoop.fr/ambassador/shifttimelog but via e-mail, for instance as monthly reports for managers)