### PR TITLE
Améliore la gestion de l'autocompletion

### DIFF
--- a/app/Resources/views/admin/booking/_partial/bucket_modal.html.twig
+++ b/app/Resources/views/admin/booking/_partial/bucket_modal.html.twig
@@ -97,12 +97,11 @@ It use the materialize modal class https://materializecss.com/modals.html
                     </div>
                 </div>
                 <div class="collapsible-body">
-                    <form method="post" action="{{ path('admin_shift_book',{'id': shift.id}) }}">
-                        <input id="form__token" type="hidden" name="form[_token]" value="{{ csrf_token('form') }}">
+                    {{ form_start(shift_book_forms[shift.id]) }}
                         <div class="row">
                             <div class="col {% if use_fly_and_fixed %}s7{% else %}s9{% endif %} input-field">
-                                <label for="appbundle_shift_shifter{{ shift.id }}">Bénéficiaire</label>
-                                <input id="appbundle_shift_shifter{{ shift.id }}" name="form[shifter]" type="text" class="autocomplete" />
+                                {{ form_label(shift_book_forms[shift.id].shifter) }}
+                                {{ form_widget(shift_book_forms[shift.id].shifter) }}
                             </div>
                             {% if use_fly_and_fixed %}
                                 <div class="col s2">
@@ -129,7 +128,7 @@ It use the materialize modal class https://materializecss.com/modals.html
                                 </div>
                             {% endif %}
                         </div>
-                    </form>
+                    {{ form_end(shift_book_forms[shift.id]) }}
                 </div>
             </li>
         {% endif %}

--- a/app/Resources/views/admin/booking/_partial/bucket_modal.html.twig
+++ b/app/Resources/views/admin/booking/_partial/bucket_modal.html.twig
@@ -105,28 +105,15 @@ It use the materialize modal class https://materializecss.com/modals.html
                             </div>
                             {% if use_fly_and_fixed %}
                                 <div class="col s2">
-                                    <div>
-                                        <label style="color: #5f5a5a; font-weight: 600;">
-                                            <input type="radio" name="form[fixe]" value="0" checked>
-                                            <span>volant</span>
-                                        </label>
-                                    </div>
-                                    <div>
-                                        <label style="color: #5f5a5a; font-weight: 600;">
-                                            <input type="radio" name="form[fixe]" value="1">
-                                            <span>fixe</span>
-                                        </label>
-                                    </div>
-                                </div>
-                                <div class="col s3">
-                                    <button class="btn add" disabled="disabled">Ajouter</button>
-                                </div>
-                            {% else %}
-                                <div class="col s3">
-                                    <input type="hidden" id="appbundle_shift_fixe" name="appbundle_shift[fixe]" value="0" checked>
-                                    <button class="btn add">Ajouter</button>
+                                    {{ form_widget(shift_book_forms[shift.id].fixe) }}
                                 </div>
                             {% endif %}
+                            <div class="col s3">
+                                {% if not use_fly_and_fixed %}
+                                    {{ form_widget(shift_book_forms[shift.id].fixe) }}
+                                {% endif %}
+                                <button class="btn add">Ajouter</button>
+                            </div>
                         </div>
                     {{ form_end(shift_book_forms[shift.id]) }}
                 </div>

--- a/app/Resources/views/admin/booking/index.html.twig
+++ b/app/Resources/views/admin/booking/index.html.twig
@@ -83,7 +83,7 @@
 {% include "admin/booking/_partial/bucket_calendar.html.twig" with { bucketsByDay: bucketsByDay } %}
 
 <div id="modal-bucket" class="modal">
-    <div class="modal-content">
+    <div id="modal-bucket-content" class="modal-content">
     </div>
 </div>
 
@@ -106,29 +106,17 @@
                 }
             })
             .trigger('change');
