### PR TITLE
Créneaux : amélioration UX sur le bouton supprimer

### DIFF
--- a/app/Resources/views/admin/booking/_partial/bucket_modal.html.twig
+++ b/app/Resources/views/admin/booking/_partial/bucket_modal.html.twig
@@ -41,13 +41,13 @@ It use the materialize modal class https://materializecss.com/modals.html
                         {% if use_card_reader_to_validate_shifts and shift.isPastOrCurrent %}
                             {% if shift.wasCarriedOut %}
                                 <form action="{{ path('shift_invalidate', { 'id': shift.id }) }}" method="POST" id="shift_invalidate_{{ shift.id }}">
-                                    <button type="submit" class="btn red">
+                                    <button type="submit" class="btn orange" title="Invalider la participation">
                                         <i class="material-icons left">highlight_off</i>Invalider la participation
                                     </button>
                                 </form>
                             {% else %}
                                 <form action="{{ path('shift_validate', { 'id': shift.id }) }}" method="POST" id="shift_validate_{{ shift.id }}">
-                                    <button type="submit" class="btn green">
+                                    <button type="submit" class="btn green" title="Valider la participation">
                                         <i class="material-icons left">check_circle</i>Valider la participation
                                     </button>
                                 </form>
@@ -55,11 +55,11 @@ It use the materialize modal class https://materializecss.com/modals.html
                         {% endif %}
                         <form action="{{ path('shift_free', { 'id': shift.id }) }}" method="POST" id="shift_free_{{ shift.id }}">
                             {% if shift.isPast %}
-                                <button type="submit" class="btn red">
-                                    <i class="material-icons left">delete</i>Supprimer
+                                <button type="submit" class="btn orange" title="Supprimer la participation">
+                                    <i class="material-icons left">delete</i>Supprimer la participation
                                 </button>
                             {% else %}
-                                <button type="submit" class="btn orange">
+                                <button type="submit" class="btn orange" title="Libérer">
                                     <i class="material-icons left">lock_open</i>Libérer
                                 </button>
                             {% endif %}
@@ -137,7 +137,9 @@ It use the materialize modal class https://materializecss.com/modals.html
         {{ form_widget(shift_add_form.formation) }}
     </div>
     <div class="col s3">
-        <button type="submit" class="btn waves-effect waves-light teal"><i class="material-icons left">add</i>Ajouter</button>
+        <button type="submit" class="btn waves-effect waves-light teal">
+            <i class="material-icons left">add</i>Ajouter
+        </button>
     </div>
 </div>
 {{ form_row(shift_add_form._token) }}

--- a/app/Resources/views/admin/booking/_partial/bucket_modal.html.twig
+++ b/app/Resources/views/admin/booking/_partial/bucket_modal.html.twig
@@ -55,7 +55,7 @@ It use the materialize modal class https://materializecss.com/modals.html
                         {% endif %}
                         <form action="{{ path('shift_free', { 'id': shift.id }) }}" method="POST" id="shift_free_{{ shift.id }}">
                             {% if shift.isPast %}
-                                <button type="submit" class="btn orange" title="Supprimer la participation">
+                                <button type="submit" class="btn red" title="Supprimer la participation">
                                     <i class="material-icons left">delete</i>Supprimer la participation
                                 </button>
                             {% else %}
@@ -71,7 +71,7 @@ It use the materialize modal class https://materializecss.com/modals.html
             <li>
                 <div class="collapsible-header" style="display: block;">
                     <div class="row" style="margin-bottom: 0px;">
-                        <div class="col {% if not shift.lastShifter %}s11{% else %}s12{% endif %}">
+                        <div class="col s12">
                             <b>
                                 <span style="font-style: italic">
                                     {% if shift.lastShifter %}réservé à {{ shift.lastShifter.displayNameWithMemberNumber }}
@@ -85,15 +85,6 @@ It use the materialize modal class https://materializecss.com/modals.html
                                 </b>&nbsp;(sans formation particulière)
                             {% endif %}
                         </div>
-                        {% if not shift.lastShifter %}
-                            <div class="col s1">
-                                <form name="form" method="post" action="{{ path('shift_delete', {'id': shift.id}) }}" onsubmit="return confirm('Etes-vous sûr de supprimer ce poste ?!');">
-                                    <input type="hidden" name="_method" value="DELETE">
-                                    <input id="form__token" type="hidden" name="form[_token]" value="{{ csrf_token('form') }}">
-                                    <a href="#" onclick="$(this).closest('form').submit(); event.stopPropagation();" title="Supprimer ce poste" class="red-text">✗</a>
-                                </form>
-                            </div>
-                        {% endif %}
                     </div>
                 </div>
                 <div class="collapsible-body">
@@ -116,6 +107,16 @@ It use the materialize modal class https://materializecss.com/modals.html
                         </div>
                     </div>
                     {{ form_end(shift_book_forms[shift.id]) }}
