### PR TITLE
Exemption de créneau : cleanup ; affichage admin ; affichage dashboard

### DIFF
--- a/app/Resources/views/admin/index.html.twig
+++ b/app/Resources/views/admin/index.html.twig
@@ -10,7 +10,7 @@
 {% block content %}
     <div class="section no-pad-bot" id="index-banner">
         <div class="container">
-            <h4 class="row center">
+            <h4>
                 <i class="material-icons">build</i>&nbsp;Administration
             </h4>
 

--- a/app/Resources/views/admin/membershipshiftexemption/index.html.twig
+++ b/app/Resources/views/admin/membershipshiftexemption/index.html.twig
@@ -9,18 +9,18 @@
 {% endblock %}
 
 {% block content %}
-    <h4>Liste des membres exempté.e.s de bénévolat</h4>
+    <h4>Liste des membres exempté.e.s de bénévolat ({{ membershipShiftExemptions | length }})</h4>
 
-    <table class="responsive-table striped">
+    <table class="responsive-table">
         <thead>
             <tr>
-                <th>Date de création</th>
-                <th>Par</th>
                 <th>Membre</th>
                 <th>Raison</th>
                 <th>Description</th>
                 <th>Début</th>
                 <th>Fin</th>
+                <th>Auteur</th>
+                <th>Date de création</th>
                 <th>Actions</th>
             </tr>
         </thead>
@@ -28,7 +28,19 @@
         <tbody>
         {% for membershipShiftExemption in membershipShiftExemptions %}
             <tr>
-                <td>{% if membershipShiftExemption.createdAt %}{{ membershipShiftExemption.createdAt|date('Y-m-d H:i:s') }}{% endif %}</td>
+                <td>{{ membershipShiftExemption.membership.beneficiaries | map(b => "<a href=\'#{path('member_show',{'member_number': b.membership.memberNumber})}\'>#{b}</a>") | join('<br/>') | raw }}</td>
+                <td>{{ membershipShiftExemption.shiftExemption }}</td>
+                <td>{{ membershipShiftExemption.description }}</td>
+                <td>
+                    {% if membershipShiftExemption.start %}
+                        {{ membershipShiftExemption.start|date('Y-m-d') }}
+                    {% endif %}
+                </td>
+                <td>
+                    {% if membershipShiftExemption.end %}
+                        {{ membershipShiftExemption.end|date('Y-m-d') }}
+                    {% endif %}
+                </td>
                 <td>
                     {% if membershipShiftExemption.createdBy and membershipShiftExemption.createdBy.beneficiary %}
                         <a href="{{ path("member_show",{'member_number': membershipShiftExemption.createdBy.beneficiary.membership.memberNumber}) }}">
@@ -38,11 +50,11 @@
                         {{membershipShiftExemption.createdBy}}
                     {% endif %}
                 </td>
-                <td>{{ membershipShiftExemption.membership.beneficiaries | map(b => "<a href=\'#{path('member_show',{'member_number': b.membership.memberNumber})}\'>#{b}</a>") | join('<br/>') | raw }}</td>
-                <td>{{ membershipShiftExemption.shiftExemption }}</td>
-                <td>{{ membershipShiftExemption.description }}</td>
-                <td>{% if membershipShiftExemption.start %}{{ membershipShiftExemption.start|date('Y-m-d') }}{% endif %}</td>
-                <td>{% if membershipShiftExemption.end %}{{ membershipShiftExemption.end|date('Y-m-d') }}{% endif %}</td>
+                <td>
+                    {% if membershipShiftExemption.createdAt %}
+                        {{ membershipShiftExemption.createdAt|date('Y-m-d H:i:s') }}
+                    {% endif %}
+                </td>
                 <td>
                     <a href="{{ path('admin_membershipshiftexemption_edit', { 'id': membershipShiftExemption.id }) }}"><i class="material-icons">edit</i>editer</a>
                 </td>

--- a/app/Resources/views/admin/shiftexemption/index.html.twig
+++ b/app/Resources/views/admin/shiftexemption/index.html.twig
@@ -9,12 +9,11 @@
 {% endblock %}
 
 {% block content %}
-    <h4>Liste des exemptions de bénévolat</h4>
+    <h4>Liste des exemptions de bénévolat ({{ shiftExemptions | length }})</h4>
 
-    <table class="responsive-table striped">
+    <table class="responsive-table">
         <thead>
             <tr>
-                <th>id</th>
                 <th>Exemption</th>
                 <th>Actions</th>
             </tr>
@@ -23,7 +22,6 @@
         <tbody>
         {% for shiftExemption in shiftExemptions %}
             <tr>
-                <td>{{ shiftExemption.id }}</td>
                 <td>{{ shiftExemption.name }}</td>
                 <td>
                     <a href="{{ path('admin_shiftexemption_edit', { 'id': shiftExemption.id }) }}"><i class="material-icons">edit</i>editer</a>