-            $('.modal').modal({
+            $('#modal-bucket').modal({
                 onCloseEnd: function() {
-                    $('.modal-content').html('');
+                    $('#modal-bucket-content').html('');
                 },
                 onOpenStart: function(modal, trigger) {
                     var url = $(trigger).attr('data-source');
                     $.get(url, function( data ) {
-                        $('.modal-content').html(data);
+                        $('#modal-bucket-content').html(data);
                         $('.collapsible').collapsible();
-                        $('input.autocomplete').autocomplete({
-                            data: {
-                                {% for beneficiary in beneficiaries %}
-                                    "{{ beneficiary.displayNameWithMemberNumber }}": null,
-                                {% endfor %}
-                            },
-                            limit: 10,
-                            onAutocomplete: function (val) {
-                                // Callback function when value is autocomplete.
-                                $('button.add').removeAttr('disabled');
-                            },
-                            minLength: 2,
-                        });
                         $('select').formSelect();
+                        eval($('#modal-bucket-content script').html());
                     });
                 }
             });

--- a/app/Resources/views/admin/commission/edit.html.twig
+++ b/app/Resources/views/admin/commission/edit.html.twig
@@ -132,13 +132,20 @@
                             var data = $form.serialize();
                             $.ajax($form.attr('action'),{
                                 data: data,
-                                method: 'post'
-                            }).success(function (d) {
-                                //console.log(d);
-                                if (d.success){
-                                    Materialize.toast(d.message,2500,'green');
-                                }else{
-                                    Materialize.toast(d.message,2500,'red');
+                                method: 'post',
+                                success: function (d) {
+                                    M.toast({
+                                        html: d.message,
+                                        displayLength: 2500,
+                                        classes: 'green'
+                                    });
+                                },
+                                error: function (d) {
+                                    M.toast({
+                                        html: d.message,
+                                        displayLength: 2500,
+                                        classes: 'red'
+                                    });
                                 }
                             });
                         }
@@ -149,15 +156,23 @@
                         var data = $form.serialize();
                         $.ajax($form.attr('action'),{
                             data: data,
-                            method: 'post'
-                        }).success(function (d) {
-                            if (d.success){
-                                Materialize.toast(d.message,2500,'green');
+                            method: 'post',
+                            success: function (d) {
+                                M.toast({
+                                    html: d.message,
+                                    displayLength: 2500,
+                                    classes: 'green'
+                                });
                                 $('#users .chips').append(d.html);
-                            }else{
-                                Materialize.toast(d.message,2500,'red');
+                                $('#form_beneficiary').val('');
+                            },
+                            error: function (d) {
+                                M.toast({
+                                    html: d.message,
+                                    displayLength: 2500,
+                                    classes: 'red'
+                                });
                             }
-                            $('#form_beneficiary').val('');
                         });
                     });
                 });

--- a/app/Resources/views/admin/mail/send.html.twig
+++ b/app/Resources/views/admin/mail/send.html.twig
@@ -13,13 +13,12 @@
             {{ form_label(form.template) }}
         </div>
         <div class="col s12">
-            <label>Destinataire(s)</label>
-            <div class="beneficiaries chips ">
-            </div>
+            {{ form_label(form.to) }}
+            {{ form_widget(form.to) }}
         </div>
         <div class="col s12">
             <label>Non-membre(s) en copie</label>
-            <div class="non-members chips ">
+            <div class="non-members chips">
             </div>
         </div>
         <div class="input-field col s12">
