### PR TITLE
Fix : pouvoir (dé)geler son compte sur son profil

### DIFF
--- a/app/Resources/views/Profile/show_content.html.twig
+++ b/app/Resources/views/Profile/show_content.html.twig
@@ -36,7 +36,8 @@
             </div>
             <div class="collapsible-body">
                 {% if display_freeze_account %}
-                    {% include "member/_partial/frozen.html.twig" with { member: member } %}
+                    {# why render instead of include? because of forms init #}
+                    {{ render(controller("AppBundle:Membership:homepageFreeze")) }}
                 {% else %}
                     <p class="red-text">
                         {{ display_freeze_account_false_message }}

--- a/app/Resources/views/default/index.html.twig
+++ b/app/Resources/views/default/index.html.twig
@@ -95,6 +95,7 @@
                                     <i class="material-icons left">settings</i>Gérer mon compte
                                 </a>
                                 {% if display_freeze_account %}
+                                    <br />
                                     {# why render instead of include? because of forms init #}
                                     {{ render(controller("AppBundle:Membership:homepageFreeze")) }}
                                 {% endif %}

--- a/app/Resources/views/default/index.html.twig
+++ b/app/Resources/views/default/index.html.twig
@@ -95,7 +95,8 @@
                                     <i class="material-icons left">settings</i>Gérer mon compte
                                 </a>
                                 {% if display_freeze_account %}
-                                    {% include "member/_partial/frozen.html.twig" with { member: app.user.beneficiary.membership } %}
+                                    {# why render instead of include? because of forms init #}
+                                    {{ render(controller("AppBundle:Membership:homepageFreeze")) }}
                                 {% endif %}
                             </div>
                         {% endif %}
@@ -169,7 +170,8 @@
     {% if app.user.beneficiary and app.user.beneficiary.membership | uptodate %}
         <div id="home-shifts" class="row">
             <div class="col s12">
-                {{ render(controller("AppBundle:Booking:homepageShifts")) }}{# use include instead? #}
+                {# why render instead of include? because of forms init #}
+                {{ render(controller("AppBundle:Booking:homepageShifts")) }}
             </div>
         </div>
     {% endif %}

--- a/app/Resources/views/layout.html.twig
+++ b/app/Resources/views/layout.html.twig
@@ -19,18 +19,6 @@
     <body>
         {% include "_partial/header.html.twig" %}
         <main>
-            {% if is_granted("IS_AUTHENTICATED_REMEMBERED") %}
-                {% if frozen %}
-                    <div class="wrapper blue lighten-5">
-                        <strong class="deep-purple-text"><i class="material-icons">pause</i>Adhésion en pause</strong>.
-                        {% if not app.user.beneficiary.membership.frozenChange %}
-                            Pour dégeler ton compte, visite <a href="{{ path('fos_user_profile_show') }}" class="">ton profil <i class="material-icons tiny">settings</i></a>
-                        {% else %}
-                            Dégel programmé.
-                        {% endif %}
-                    </div>
-                {% endif %}
-            {% endif %}
             {% set _breadcrumbs = block('breadcrumbs') %}
             {% if _breadcrumbs is not empty %}
                 <div class="wrapper breadcrumbs blue-grey lighten-5">
@@ -38,6 +26,23 @@
                         {% block breadcrumbs %}{% endblock breadcrumbs %}
                     </div>
                 </div>
+            {% endif %}
+            {% if is_granted("IS_AUTHENTICATED_REMEMBERED") %}
+                {% if frozen %}
+                    <div class="row">
+                        <div class="col s12">
+                            <div class="card-panel" style="background-color: rgba(0, 138, 255, 0.1);margin-bottom:0;">
+                                <strong class="orange"><i class="material-icons left">ac_unit</i>Adhésion en pause</strong>
+                                <br />
+                                {% if not app.user.beneficiary.membership.frozenChange %}
+                                    Pour dégeler ton compte, visite <a href="{{ path('fos_user_profile_show') }}">ton profil <i class="material-icons tiny">settings</i></a>
+                                {% else %}
+                                    Dégel programmé.
+                                {% endif %}
+                            </div>
+                        </div>
+                    </div>
+                {% endif %}
             {% endif %}
             {% if app.request.hasPreviousSession %}
                 {% for type, messages in app.session.flashBag.all %}

--- a/app/Resources/views/member/_partial/frozen.html.twig
+++ b/app/Resources/views/member/_partial/frozen.html.twig
@@ -9,12 +9,12 @@
             <i class="material-icons left">cancel</i>Annuler le gel de mon compte
         </a>
     {% else %}
-        <a class="waves-effect waves-light btn modal-trigger blue" href="#freeze">
+        <a class="waves-effect waves-light btn modal-trigger blue" href="#freeze-confirmation-modal">
             <i class="material-icons left">ac_unit</i>Geler mon compte
         </a>
 
-        <!-- Modal Structure -->
-        <div class="modal" id="freeze">
+        {{ form_start(freeze_change_form) }}
+        <div class="modal" id="freeze-confirmation-modal">
             <div class="modal-content">
                 <h5>
                     <i class="material-icons small">ac_unit</i>&nbsp;Gel de compte
@@ -33,11 +33,12 @@
             </div>
             <div class="modal-footer">
                 <a href="#!" class="modal-action modal-close waves-effect waves-green btn-flat red-text">Retour</a>
-                <a class="waves-effect waves-light btn green" href="{{ path('member_freeze_change',{ 'id' : member.id }) }}">
+                <button type="submit" class="waves-effect waves-light btn green">
                     <i class="material-icons left">check</i>Ok, je gèle mon compte
-                </a>
+                </button>
             </div>
         </div>
+        {{ form_end(freeze_change_form) }}
     {% endif %}
 {% else %}
     {% if member.frozenChange %}

--- a/app/Resources/views/member/_partial/frozen.html.twig
+++ b/app/Resources/views/member/_partial/frozen.html.twig
@@ -5,7 +5,6 @@
         <br />
         Soit le <strong>{{ end_current_cycle | date_modify('+1 day') |date_fr_long }}</strong>.
         <br />
-        <br />
         {{ form_start(freeze_change_form) }}
         <button type="submit" class="waves-effect waves-light btn orange">
             <i class="material-icons left">cancel</i>Annuler le gel de mon compte

--- a/app/Resources/views/member/_partial/frozen.html.twig
+++ b/app/Resources/views/member/_partial/frozen.html.twig
@@ -3,7 +3,7 @@
     {% if member.frozenChange %}
         Comme demandé, mon compte sera gelé à la fin de mon cycle courant.
         <br />
-        Soit le <strong>{{ end_current_cycle | date_modify('+1 day') |date_fr_long }}</strong>.
+        Soit le <strong>{{ end_current_cycle | date_modify('+1 day') | date_fr_long }}</strong>.
         <br />
         {{ form_start(freeze_change_form) }}
         <button type="submit" class="waves-effect waves-light btn orange">
@@ -14,7 +14,6 @@
         <a class="waves-effect waves-light btn modal-trigger blue" href="#freeze-confirmation-modal">
             <i class="material-icons left">ac_unit</i>Geler mon compte
         </a>
-
         {{ form_start(freeze_change_form) }}
         <div class="modal" id="freeze-confirmation-modal">
             <div class="modal-content">
@@ -44,14 +43,22 @@
     {% endif %}
 {% else %}
     {% if member.frozenChange %}
-        Mon compte sera degelé à la fin de mon cycle courrant qui termine le {{ end_current_cycle |date_fr_long }}<br>
-        <a class="btn-large waves-effect waves-light btn orange" href="{{ path('member_freeze_change',{ 'id' : member.id }) }}">
+        Mon compte sera dégelé à la fin de mon cycle courant.
+        <br />
+        <strong>Soit le {{ end_current_cycle | date_fr_long }}</strong>.
+        <br />
+        {{ form_start(freeze_change_form) }}
+        <button type="submit" class="waves-effect waves-light btn orange">
             <i class="material-icons left">cancel</i>Annuler la demande de degel de mon compte
-        </a>
+        </button>
+        {{ form_end(freeze_change_form) }}
     {% else %}
         Mon compte est gelé
-        <a class="btn-large waves-effect waves-light btn green" href="{{ path('member_freeze_change',{ 'id' : member.id }) }}">
+        <br />
+        {{ form_start(freeze_change_form) }}
+        <button type="submit" class="waves-effect waves-light btn green">
             <i class="material-icons left">play_circle_filled</i>Demander le dégèle de mon compte
-        </a>
+        </button>
+        {{ form_end(freeze_change_form) }}
     {% endif %}
 {% endif %}

--- a/app/Resources/views/member/_partial/frozen.html.twig
+++ b/app/Resources/views/member/_partial/frozen.html.twig
@@ -1,13 +1,16 @@
 {% set end_current_cycle = membership_service.endOfCycle(member) %}
 {% if not member.frozen %}
     {% if member.frozenChange %}
+        Comme demandé, mon compte sera gelé à la fin de mon cycle courant.
         <br />
-        Comme demandé, mon compte sera gelé à la fin de mon cycle courant. soit le
-        <strong>{{ end_current_cycle | date_modify('+1 day') |date_fr_long }}</strong>
+        Soit le <strong>{{ end_current_cycle | date_modify('+1 day') |date_fr_long }}</strong>.
         <br />
-        <a class="btn-large waves-effect waves-light btn orange" href="{{ path('member_freeze_change',{ 'id' : member.id }) }}">
+        <br />
+        {{ form_start(freeze_change_form) }}
+        <button type="submit" class="waves-effect waves-light btn orange">
             <i class="material-icons left">cancel</i>Annuler le gel de mon compte
-        </a>
+        </button>
+        {{ form_end(freeze_change_form) }}
     {% else %}
         <a class="waves-effect waves-light btn modal-trigger blue" href="#freeze-confirmation-modal">
             <i class="material-icons left">ac_unit</i>Geler mon compte

--- a/src/AppBundle/Controller/BookingController.php
+++ b/src/AppBundle/Controller/BookingController.php
@@ -105,7 +105,7 @@ class BookingController extends Controller
                 return $this->redirectToRoute('homepage');
             }
             if ($this->getUser()->getBeneficiary()->getMembership()->getFrozen()){
-                $session->getFlashBag()->add('warning', 'Oups, ton compte est gelé ❄️ ! Dégel pour réserver 😉');
+                $session->getFlashBag()->add('warning', 'Oups, ton compte est gelé ❄️ !<br />Dégel pour réserver 😉');
                 return $this->redirectToRoute('homepage');
             }
         }

--- a/src/AppBundle/Controller/DefaultController.php
+++ b/src/AppBundle/Controller/DefaultController.php
@@ -76,25 +76,22 @@ class DefaultController extends Controller
                 $cycle_end = $this->get('membership_service')->getEndOfCycle($membership);
                 $dayAfterEndOfCycle = clone $cycle_end;
                 $dayAfterEndOfCycle->modify('+1 day');
+                $profileUrlHtml = "<a style=\"text-decoration:underline;color:white;\" href=\"" . $this->get('router')->generate('fos_user_profile_show') . "\"><i class=\"material-icons tiny\">settings</i> ton profil</a>.";
                 if ($membership->getFrozenChange() && !$membership->getFrozen()) {
                     $now = new \DateTime('now');
                     $session->getFlashBag()->add('warning',
                         'Comme demandé, ton compte sera gelé dans ' .
                         date_diff($now, $cycle_end)->format('%a jours') .
-                        ', le <strong>' . AppExtension::date_fr_long($dayAfterEndOfCycle) . '</strong>' .
-                        " Pour annuler, visite <a style=\"text-decoration:underline;color:white;\" href=\"" .
-                        $this->get('router')->generate('fos_user_profile_show')
-                        . "\">ton profil <i class=\"material-icons tiny\">settings</i></a>");
+                        ', le <strong>' . $this->container->get('twig')->getExtension(AppExtension::class)->date_fr_long($dayAfterEndOfCycle) . '</strong>.' .
+                        "<br />Pour annuler, visite " . $profileUrlHtml);
                 }
                 if ($membership->getFrozenChange() && $membership->getFrozen()) {
                     $now = new \DateTime('now');
                     $session->getFlashBag()->add('notice',
                         'Comme demandé, ton compte sera dégelé dans ' .
                         date_diff($now, $cycle_end)->format('%a jours') .
-                        ', le <strong>' . AppExtension::date_fr_long($dayAfterEndOfCycle) . '</strong>' .
-                        " Pour annuler, visite <a style=\"text-decoration:underline;color:white;\" href=\"" .
-                        $this->get('router')->generate('fos_user_profile_show')
-                        . "\">ton profil <i class=\"material-icons tiny\">settings</i></a>");
+                        ', le <strong>' . $this->container->get('twig')->getExtension(AppExtension::class)->date_fr_long($dayAfterEndOfCycle) . '</strong>.' .
+                        "<br />Pour annuler, visite " . $profileUrlHtml);
                 }
 
                 if ($this->get('membership_service')->canRegister($membership)) {

--- a/src/AppBundle/Controller/MembershipController.php
+++ b/src/AppBundle/Controller/MembershipController.php
@@ -1056,6 +1056,21 @@ class MembershipController extends Controller
         ));
     }
 