--- a/app/Resources/views/admin/user/list.html.twig
+++ b/app/Resources/views/admin/user/list.html.twig
@@ -233,6 +233,9 @@
                         {% if not member.mainBeneficiary.user.isEnabled %}
                             <i class="material-icons" title="Compte pas encore activé">phonelink_off</i>
                         {% endif %}
+                        {% if member.isExemptedFromShifts() %}
+                            <i class="material-icons" title="Compte exempté">beach_access</i>
+                        {% endif %}
                     </td>
                     <td>
                         <a href="{{ path('member_show', { 'member_number': member.memberNumber }) }}">{{ member.memberNumber }}</a>

--- a/app/Resources/views/admin/user/list.html.twig
+++ b/app/Resources/views/admin/user/list.html.twig
@@ -230,11 +230,11 @@
                         {% if member.frozen %}
                             <i class="material-icons" title="Compte gelé">ac_unit</i>
                         {% endif %}
-                        {% if not member.mainBeneficiary.user.isEnabled %}
-                            <i class="material-icons" title="Compte pas encore activé">phonelink_off</i>
-                        {% endif %}
                         {% if member.isExemptedFromShifts() %}
                             <i class="material-icons" title="Compte exempté">beach_access</i>
+                        {% endif %}
+                        {% if not member.mainBeneficiary.user.isEnabled %}
+                            <i class="material-icons" title="Compte pas encore activé">phonelink_off</i>
                         {% endif %}
                     </td>
                     <td>

--- a/app/Resources/views/booking/home_booked_shifts.html.twig
+++ b/app/Resources/views/booking/home_booked_shifts.html.twig
@@ -1,6 +1,17 @@
 {% if app.user.beneficiary %}
     {% set beneficiary = app.user.beneficiary %}
     {% set member = beneficiary.membership %}
+
+    {% if member.isExemptedFromShifts() %}
+        {% set firstValidMembershipShiftExemption = member.getValidMembershipShiftExemptions().first %}
+        <div class="card-panel teal white-text">
+            <i class="material-icons small left">beach_access</i>
+            <strong>{% if member.beneficiaries | length %}Votre{% else %}Ton{% endif %} compte est exempté de créneau !</strong>
+            <br />
+            ({{ firstValidMembershipShiftExemption.shiftExemption }}) jusqu'au {{ firstValidMembershipShiftExemption.end | date_fr_full }}
+        </div>
+    {% endif %}
+
     <ul class="collapsible collapsible-expandable">
         {% if use_fly_and_fixed %}
             <li class="active">

--- a/app/Resources/views/member/_partial/shifts.html.twig
+++ b/app/Resources/views/member/_partial/shifts.html.twig
@@ -5,7 +5,7 @@
         {% set firstValidMembershipShiftExemption = member.getValidMembershipShiftExemptions().first %}
         <div class="card-panel teal white-text">
             <i class="material-icons small left">beach_access</i>
-            <strong>Compte exempté de créneau</strong>
+            <strong>Compte exempté de créneau !</strong>
             <br />
             ({{ firstValidMembershipShiftExemption.shiftExemption }}) jusqu'au {{ firstValidMembershipShiftExemption.end | date_fr_full }}
         </div>

--- a/app/Resources/views/member/_partial/shifts.html.twig
+++ b/app/Resources/views/member/_partial/shifts.html.twig
@@ -1,5 +1,17 @@
 {% set firstShiftDate = member.firstShiftDate %}
 
+{% if member.isExemptedFromShifts() %}
+    <div class="row">
+        {% set firstValidMembershipShiftExemption = member.getValidMembershipShiftExemptions().first %}
+        <div class="card-panel teal white-text">
+            <i class="material-icons small left">beach_access</i>
+            <strong>Compte exempté de créneau</strong>
+            <br />
+            ({{ firstValidMembershipShiftExemption.shiftExemption }}) jusqu'au {{ firstValidMembershipShiftExemption.end | date_fr_full }}
+        </div>
+    </div>
+{% endif %}
+
 {% if use_fly_and_fixed %}
     <div class="row">
         <h6>Créneau fixe</h6>

--- a/app/Resources/views/member/show.html.twig
+++ b/app/Resources/views/member/show.html.twig
@@ -17,8 +17,12 @@
     <h4>
         {% if member.withdrawn %}<del>{% endif %}
         Membre #{{ member.memberNumber }}{% if member.withdrawn %}</del>{% endif %}
-        {% if member.frozen %}<i class="material-icons">ac_unit</i>{% endif %}
-        {% if member.withdrawn %}<i class="material-icons">block</i>{% endif %}
+        {% if not member.mainBeneficiary.user.isEnabled %}
+            <i class="material-icons" title="Compte pas encore activé">phonelink_off</i>
+        {% endif %}
+        {% if member.isExemptedFromShifts() %}<i class="material-icons" title="Compte exempté">beach_access</i>{% endif %}
+        {% if member.frozen %}<i class="material-icons" title="Compte gelé">ac_unit</i>{% endif %}
+        {% if member.withdrawn %}<i class="material-icons" title="Compte fermé">block</i>{% endif %}
     </h4>
 
     <div class="row">