@@ -44,37 +43,6 @@
     <script>
         jQuery(
             function() {
-                function updateBeneficiaries() {
-                    var chipsData = M.Chips.getInstance($('.beneficiaries')).chipsData;
-                    var ids = chipsData.map((member) => member['tag']); // .split(' ')[0].substring(1)));
-                    $("input[name='form[to]']").val(JSON.stringify(ids));
-                };
-                $.ajax({
-                    type: 'GET',
-                    url: '{{ path('mail_get_beneficiaries') }}',
-                    success: function(response) {
-                        var dataUsers = response.reduce(function(map, obj) {
-                            map[obj] = null;
-                            return map;
-                        }, {});
-                        $('.beneficiaries').chips({
-                            placeholder: 'Beneficiaire',
-                            data: [
-                                {% for beneficiary in to %}
-                                {
-                                tag: "{{ beneficiary.displayNameWithMemberNumber }}",
-                            },{% endfor %} ],
-                            autocompleteOptions: {
-                                data: dataUsers,
-                                limit: Infinity,
-                                minLength: 1
-                            },
-                            onChipAdd: updateBeneficiaries,
-                            onChipDelete: updateBeneficiaries
-                        });
-                        updateBeneficiaries();
-                    }
-                });
                 function updateNonMembers() {
                     var chipsData = M.Chips.getInstance($('.non-members')).chipsData;
                     var emails = chipsData.map((member) => (member['tag']));

--- a/app/Resources/views/admin/mail/send.html.twig
+++ b/app/Resources/views/admin/mail/send.html.twig
@@ -48,28 +48,18 @@
                     var emails = chipsData.map((member) => (member['tag']));
                     $("input[name='form[cci]']").val(JSON.stringify(emails));
                 };
-                $.ajax({
-                    type: 'GET',
-                    url: '{{ path('mail_get_non_members') }}',
-                    success: function(response) {
-                        var dataUsers = response.reduce(function(map, obj) {
-                            map[obj] = null;
-                            return map;
-                        }, {});
-                        $('.non-members').chips({
-                            placeholder: 'Non-membre',
-                            data: [],
-                            autocompleteOptions: {
-                                data: dataUsers,
-                                limit: Infinity,
-                                minLength: 1
-                            },
-                            onChipAdd: updateNonMembers,
-                            onChipDelete: updateNonMembers
-                        });
-                        updateNonMembers();
-                    }
+                $('.non-members').chips({
+                    placeholder: 'Non-membre',
+                    data: [],
+                    autocompleteOptions: {
+                        data: {{ non_members | json_encode(constant('JSON_UNESCAPED_UNICODE')) | raw }},
+                        limit: Infinity,
+                        minLength: 1
+                    },
+                    onChipAdd: updateNonMembers,
+                    onChipDelete: updateNonMembers
                 });
+                updateNonMembers();
             }
         );
     </script>

--- a/app/Resources/views/admin/member/join.html.twig
+++ b/app/Resources/views/admin/member/join.html.twig
@@ -25,11 +25,17 @@
     {{ form_start(form) }}
         <div class="row">
             <div class="input-field col m6 s12">
+                <div class="errors">
+                    {{ form_errors(form.from_text) }}
+                </div>
                 <i class="material-icons prefix">person</i>
                 {{ form_widget(form.from_text) }}
                 {{ form_label(form.from_text) }}
             </div>
             <div class="input-field col m6 s12">
+                <div class="errors">
+                    {{ form_errors(form.dest_text) }}
+                </div>
                 <i class="material-icons prefix">person</i>
                 {{ form_widget(form.dest_text) }}
                 {{ form_label(form.dest_text) }}
@@ -37,25 +43,4 @@
         </div>
         {{ form_widget(form.join) }}
     {{ form_end(form) }}
-{% endblock %}
-
-{% block javascripts %}
-    <script>
-        $(document).ready(function() {
-            $('input.autocomplete').autocomplete({
-                data: {
-                    {% for member in members %}
-                        {% if member.mainBeneficiary %}
-                            "{{ member.mainBeneficiary.displayNameWithMemberNumber }}": null,
-                        {% endif %}
-                    {% endfor %}
-                },
-                limit: 10, // The max amount of results that can be shown at once. Default: Infinity.
-                onAutocomplete: function(val) {
-                    // Callback function when value is autcompleted.
-                },
-                minLength: 1, // The minimum length of the input for the autocomplete to start. Default: 1.
-            });
-        })
-    </script>
 {% endblock %}

--- a/app/Resources/views/admin/period/edit.html.twig
+++ b/app/Resources/views/admin/period/edit.html.twig
@@ -80,15 +80,18 @@
                                 </div>
                             </div>
                             <div class="collapsible-body">
+                                {{ form_start(pp_book_forms[position.id]) }}
                                 <div class="row">
-                                    <div class="col {% if use_fly_and_fixed %}s7{% else %}s9{% endif %} input-field">
-                                        <input id ="benef{{ position.id }}" type="text" class="autocomplete" name="beneficiary" placeholder="Beneficiaire" />
+                                    <div class="col s7 input-field">
+                                        {{ form_label(pp_book_forms[position.id].shifter) }}
+                                        {{ form_errors(pp_book_forms[position.id].shifter) }}
+                                        {{ form_widget(pp_book_forms[position.id].shifter) }}
                                     </div>
                                     <div class="col s3">
-                                        <input type="hidden" class="checkedTypeService{{ position.id }}" name="typeService{{ position.id }}" value=0 />
-                                        <button type="button" class="btn add" onclick="postPosition({{ position.id }})">Ajouter</button>
+                                        <button type="submit" class="btn waves-effect waves-light"><i class="material-icons left">add</i>Ajouter</button>
                                     </div>
                                 </div>
+                                {{ form_end(pp_book_forms[position.id]) }}
                             </div>
                         </li>
                     {% endif %}
@@ -130,56 +133,4 @@
         </div>
     </div>
     {{ form_end(position_form) }}
-{% endblock %}
-
-{% block javascripts %}
-    <script>
-        $(document).ready(function ($) {
-            $('input.autocomplete').autocomplete({
-                data: {
-                    {% for beneficiary in beneficiaries %}
-                        "{{ beneficiary.displayNameWithMemberNumber }}": null,
-                    {% endfor %}
-                },
-                limit: 10, // The max amount of results that can be shown at once. Default: Infinity.
-                onAutocomplete: function(val) {
-                    // Callback function when value is autcompleted.
-                    $('button.add').removeAttr('disabled');
-                },
-                minLength: 2, // The minimum length of the input for the autocomplete to start. Default: 1.
-            });
-            $('input.empty-shift').keydown(function () {
-                $('button.add:not(:disabled)').attr('disabled','disabled');
-            });
-        })
-
-        function postPosition(positionId) {
-            let selectedBenef = document.getElementById('benef'+positionId);
-
-            if (selectedBenef != null) {
-                let url = "{{ path('book_position_from_period',{'id': 'tmpId'}) }}";
-                url = url.replace("tmpId", positionId);
-
-                let body = {
-                    "beneficiary": selectedBenef.value
-                };
-
-                // If using old IE version
-                var xhttp = window.XMLHttpRequest ? new XMLHttpRequest() : new ActiveXObject("Microsoft.XMLHTTP");
-
-                xhttp.open("POST", url, true);
-                xhttp.onreadystatechange = function () {
-                    if (xhttp.readyState > 3) {
-                        if (200 <= xhttp.status && xhttp.status < 300) {
-                            window.location.replace(xhttp.responseText);
-                        } else {
-                            alert("une erreur est survenue");
-                        }
-                    }
-                };
-                xhttp.send(JSON.stringify(body));
-                return xhttp;
-            }
-        }
-    </script>
 {% endblock %}

--- a/app/Resources/views/booking/_partial/home_shift_contactform.html.twig
+++ b/app/Resources/views/booking/_partial/home_shift_contactform.html.twig
@@ -9,9 +9,8 @@
                 <div class="errors">
                     {{ form_errors(form.to) }}
                 </div>
-                {{ form_widget(form.to) }}
                 {{ form_label(form.to) }}
-                <div id="to{{ shift.id }}"></div>
+                {{ form_widget(form.to) }}
             </div>
             <div class="col s12">
                 <div class="errors">
@@ -30,26 +29,3 @@
            onclick="javascript:$('#contactform{{ shift.id }}').submit();return false;"><i class="material-icons right">send</i>Envoyer</a>
     </div>
 </div>
-<script>
-    function updateForm{{ shift.id}}() {
-        var chipsData = M.Chips.getInstance($('#to{{ shift.id }}')).chipsData;
-        var ids = chipsData.map((member) => (member['tag'].split(' ')[0].substring(1)));
-        $("#contactform{{ shift.id }} input[name='form[to]']").val(JSON.stringify(ids));
-    }
-    function toto{{ shift.id }}() {
-        var allMembers = [{% for shift in coShifts %}"{{ shift.shifter.publicDisplayNameWithMemberNumber }}",{% endfor %}];
-        $('#to{{ shift.id }}').chips({
-            autocompleteOptions: {
-                data: allMembers.reduce(function(map, obj) {
-                    map[obj] = null;
-                    return map;
-                }, {}),
-            },
-            data: allMembers.map((member) => ({tag: member})),
-            onChipAdd: updateForm{{ shift.id}},
-            onChipDelete: updateForm{{ shift.id}}
-        });
-        updateForm{{ shift.id}}();
-    }
-    setTimeout(toto{{ shift.id }},500);
-</script>

--- a/app/Resources/views/form/fields.html.twig
+++ b/app/Resources/views/form/fields.html.twig
@@ -11,35 +11,15 @@
 
 {% block autocomplete_beneficiary_widget %}
     {% spaceless %}
-        {% set attr = attr|merge({class: (attr.class|default('') ~ 'email_membership_autocomplete')|trim}) %}
-        {{ form_label(form) }}
-        <input type="text" autocomplete="off" {{ block('widget_attributes') }} {% if value is not empty %}value="{{ value }}" {% endif %}/>
+        <input type="text" {{ block('widget_attributes') }} {% if value is not empty %}value="{{ value }}" {% endif %}/>
     {% endspaceless %}
     <script>
         defer(function(){
-            //
-            $('#{{ id }}').on('keydown',function () {
-                if ($(this).val().length > 2){
-                    jQuery.ajax({
-                        type: 'POST',
-                        url: "{{ path('beneficiary_list') }}",
-                        data: {'string':$(this).val()},
-                        success: function (response) {
-                            var accounts = response;
-                            var data = {};
-                            for (var i = 0; i < accounts.length; i++) {
-                                data[accounts[i].name] = accounts[i].icon;
-                            }
-                            $('#{{ id }}').autocomplete({
-                                data: data,
-                                limit: 6, // The max amount of results that can be shown at once. Default: Infinity.
-                            }).trigger('keyup');
-                        }
-                    });
-                }
-            }).dblclick(function () {
-                $(this).val('');
-            })
+            // Init autocomplete
+            $('#{{ id }}').autocomplete({
+                data: {{ beneficiary_service.autocompleteBeneficiaries | json_encode(constant('JSON_UNESCAPED_UNICODE')) | raw }},
+                limit: 6,
+            });
         });
     </script>
 {% endblock %}

--- a/app/Resources/views/form/fields.html.twig
+++ b/app/Resources/views/form/fields.html.twig
@@ -75,6 +75,24 @@
     </script>
 {% endblock %}
 
+{% block radio_choice_widget %}
+    {% spaceless %}
+        <div {{ block('widget_container_attributes') }}>
+            {% for child in form %}
+                <div>
+                    <label for="{{ child.vars.id }}" class="required" style="color: #5f5a5a; font-weight: 600;">
+                        {{ form_widget(child) }}
+                        <span>{{ child.vars.label }}</span>
+                    </label>
+                </div>
+            {% endfor %}
+            {% for child in form %}
+                {{ form_widget(child) }}
+            {% endfor %}
+        </div>
+    {% endspaceless %}
+{% endblock %}
+
 {% block simplemde_editor_row %}
     <div class="markdow-editor">
         <div class="errors">

--- a/app/Resources/views/form/fields.html.twig
+++ b/app/Resources/views/form/fields.html.twig
@@ -61,7 +61,11 @@
                     return {tag: this.value};
                 }),
                 autocompleteOptions: {
+                    {% if is_granted("ROLE_USER_MANAGER") %}
                     data: {{ beneficiary_service.autocompleteBeneficiaries | json_encode(constant('JSON_UNESCAPED_UNICODE')) | raw }},
+                    {% else %}
+                    data: [],
+                    {% endif %}
                     limit: 6,
                 },
                 onChipAdd: updateInput{{ id }}Forms,