+    /**
+     * @return Response
+     */
+    public function homepageFreezeAction(): Response
+    {
+        $member = $this->getUser()->getBeneficiary()->getMembership();
+
+        $freezeChangeForm = $this->createFreezeChangeForm($member);
+
+        return $this->render('member/_partial/frozen.html.twig', array(
+            'member' => $member,
+            'freeze_change_form' => $freezeChangeForm->createView(),
+        ));
+    }
+
     private function createNewBeneficiaryForm(Membership $member)
     {
         $newBeneficiaryAction = $this->generateUrl('member_new_beneficiary', array('member_number' => $member->getMemberNumber()));

--- a/src/AppBundle/Controller/MembershipController.php
+++ b/src/AppBundle/Controller/MembershipController.php
@@ -651,10 +651,18 @@ class MembershipController extends Controller
             $em->persist($member);
             $em->flush();
 
-            if ($member->getFrozenChange()) {
-                $session->getFlashBag()->add('success', 'Le compte sera gelé à la fin du cycle !');
+            if ($member->isFrozen()) {
+                if ($member->getFrozenChange()) {
+                    $session->getFlashBag()->add('success', 'Le compte sera dégelé à la fin du cycle !');
+                } else {
+                    $session->getFlashBag()->add('success', 'La demande de dégel a été annulée !');
+                }
             } else {
-                $session->getFlashBag()->add('success', 'Le compte sera dégelé à la fin du cycle !');
+                if ($member->getFrozenChange()) {
+                    $session->getFlashBag()->add('success', 'Le compte sera gelé à la fin du cycle !');
+                } else {
+                    $session->getFlashBag()->add('success', 'La demande de gel a été annulée !');
+                }
             }
         }
 

--- a/src/AppBundle/Controller/ShiftController.php
+++ b/src/AppBundle/Controller/ShiftController.php
@@ -387,14 +387,13 @@ class ShiftController extends Controller
     public function dismissShiftAction(Request $request, Shift $shift)
     {
         $session = new Session();
+        $em = $this->getDoctrine()->getManager();
 
         if (!$this->isGranted('dismiss', $shift)) {
             $session->getFlashBag()->add("error", "Impossible d'annuler ce créneau");
             return $this->redirectToRoute("booking");
         }
 
-        $beneficiary = $shift->getShifter();
-        $em = $this->getDoctrine()->getManager();
         if($shift->isFixe()) {
             $session->getFlashBag()->add("error", "Impossible d'annuler un créneau fixe");
             return $this->redirectToRoute("booking");
@@ -406,6 +405,7 @@ class ShiftController extends Controller
         $em->persist($shift);
         $em->flush();
 
+        $beneficiary = $shift->getShifter();
         $reason = $request->get("reason");
         $dispatcher = $this->get('event_dispatcher');
         $dispatcher->dispatch(ShiftDismissedEvent::NAME, new ShiftDismissedEvent($shift, $beneficiary, $reason));


### PR DESCRIPTION
### Quoi ?

Suite aux modifs sur les formulaires (utilisation de la méthode POST - voir Issue #642 ), les actions de (dé)gel sur son compte ne marchaient plus.

Ces actions sont possible coté profil si la paramètre `display_freeze_account` est à `true`

Modifications apportées : 
- réparé la possibilité de demander le (dé)gel de son compte
- nouvelle fonction `MembershipController.homepageFreezeAction`
- réparé les success messages de la fonction `MembershipController.freezeChangeAction`
- amélioré l'affichage (voir captures :point_down: )

### Captures d'écran

|Avant|Après|
|---|---|
|![Screenshot from 2022-12-23 02-02-33](https://user-images.githubusercontent.com/7147385/209250577-8883e0db-50bf-4d39-b4e5-9cad6020f00d.png)|![Screenshot from 2022-12-23 02-04-35](https://user-images.githubusercontent.com/7147385/209250706-74bec832-0d2a-46d0-8593-f9a99099ad82.png)|
|![Screenshot from 2022-12-23 02-03-26](https://user-images.githubusercontent.com/7147385/209250619-9446ecc2-a4a1-489a-be0a-84565bd7e269.png)|![Screenshot from 2022-12-23 01-35-54](https://user-images.githubusercontent.com/7147385/209250652-8e8a640f-5cb1-47ab-a878-d7bc13b20912.png)|



