### PR TITLE
Enlève la possibilité de se logguer avec le cookie pour accéder à un service externe

### DIFF
--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -52,5 +52,5 @@ security:
       - { path: ^/register, role: IS_AUTHENTICATED_ANONYMOUSLY }
       - { path: ^/resetting, role: IS_AUTHENTICATED_ANONYMOUSLY }
       - { path: ^/admin/, role: ROLE_ADMIN_PANEL }
-      - { path: ^/api, roles: [ IS_AUTHENTICATED_FULLY, IS_AUTHENTICATED_REMEMBERED] }
+      - { path: ^/api, rols: IS_AUTHENTICATED_FULLY }
       - { path: ^/api/oauth/, role: ROLE_OAUTH_LOGIN }

--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -52,5 +52,5 @@ security:
       - { path: ^/register, role: IS_AUTHENTICATED_ANONYMOUSLY }
       - { path: ^/resetting, role: IS_AUTHENTICATED_ANONYMOUSLY }
       - { path: ^/admin/, role: ROLE_ADMIN_PANEL }
-      - { path: ^/api, rols: IS_AUTHENTICATED_FULLY }
+      - { path: ^/api, role: IS_AUTHENTICATED_FULLY }
       - { path: ^/api/oauth/, role: ROLE_OAUTH_LOGIN }


### PR DESCRIPTION
Depuis un ordinateur public, il arrive souvent qu'un utilisateur se déconnecte du service (ex, Mattermost) mais oublie de se déconnecter de l'espace membre. Un utilisateur peut donc se reconnecter sur le service en question.

L'idée est de forcer l'authentification pour se reconnecter à un service et éviter l'utilisation "remember me cookie".