--- a/app/Resources/views/form/fields.html.twig
+++ b/app/Resources/views/form/fields.html.twig
@@ -24,6 +24,52 @@
     </script>
 {% endblock %}
 
+{% block autocomplete_beneficiary_collection_widget %}
+    {% spaceless %}
+        <div {{ block('widget_container_attributes') }}>
+            {% for child in form %}
+                {{ form_widget(child) }}
+            {% endfor %}
+        </div>
+    {% endspaceless %}
+    <div {% if id is not empty %}id="{{ id }}_chips"{% endif %} class="chips">
+    </div>
+    <script>
+        defer(function(){
+            function updateInput{{ id }}Forms() {
+                var chipsData = M.Chips.getInstance($('#{{ id }}_chips')).chipsData;
+                var list = $('#{{ id }}');
+                var counter = list.children().length
+                for (let i = 0; i < Math.abs(chipsData.length - counter); i++) {
+                    if (chipsData.length > counter) {
+                        $("<input>").attr({
+                            name: "{{ full_name }}[" + counter + "]",
+                            id: "{{ id }}" + '_' + counter,
+                            type: "hidden",
+                        }).appendTo(list);
+                    } else {
+                        list.children().last().remove();
+                    }
+                }
+                chipsData.each(function (index, member) {
+                    $("input[name='{{ full_name }}[" + index + "]']").val(member['tag']);
+                });
+            }
+            $('#{{ id }}_chips').chips({
+                placeholder: 'Beneficiaire',
+                data: $('#{{ id }} :input').map(function() {
+                    return {tag: this.value};
+                }),
+                autocompleteOptions: {
+                    data: {{ beneficiary_service.autocompleteBeneficiaries | json_encode(constant('JSON_UNESCAPED_UNICODE')) | raw }},
+                    limit: 6,
+                },
+                onChipAdd: updateInput{{ id }}Forms,
+                onChipDelete: updateInput{{ id }}Forms,
+            });
+        });
+    </script>
+{% endblock %}
 
 {% block simplemde_editor_row %}
     <div class="markdow-editor">