--- a/src/AppBundle/Controller/MembershipShiftExemptionController.php
+++ b/src/AppBundle/Controller/MembershipShiftExemptionController.php
@@ -103,7 +103,6 @@ class MembershipShiftExemptionController extends Controller
         $editForm->handleRequest($request);
 
         if ($editForm->isSubmitted() && $editForm->isValid()) {
-
             if ($this->isMembershipHasShiftsOnExemptionPeriod($membershipShiftExemption)) {
                 $session->getFlashBag()->add("error", "Désolé, les bénéficiaires ont déjà des créneaux planifiés sur la plage d'exemption.");
             } else {
@@ -111,7 +110,7 @@ class MembershipShiftExemptionController extends Controller
                 $this->getDoctrine()->getManager()->flush();
             }
 
-            return $this->redirectToRoute('admin_membershipshiftexemption_edit', array('id' => $membershipShiftExemption->getId()));
+            return $this->redirectToRoute('admin_membershipshiftexemption_index');
         }
 
         return $this->render('admin/membershipshiftexemption/edit.html.twig', array(

--- a/src/AppBundle/Entity/Membership.php
+++ b/src/AppBundle/Entity/Membership.php
@@ -676,8 +676,11 @@ class Membership
      * @param \DateTime $date
      * @return boolean
      */
-    public function isExemptedFromShifts(\Datetime $date)
+    public function isExemptedFromShifts(\DateTime $date = null)
     {
+        if (!$date) {
+            $date = new \DateTime('now');
+        }
         return $this->membershipShiftExemptions->exists(function($key, $value) use ($date) {
             return $value->isValid($date);
         });

--- a/src/AppBundle/Entity/Membership.php
+++ b/src/AppBundle/Entity/Membership.php
@@ -671,6 +671,21 @@ class Membership
     }
 
     /**
+     * Get valid membership shiftExemptions
+     *
+     * @return \Doctrine\Common\Collections\Collection
+     */
+    public function getValidMembershipShiftExemptions(\DateTime $date = null)
+    {
+        if (!$date) {
+            $date = new \DateTime('now');
+        }
+        return $this->membershipShiftExemptions->filter(function($membershipShiftExemption) use ($date) {
+            return $membershipShiftExemption->isValid($date);
+        });
+    }
+
+    /**
      * Return if the membership is exempted from doing shifts
      *
      * @param \DateTime $date

--- a/src/AppBundle/Form/ShiftExemptionType.php
+++ b/src/AppBundle/Form/ShiftExemptionType.php
@@ -4,6 +4,7 @@ namespace AppBundle\Form;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ShiftExemptionType extends AbstractType
@@ -13,8 +14,10 @@ class ShiftExemptionType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('name');
-    }/**
+        $builder->add('name', TextType::class, array('label' => 'Nom', 'required' => true));
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function configureOptions(OptionsResolver $resolver)
@@ -31,6 +34,5 @@ class ShiftExemptionType extends AbstractType
     {
         return 'appbundle_shiftexemption';
     }
-
 
 }

--- a/src/AppBundle/Service/MembershipService.php
+++ b/src/AppBundle/Service/MembershipService.php
@@ -35,7 +35,7 @@ class MembershipService
      * @return \DateInterval|false
      * @throws \Exception
      */
-    public function getRemainder(Membership $membership,\DateTime $date = null)
+    public function getRemainder(Membership $membership, \DateTime $date = null)
     {
         if (!$date){
             $date = new \DateTime('now');


### PR DESCRIPTION
### Quoi ?

Suite de #659

Modifications apportées : 
- liste des membres exemptées : enlevé `striped`, réorganisé les colonnes, redirection vers index
- liste des types d'exemptions : enlevé la colonne `id`
- liste admin des membres : nouvel icon devant les membres exemptés
- page admin d'un membre : icon si exempté, bandeau dans la section "créneaux"
- page dashboard : bandeau si le membre est exempté

### Captures d'écran

|page|image|
|---|---|
|liste admin des membres |![Screenshot from 2022-12-03 19-58-33](https://user-images.githubusercontent.com/7147385/205457407-303a5d64-4f44-478f-a90e-a045576e5f8f.png)|
|page admin d'un membre|![Screenshot from 2022-12-03 19-56-16](https://user-images.githubusercontent.com/7147385/205457309-a6773950-bcb5-4ae1-a776-7ec8f226fe22.png)<br />![Screenshot from 2022-12-03 19-57-00](https://user-images.githubusercontent.com/7147385/205457331-d51da31b-e2bc-4617-98e5-d87f97910d63.png)|
|page dashboard|![Screenshot from 2022-12-03 19-57-41](https://user-images.githubusercontent.com/7147385/205457376-f8f3b306-16a4-49e5-83c0-eef7cf613f4c.png)|




