### PR TITLE
Bugfix : coté admin, pouvoir réserver un créneau 'volant'

### DIFF
--- a/app/Resources/views/admin/booking/_partial/bucket_modal.html.twig
+++ b/app/Resources/views/admin/booking/_partial/bucket_modal.html.twig
@@ -108,7 +108,7 @@ It use the materialize modal class https://materializecss.com/modals.html
                                 <div class="col s2">
                                     <div>
                                         <label style="color: #5f5a5a; font-weight: 600;">
-                                            <input type="radio" name="form[fixe]" checked value="0">
+                                            <input type="radio" name="form[fixe]" value="0" checked>
                                             <span>volant</span>
                                         </label>
                                     </div>
@@ -124,7 +124,7 @@ It use the materialize modal class https://materializecss.com/modals.html
                                 </div>
                             {% else %}
                                 <div class="col s3">
-                                    <input type="hidden" id="appbundle_shift_fixe" name="appbundle_shift[fixe]" checked value="0">
+                                    <input type="hidden" id="appbundle_shift_fixe" name="appbundle_shift[fixe]" value="0" checked>
                                     <button class="btn add">Ajouter</button>
                                 </div>
                             {% endif %}

--- a/src/AppBundle/Controller/BookingController.php
+++ b/src/AppBundle/Controller/BookingController.php
@@ -745,7 +745,7 @@ class BookingController extends Controller
             }
 
             // $fixe = $form->get("fixe")->getData();  // Symfony 3.4 : always returns true, even if "0" is passed from the form data
-            $fixe = $request->request->get("form")["fixe"];  // TODO Symfony 4.1 : re-use the previous line
+            $fixe = $request->request->get("form")["fixe"] ?? false;  // TODO Symfony 4.1 : re-use the previous line
             $str = $form->get("shifter")->getData();
             $em = $this->getDoctrine()->getManager();
             // $membership = $em->getRepository('AppBundle:Membership')->findOneFromAutoComplete($str);

--- a/src/AppBundle/Controller/BookingController.php
+++ b/src/AppBundle/Controller/BookingController.php
@@ -733,7 +733,7 @@ class BookingController extends Controller
 
         $form = $this->createFormBuilder()
             ->add('shifter', TextType::class)
-            ->add('fixe', RadioType::class)
+            ->add('fixe', RadioType::class, array('required' => false))  // TODO Symfony 4.1 : 'false_values' => ['false', '0']
             ->getForm();
 
         $form->handleRequest($request);
@@ -744,7 +744,8 @@ class BookingController extends Controller
                 return new Response($this->generateUrl("booking_admin"), 205);
             }
 
-            $fixe = $form->get("fixe")->getData();
+            // $fixe = $form->get("fixe")->getData();  // Symfony 3.4 : always returns true, even if "0" is passed from the form data
+            $fixe = $request->request->get("form")["fixe"];  // TODO Symfony 4.1 : re-use the previous line
             $str = $form->get("shifter")->getData();
             $em = $this->getDoctrine()->getManager();
             // $membership = $em->getRepository('AppBundle:Membership')->findOneFromAutoComplete($str);


### PR DESCRIPTION
Voir l'issue pour les détails

Testé tous les cas de figure en regardant la donnée finale dans la DB
- use_fly_and_fixed : true ou false
- si use_fly_and_fixed = true : choix volant ou fixe