--- a/app/Resources/views/user/_partial/user_quick_form.html.twig
+++ b/app/Resources/views/user/_partial/user_quick_form.html.twig
@@ -106,14 +106,13 @@
             <div class="col s12">
                 <h4>Ajout à une adhésion existante</h4>
             </div>
-            <div class="col s12">
+            <div class="input-field col s12">
                 <div class="errors">
                     {{ form_errors(form.join_to) }}
                 </div>
-                <div class="input-field">
-                    <i class="material-icons prefix">person_add</i>
-                    {{ form_widget(form.join_to) }}
-                </div>
+                <i class="material-icons prefix">person_add</i>
+                {{ form_widget(form.join_to) }}
+                {{ form_label(form.join_to) }}
             </div>
         </div>
     </div>

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -53,6 +53,7 @@ twig:
     registration_duration: '%registration_duration%'
     support_email: '%transactional_mailer_user%'
     images_tmp_dir: '%images_tmp_dir%'
+    beneficiary_service: "@beneficiary_service"
     shift_service: "@shift_service"
     maximum_nb_of_beneficiaries_in_membership: '%maximum_nb_of_beneficiaries_in_membership%'
     allow_extra_shifts: '%allow_extra_shifts%'

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -167,6 +167,12 @@ services:
                 - "%max_time_in_advance_to_book_extra_shifts%"
                 - "%forbid_shift_overlap_time%"
 
+    beneficiary_service:
+            class:  AppBundle\Service\BeneficiaryService
+            public: true
+            arguments:
+                - "@doctrine.orm.entity_manager"
+
     logger.user_processor:
             class: AppBundle\Monolog\MonologUserProcessor
             arguments:

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -37,6 +37,9 @@ services:
     AppBundle\Controller\AmbassadorController:
         arguments:
             - "%time_after_which_members_are_late_with_shifts%"
+    AppBundle\Controller\BookingController:
+        arguments:
+            - "%use_fly_and_fixed%"
     AppBundle\Helper\:
         resource: '../../src/AppBundle/Helper'
         arguments: ['@service_container']

