### PR TITLE
Admin : homogéniser l'ordre d'affichage des créneaux des bucket

### DIFF
--- a/src/AppBundle/Controller/BookingController.php
+++ b/src/AppBundle/Controller/BookingController.php
@@ -263,7 +263,6 @@ class BookingController extends Controller
 
         try {
             if ($filterForm->isSubmitted() && $filterForm->isValid()) {
-
                 $job = $filterForm->get("job")->getData();
                 $filling = $filterForm->get("filling")->getData();
 
@@ -307,19 +306,17 @@ class BookingController extends Controller
     }
 
     /**
-     * build the bucket (regrouping all the shift at the same time
-     * with the same job)
+     * build the bucket (regrouping all the shift at the same time with the same job)
+     * // TODO Maybe it should be in the BucketRepository...
      * @param array $shifts
      * @param string|null $filling
      * @return array
      */
     private function bucketFactory(array $shifts, string $filling = null): array
     {
-        // TODO Maybe it should be but in the BucketRepository...
-
         $bucketsByDay = array();
-        foreach ($shifts as $shift) {
 
+        foreach ($shifts as $shift) {
             $day = $shift->getStart()->format("d m Y");
             $jobId = $shift->getJob()->getId();
 
@@ -344,14 +341,13 @@ class BookingController extends Controller
                     foreach ($bucketByInterval as $interval => $bucket) {
                         $nbShifts = count($bucket->getShifts());
                         $bookableShifts = count($shiftService->getBookableShifts($bucket));
-                        if  (($filling == 'empty' and  $bookableShifts != $nbShifts  )
-                          or ($filling == 'full' and $bookableShifts !=  0)
-                            or ( $filling == 'partial' and ($bookableShifts == $nbShifts  or $bookableShifts ==  0))) {
-
+                        if  (($filling == 'empty' and $bookableShifts != $nbShifts)
+                        or ($filling == 'full' and $bookableShifts != 0)
+                        or ( $filling == 'partial' and ($bookableShifts == $nbShifts or $bookableShifts == 0))) {
                             unset($bucketsByDay[$day][$jobId][$interval]);
-                            if (count($bucketsByDay[$day][$jobId])==0){
+                            if (count($bucketsByDay[$day][$jobId]) == 0) {
                                 unset($bucketsByDay[$day][$jobId]);
-                                if (count($bucketsByDay[$day])==0){
+                                if (count($bucketsByDay[$day]) == 0) {
                                     unset($bucketsByDay[$day]);
                                 }
                             }
@@ -373,7 +369,6 @@ class BookingController extends Controller
      */
     public function adminAction(Request $request): Response
     {
-
         $filter = $this->adminFilterFormFactory($request);
 
         // calendar creation
@@ -393,7 +388,6 @@ class BookingController extends Controller
             'jobs' => $jobs,
             'beneficiaries' => $beneficiaries,
         ]);
-
     }
 
     /**

--- a/src/AppBundle/Entity/ShiftBucket.php
+++ b/src/AppBundle/Entity/ShiftBucket.php
@@ -71,10 +71,15 @@ class ShiftBucket
                     return 1;
                 }
             } else {
-                if (!$b->getFormation())
+                if (!$b->getFormation()) {
                     return -1;
-                else
-                    return $a->getFormation()->getId() < $b->getFormation()->getId();
+                } else {
+                    if ($a->getFormation()->getId() != $b->getFormation()->getId()) {
+                        return $a->getFormation()->getId() < $b->getFormation()->getId();
+                    } else {
+                        return $a->getBookedTime() < $b->getBookedTime();
+                    }
+                }
             }
         }
         if ($a->getLastShifter() && $a->getLastShifter()->getId() == $beneficiary->getId()) {

--- a/src/AppBundle/Repository/ShiftRepository.php
+++ b/src/AppBundle/Repository/ShiftRepository.php
@@ -31,7 +31,11 @@ class ShiftRepository extends \Doctrine\ORM\EntityRepository
             ->setParameter('start', $shift->getStart())
             ->setParameter('end', $shift->getEnd())
             ->setParameter('job', $shift->getJob())
-            ->orderBy('s.shifter', 'DESC');
+            ->addSelect('CASE WHEN s.formation IS NOT NULL THEN 1 ELSE 0 END as HIDDEN formation_is_not_null')
+            ->addSelect('CASE WHEN s.shifter IS NOT NULL THEN 1 ELSE 0 END as HIDDEN shifter_is_not_null')
+            ->addOrderBy('formation_is_not_null', 'DESC')
+            ->addOrderBy('shifter_is_not_null', 'DESC')
+            ->addOrderBy('s.bookedTime', 'DESC');  // ordering similar to ShiftBucket.compareShifts()
 
         return $qb
             ->getQuery()


### PR DESCRIPTION
Voir l'issue pour les détails

J'ai fait en sorte que l'order des bucket_card (ShiftBucket.compareShifts()) soient au plus près similaire à l'order des bucket_modal (ShiftRepository.findBucket())

1. est-ce que le shift a une formation ? (si oui, alors ordonné par formation_id, s'applique seulement à bucket_card)
2. est-ce que le shift a un shifter ?
3. le bookedTime du shift