+                    {# TODO: use symfony form + confirmation-modal #}
+                    {% if not shift.lastShifter %}
+                        <form name="form" method="post" action="{{ path('shift_delete', { 'id': shift.id }) }}" onsubmit="return confirm('Etes-vous sûr de supprimer ce poste ?!');">
+                            <input type="hidden" name="_method" value="DELETE">
+                            <input id="form__token" type="hidden" name="form[_token]" value="{{ csrf_token('form') }}">
+                            <a href="#" onclick="$(this).closest('form').submit(); event.stopPropagation();" title="Supprimer le poste" class="btn red">
+                                <i class="material-icons left">delete</i>Supprimer
+                            </a>
+                        </form>
+                    {% endif %}
                 </div>
             </li>
         {% endif %}
@@ -162,7 +163,7 @@ It use the materialize modal class https://materializecss.com/modals.html
 <form method="post" action="{{ path('bucket_delete', { 'id': bucket.id }) }}" onsubmit="return confirm('Supprimer les créneaux et les réservations ?!');" style="display:inline;">
     <input type="hidden" name="_method" value="DELETE">
     <input type="hidden" name="form[_token]" value="{{ csrf_token('form') }}">
-    <button type="submit" title="Supprimer tous les créneaux à cette heure et ce poste" class="red btn">
+    <button type="submit" class="btn red" title="Supprimer tous les créneaux à cette heure et ce poste">
         <i class="material-icons left">delete</i>Supprimer
     </button>
 </form>

--- a/app/Resources/views/admin/period/edit.html.twig
+++ b/app/Resources/views/admin/period/edit.html.twig
@@ -20,7 +20,7 @@
     {{ form_end(form) }}
 
     {% if is_granted("ROLE_ADMIN") %}
-        <a href="#remove-period-confirmation-modal" class="modal-trigger btn waves-effect waves-light red" title="supprimer le créneau type">
+        <a href="#remove-period-confirmation-modal" class="modal-trigger btn waves-effect waves-light red" title="Supprimer le créneau type">
             Supprimer
         </a>
         {{ form_start(delete_form) }}

--- a/app/Resources/views/user/_partial/shift_card.html.twig
+++ b/app/Resources/views/user/_partial/shift_card.html.twig
@@ -24,7 +24,7 @@
         {% if is_granted('free',shift) %}
             <form action="{{ path('shift_free', { 'id': shift.id }) }}" method="POST">
                 {% if shift.isPast %}
-                    <button type="submit" class="btn orange" title="Supprimer la participation">
+                    <button type="submit" class="btn red" title="Supprimer la participation">
                         <i class="material-icons left">delete</i>Supprimer la participation
                     </button>
                 {% else %}

--- a/app/Resources/views/user/_partial/shift_card.html.twig
+++ b/app/Resources/views/user/_partial/shift_card.html.twig
@@ -9,7 +9,7 @@
         {% if use_card_reader_to_validate_shifts and shift.isPastOrCurrent %}
             {% if shift.wasCarriedOut %}
                 <form action="{{ path('shift_invalidate', { 'id': shift.id }) }}" method="POST" id="invalidate_shift_{{ shift.id }}">
-                    <button type="submit" class="btn red" title="Invalider la participation">
+                    <button type="submit" class="btn orange" title="Invalider la participation">
                         <i class="material-icons left">highlight_off</i>Invalider la participation
                     </button>
                 </form>
@@ -24,8 +24,8 @@
         {% if is_granted('free',shift) %}
             <form action="{{ path('shift_free', { 'id': shift.id }) }}" method="POST">
                 {% if shift.isPast %}
-                    <button type="submit" class="btn red" title="Supprimer">
-                        <i class="material-icons left">delete</i>Supprimer
+                    <button type="submit" class="btn orange" title="Supprimer la participation">
+                        <i class="material-icons left">delete</i>Supprimer la participation
                     </button>
                 {% else %}
                     <button type="submit" class="btn orange" title="Libérer">

--- a/src/AppBundle/Controller/BookingController.php
+++ b/src/AppBundle/Controller/BookingController.php
@@ -421,16 +421,13 @@ class BookingController extends Controller
             array(
                 'action' => $this->generateUrl('shift_new'),
                 'only_add_formation' => true,
-            )
-        )
-            ->createView();
+            ));
 
         return $this->render('admin/booking/_partial/bucket_modal.html.twig', [
             'shifts' => $shifts,
-            'shift_add_form' => $shiftAddForm,
+            'shift_add_form' => $shiftAddForm->createView(),
             'shift_book_forms' => $shiftBookForms
         ]);
-
     }
 
     /**
@@ -551,7 +548,7 @@ class BookingController extends Controller
                 $count++;
             }
             $em->flush();
-            $session->getFlashBag()->add('success', $count . " shifts removed");
+            $session->getFlashBag()->add('success', $count . " créneaux ont été supprimés !");
         }
         return $this->redirectToRoute('booking_admin');
     }


### PR DESCRIPTION
Suite de #646

### Quoi ?

Dans la page Admin > Gérer les créneaux : clarifier le bouton supprimer, entre "supprimer un bénéficiaire d'un créneau" de "supprimer un poste de créneau" de "supprimer un créneau entier"

Modifications apportées : 
- renommé "Supprimer" en "Supprimer la participation"
- bougé l'action de "Supprimer" un poste libre dans le collapsible-body + transformé en vrai bouton (similaire au changement effectué dans la PR #627 pour la suppression d'un poste de créneau type)
- généralisé la couleur "orange" pour "invalider", et "rouge" pour "supprimer"

### Captures d'écran

||Avant|Après|
|---|---|---|
|créneau avec bénéficiaire inscrit|![Screenshot from 2022-11-25 14-28-36](https://user-images.githubusercontent.com/7147385/203996437-a6abee7a-2080-4063-84fe-cff08ef94fac.png)|![Screenshot from 2022-11-25 14-27-42](https://user-images.githubusercontent.com/7147385/203996711-88f1465c-7e5a-4054-a28f-5099133e504e.png)|
|créneau libre|![Screenshot from 2022-11-25 14-28-48](https://user-images.githubusercontent.com/7147385/203996584-1386b9e5-2d42-42b4-b193-0a19991e3ab6.png)|![Screenshot from 2022-11-25 14-27-33](https://user-images.githubusercontent.com/7147385/203996455-d2e34e6f-a4ee-4ca7-bfaf-51f8603ad58a.png)|