--- a/src/AppBundle/Command/SendMassMailCommand.php
+++ b/src/AppBundle/Command/SendMassMailCommand.php
@@ -100,7 +100,7 @@ class SendMassMailCommand extends ContainerAwareCommand
                 $to[] = $beneficiary->getEmail();
         }
         if (!$exclude_non_member){
-            $non_members = $em->getRepository("AppBundle:User")->findNonMember();
+            $non_members = $em->getRepository("AppBundle:User")->findActiveNonMembers();
             foreach ($non_members as $user){
                 $to[] = $user->getEmail();
             }

--- a/src/AppBundle/Controller/BookingController.php
+++ b/src/AppBundle/Controller/BookingController.php
@@ -17,6 +17,7 @@ use AppBundle\Security\ShiftVoter;
 use DateTime;
 use AppBundle\Entity\ShiftBucket;
 use AppBundle\Form\AutocompleteBeneficiaryType;
+use AppBundle\Form\RadioChoiceType;
 use AppBundle\Form\ShiftType;
 use Exception;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
@@ -42,6 +43,16 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
  */
 class BookingController extends Controller
 {
+    /**
+     * @var boolean
+     */
+    private $useFlyAndFixed;
+
+    public function __construct(bool $useFlyAndFixed)
+    {
+        $this->useFlyAndFixed = $useFlyAndFixed;
+    }
+
     /**
      * @return Response
      */
@@ -955,7 +966,20 @@ class BookingController extends Controller
         $form = $this->get('form.factory')->createNamedBuilder('shift_book_forms_' . $shift->getId())
             ->setAction($this->generateUrl('admin_shift_book', array('id' => $shift->getId())))
             ->add('shifter', AutocompleteBeneficiaryType::class, array('label'=>'Numéro d\'adhérent ou nom du membre', 'required'=>true));
-            ->add('fixe', RadioType::class);
+
+        if ($this->useFlyAndFixed) {
+            $form = $form->add('fixe', RadioChoiceType::class, [
+                'choices'  => [
+                    'Volant' => 0,
+                    'Fixe' => 1,
+                ],
+                'data' => 0
+            ]);
+        } else {
+            $form = $form->add('fixe', HiddenType::class, [
+                'data' => 0
+            ]);
+        }
 
         return $form->getForm();
     }

--- a/src/AppBundle/Entity/Beneficiary.php
+++ b/src/AppBundle/Entity/Beneficiary.php
@@ -625,22 +625,6 @@ class Beneficiary
         return '#' . $this->getMemberNumber() . ' ' . $this->getFirstname() . ' ' . $this->getLastname();
     }
 
-    public function getAutocompleteLabelFull(): string
-    {
-        $label = '#' . $this->getMemberNumber();
-
-        if($this->getMembership()->getWithdrawn()){
-            $label .= " [&#x26A0;]";
-        }elseif ($this->getMembership()->isFrozen()){
-            $label .= " [&#x2744;]";
-        }
-
-        $label .=  ' ' . $this->getFirstname() . ' ' . $this->getLastname();
-        $label .=   ' ' . $this->getEmail() . ' (' . $this->getId() . ')';
-        return $label;
-
-    }
-
     /**
      * Add reservedShift
      *

--- a/src/AppBundle/Entity/Beneficiary.php
+++ b/src/AppBundle/Entity/Beneficiary.php
@@ -224,9 +224,17 @@ class Beneficiary
         return $this->getFirstname() . ' ' . $this->getLastname();
     }
 
+    /**
+     * /!\ DO NOT MODIFY /!\
+     *
+     * Such a method is also used for autocomplete. If you want to
+     * change it, you HAVE to adapt the methods used in data
+     * transformer: BeneficiaryToStringTransformer. Otherwise,
+     * autocomplete will be broken.
+     */
     public function getDisplayNameWithMemberNumber(): string
     {
-        return '#' . $this->getMemberNumber() . ' ' . $this->getDisplayName();
+        return '#' . $this->getMemberNumber() . ' ' . $this->getFirstname() . ' ' . $this->getLastname();
     }
 
     public function getDisplayNameWithMemberNumberAndStatusIcon(): string
@@ -618,11 +626,6 @@ class Beneficiary
         // 	for dispensed beneficiary &#127989;
         return $res;
 
-    }
-
-    public function getAutocompleteLabel(): string
-    {
-        return '#' . $this->getMemberNumber() . ' ' . $this->getFirstname() . ' ' . $this->getLastname();
     }
 
     /**

--- a/src/AppBundle/Entity/User.php
+++ b/src/AppBundle/Entity/User.php
@@ -311,13 +311,6 @@ class User extends BaseUser
         return $this->annotations;
     }
 
-    public function getAutocompleteLabel(){
-        if ($this->getBeneficiary())
-            return '#'.$this->getId().' '.$this->getFirstname().' '.$this->getLastname();
-        else
-            return '#'.$this->getId().' '.$this->getUsername();
-    }
-
     /**
      * @return Beneficiary
      */

