### PR TITLE
Bugfix : conflits dans le routing de MembershipController

### DIFF
--- a/src/AppBundle/Controller/MembershipController.php
+++ b/src/AppBundle/Controller/MembershipController.php
@@ -70,8 +70,9 @@ class MembershipController extends Controller
 
     /**
      * Finds and displays a membership entity.
+     * Why the '/show' in the route? Because routing conflict if not
      *
-     * @Route("/{member_number}", name="member_show")
+     * @Route("/{member_number}/show", name="member_show")
      * @Method("GET")
      * @param Membership $member
      * @return \Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\Response


### PR DESCRIPTION
Dans la PR #641 j'avais renommé la route `/member/show/{member_number}` en `/member/{member_number}``, mais avec symfony on ne peut pas donner d'ordre de priorisation sur les routes, donc ca rentrait en conflit avec `/member/join` ou `/member/office_tools`

Solution : re-renommer en `/member/{member_number}/show`