--- a/src/AppBundle/Form/AutocompleteBeneficiaryCollectionType.php
+++ b/src/AppBundle/Form/AutocompleteBeneficiaryCollectionType.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace AppBundle\Form;
+
+use AppBundle\Form\AutocompleteBeneficiaryHiddenType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\AbstractType;
+
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+
+class AutocompleteBeneficiaryCollectionType extends AbstractType
+{
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'entry_type' => AutocompleteBeneficiaryHiddenType::class,
+            'allow_add' => true,
+            'prototype' => false,
+            'block_prefix' => 'autocomplete_beneficiary_collection'
+        ]);
+    }
+
+    public function getParent()
+    {
+        return CollectionType::class;
+    }
+
+}

--- a/src/AppBundle/Form/AutocompleteBeneficiaryHiddenType.php
+++ b/src/AppBundle/Form/AutocompleteBeneficiaryHiddenType.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace AppBundle\Form;
+
+use AppBundle\Form\DataTransformer\BeneficiaryToStringTransformer;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\AbstractType;
+
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+
+class AutocompleteBeneficiaryHiddenType extends AbstractType
+{
+
+    private $transformer;
+
+    public function __construct(BeneficiaryToStringTransformer $transformer)
+    {
+        $this->transformer = $transformer;
+    }
+
+    public function getParent()
+    {
+        return HiddenType::class;
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->addModelTransformer($this->transformer);
+    }
+
+}

--- a/src/AppBundle/Form/AutocompleteBeneficiaryType.php
+++ b/src/AppBundle/Form/AutocompleteBeneficiaryType.php
@@ -20,15 +20,10 @@ class AutocompleteBeneficiaryType extends AbstractType
         $this->transformer = $transformer;
     }
 
-    public function getBlockPrefix()
-    {
-        return 'autocomplete_beneficiary';
-    }
-
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
-            'invalid_message' => 'Les données sélectionnées ne correspondent à aucun bénéficiaire',
+            'block_prefix' => 'autocomplete_beneficiary'
         ]);
     }
 

--- a/src/AppBundle/Form/AutocompleteBeneficiaryType.php
+++ b/src/AppBundle/Form/AutocompleteBeneficiaryType.php
@@ -23,7 +23,8 @@ class AutocompleteBeneficiaryType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
-            'block_prefix' => 'autocomplete_beneficiary'
+            'block_prefix' => 'autocomplete_beneficiary',
+            'attr' => ['class' => 'autocomplete'],
         ]);
     }
 

--- a/src/AppBundle/Form/DataTransformer/BeneficiaryToStringTransformer.php
+++ b/src/AppBundle/Form/DataTransformer/BeneficiaryToStringTransformer.php
@@ -35,7 +35,7 @@ class BeneficiaryToStringTransformer implements DataTransformerInterface
             return '';
         }
 
-        return $beneficiary->getAutocompleteLabel();
+        return $beneficiary->getDisplayNameWithMemberNumber();
     }
 
     /**

--- a/src/AppBundle/Form/RadioChoiceType.php
+++ b/src/AppBundle/Form/RadioChoiceType.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace AppBundle\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\AbstractType;
+
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+
+class RadioChoiceType extends AbstractType
+{
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'expanded' => true,
+            'multiple' => false,
+            'block_prefix' => 'radio_choice'
+        ]);
+    }
+
+    public function getParent()
+    {
+        return ChoiceType::class;
+    }
+
+
+}

--- a/src/AppBundle/Repository/BeneficiaryRepository.php
+++ b/src/AppBundle/Repository/BeneficiaryRepository.php
@@ -62,4 +62,24 @@ class BeneficiaryRepository extends \Doctrine\ORM\EntityRepository
 
         return $qb->getQuery()->getResult();
     }
+
+    public function findCoShifters($shift)
+    {
+        $qb = $this->createQueryBuilder('b')
+                   ->leftJoin('b.shifts', 's')
+                    ->where('s.start = :start')
+                    ->andWhere('s.end = :end')
+                    ->andWhere('s.job = :job')
+                    ->andWhere('s.id != :id')
+                    ->andWhere('s.shifter IS NOT NULL')
+                    ->setParameter('start', $shift->getStart())
+                    ->setParameter('end', $shift->getEnd())
+                    ->setParameter('job', $shift->getJob())
+                    ->setParameter('id', $shift->getId());
+
+        return $qb
+            ->getQuery()
+            ->getResult();
+
+    }
 }

--- a/src/AppBundle/Repository/BeneficiaryRepository.php
+++ b/src/AppBundle/Repository/BeneficiaryRepository.php
@@ -24,7 +24,7 @@ class BeneficiaryRepository extends \Doctrine\ORM\EntityRepository
             ->where('CONCAT(\'#\', m.member_number, \' \', b.firstname, \' \', b.lastname) = :fullname')
             ->setParameter('fullname', $beneficiary);
 
-        return $qb->getQuery()->getSingleResult();
+        return $qb->getQuery()->getOneOrNullResult();
     }
 
     /**

--- a/src/AppBundle/Repository/MembershipRepository.php
+++ b/src/AppBundle/Repository/MembershipRepository.php
@@ -12,22 +12,6 @@ use Doctrine\ORM\Query\Expr\Join;
  */
 class MembershipRepository extends \Doctrine\ORM\EntityRepository
 {
-    /**
-     * findOneFromAutoComplete
-     *
-     * We consider that the $str will have the following format:
-     * "<Membership.member_number> <Beneficiary.firstname> <Beneficiary.lastname>"
-     */
-    public function findOneFromAutoComplete($str)
-    {
-        $re = '/^#([0-9]+).*/';
-        preg_match_all($re, $str, $matches, PREG_SET_ORDER, 0);
-        if (count($matches) == 1) {
-            $membershipNumber = $matches[0][1];
-            return $this->findOneBy(array("member_number" => $membershipNumber));
-        }
-        return null;
-    }
 
     public function findWithNewCycleStarting($date = null)
     {

--- a/src/AppBundle/Repository/UserRepository.php
+++ b/src/AppBundle/Repository/UserRepository.php
@@ -27,13 +27,14 @@ class UserRepository extends \Doctrine\ORM\EntityRepository
         return $qb->getQuery()->getResult();
     }
 
-    public function findNonMember()
+    public function findActiveNonMembers()
     {
         $qb = $this->_em->createQueryBuilder();
         $qb->select('u')
             ->from($this->_entityName, 'u')
             ->leftJoin('u.beneficiary', 'b')
-            ->where('b.id is NULL');
+            ->where('b.id is NULL')
+            ->andWhere("u.enabled = 1");
 
         return $qb->getQuery()->getResult();
     }

--- a/src/AppBundle/Service/BeneficiaryService.php
+++ b/src/AppBundle/Service/BeneficiaryService.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace AppBundle\Service;
+
+use AppBundle\Entity\Beneficiary;
+use AppBundle\Entity\Membership;
+use AppBundle\Entity\Registration;
+use AppBundle\Entity\Shift;
+use AppBundle\Entity\ShiftBucket;
+use Doctrine\Common\Collections\ArrayCollection;
+use phpDocumentor\Reflection\Types\Array_;
+use Symfony\Component\DependencyInjection\Container;
+
+class BeneficiaryService
+{
+
+    protected $em;
+
+    public function __construct($em)
+    {
+        $this->em = $em;
+    }
+
+    /**
+     * Return autocomplete information
+     */
+    public function getAutocompleteBeneficiaries()
+    {
+        $beneficiaries = $this->em->getRepository('AppBundle:Beneficiary')->findAllActive();
+
+        $returnArray = array();
+        foreach ($beneficiaries as $beneficiary){
+            $returnArray[$beneficiary->getAutocompleteLabel()] = '';
+        }
+        return $returnArray;
+    }
+
+}

--- a/src/AppBundle/Service/BeneficiaryService.php
+++ b/src/AppBundle/Service/BeneficiaryService.php
@@ -30,7 +30,7 @@ class BeneficiaryService
 
         $returnArray = array();
         foreach ($beneficiaries as $beneficiary){
-            $returnArray[$beneficiary->getAutocompleteLabel()] = '';
+            $returnArray[$beneficiary->getDisplayNameWithMemberNumber()] = '';
         }
         return $returnArray;
     }


### PR DESCRIPTION
- Améliore le type `AutocompleteBeneficiaryType` pour créer des inputs avec la complétion (ajout d'un block custom dans twig pour ajouter automatiquement le JS)
- Ajout d'un type `AutocompleteBeneficiaryCollectionType` pour créer un inputs acceptant une liste de beneficiaire en utilisant les 'chips' de materializecss (ajout d'un block custom dans twig pour ajouter automatiquement le JS)
- Ajout d'un type `RadioChoiceType` qui surcharge ChoiceType pour gérer des formulaires utilisant des inputs radio compatible avec materializecss
- Modification de la completion pour booker des periodPosition ou des shifts (utilisation de AutocompleteBeneficiaryType)
- Modification de la completion pour joindre 2 comptes (utilisation de AutocompleteBeneficiaryType)
- Modification de la completion pour envoyer des mails côté admin et co-membres d'un créneau (utilisation de AutocompleteBeneficiaryCollectionType)
- Utilisation de `RadioChoiceType` dans le formulaire admin de réservation d'un créneau fixe ou volant