### PR TITLE
Exemption : amélioration sur les couleurs

### DIFF
--- a/app/Resources/views/admin/index.html.twig
+++ b/app/Resources/views/admin/index.html.twig
@@ -23,8 +23,8 @@
 
             {% if is_granted("ROLE_USER_MANAGER") %}
                 <h6><i class="material-icons">people</i>&nbsp;Membres</h6>
-                <a href="{{ path("user_index") }}" class="waves-effect waves-light btn">
-                    <i class="material-icons left">people</i>Gérer les adhérents
+                <a href="{{ path("user_index") }}" class="waves-effect waves-light btn white black-text">
+                    <i class="material-icons left main-color-text">people</i>Gérer les adhérents
                 </a>
                 <a href="{{ path('ambassador_shifttimelog_list') }}" class="waves-effect waves-light btn">
                     <i class="material-icons left">phone</i>Relances créneaux

--- a/app/Resources/views/admin/user/list.html.twig
+++ b/app/Resources/views/admin/user/list.html.twig
@@ -209,12 +209,12 @@
         <thead>
             <tr>
                 <th class="hide-on-med-and-down">Etat</th>
-                <th data-col="o.member_number" style="cursor:pointer;">#</th>
-                <th data-col="u.username" style="cursor:pointer;">username</th>
-                <th data-col="b.firstname" style="cursor:pointer;">prénom</th>
-                <th data-col="b.lastname" style="cursor:pointer;">nom</th>
-                <th data-col="b.email" style="cursor:pointer;">email</th>
-                <th data-col="r.date" class="hide-on-small-and-down" style="cursor:pointer;">Adhésion(s)</th>
+                <th data-col="o.member_number">#</th>
+                <th data-col="u.username">username</th>
+                <th data-col="b.firstname">prénom</th>
+                <th data-col="b.lastname">nom</th>
+                <th data-col="b.email">email</th>
+                <th data-col="r.date" class="hide-on-small-and-down">Adhésion(s)</th>
                 <th class="hide-on-med-and-down">Formation(s)</th>
                 <th class="hide-on-med-and-down">Commission(s)</th>
             </tr>
@@ -359,6 +359,9 @@
     <style>
         th.active {
             color: {{ main_color }};
+        }
+        th[data-col] {
+            cursor: pointer;
         }
         tr.withdrawn {
             background: rgba(255, 50, 0, 0.2);

--- a/app/Resources/views/admin/user/list.html.twig
+++ b/app/Resources/views/admin/user/list.html.twig
@@ -209,12 +209,12 @@
         <thead>
             <tr>
                 <th class="hide-on-med-and-down">Etat</th>
-                <th data-col="o.member_number">#</th>
-                <th data-col="u.username">username</th>
-                <th data-col="b.firstname">prénom</th>
-                <th data-col="b.lastname">nom</th>
-                <th data-col="b.email">email</th>
-                <th class="hide-on-small-and-down" data-col="r.date">Adhésion(s)</th>
+                <th data-col="o.member_number" style="cursor:pointer;">#</th>
+                <th data-col="u.username" style="cursor:pointer;">username</th>
+                <th data-col="b.firstname" style="cursor:pointer;">prénom</th>
+                <th data-col="b.lastname" style="cursor:pointer;">nom</th>
+                <th data-col="b.email" style="cursor:pointer;">email</th>
+                <th data-col="r.date" class="hide-on-small-and-down" style="cursor:pointer;">Adhésion(s)</th>
                 <th class="hide-on-med-and-down">Formation(s)</th>
                 <th class="hide-on-med-and-down">Commission(s)</th>
             </tr>
@@ -222,7 +222,7 @@
         <tbody>
         {% for member in members %}
             {% if member.mainBeneficiary %}
-                <tr class="{% if member.withdrawn %}withdrawn{% elseif member.frozen %}frozen{% endif %}" data-url="{{ path('member_show', { 'member_number': member.memberNumber }) }}" >
+                <tr data-url="{{ path('member_show', { 'member_number': member.memberNumber }) }}" class="{% if member.withdrawn %}withdrawn{% elseif member.frozen %}frozen{% elseif member.isExemptedFromShifts() %}exempted{% endif %}">
                     <td class="hide-on-med-and-down">
                         {% if member.withdrawn %}
                             <i class="material-icons" title="Compte fermé">block</i>
@@ -293,8 +293,8 @@
                     </td>
                 </tr>
             {% else %}
-                <tr class="{% if member.withdrawn %}withdrawn{% endif %} {% if member.frozen %}frozen{% endif %}" data-url="{{ path('member_show', { 'member_number': member.memberNumber }) }}" >
-                    <td colspan="9">{{ member.mainBeneficiary.user }}</td>
+                <tr data-url="{{ path('member_show', { 'member_number': member.memberNumber }) }}" class="{% if member.withdrawn %}withdrawn{% endif %} {% if member.frozen %}frozen{% endif %}">
+                    <td colspan="9">{{ member }}</td>
                 </tr>
             {% endif %}
         {% endfor %}
@@ -357,26 +357,27 @@
 
 {% block stylesheets %}
     <style>
-        td strong{
-            /*font-weight: 600;*/
+        th.active {
+            color: {{ main_color }};
         }
-        th.active{
-            color: #51CAE9;
-        }
-        tr.withdrawn{
+        tr.withdrawn {
             background: rgba(255, 50, 0, 0.2);
         }
-        tr.frozen{
+        tr.frozen {
             background-color: rgba(0, 138, 255, 0.1);
             background-image: url({% image '@AppBundle/Resources/public/img/snowflakes.svg' %}{{ asset_url }}{% endimage %});
             background-position: top right;
             background-repeat: no-repeat;
             background-size: contain;
         }
-        tr.frozen td{
+        tr.frozen td {
             background-color: rgba(255, 255, 255, 0.5);
         }
-        tbody tr{
+        tr.exempted {
+            /* teal */
+            background-color: rgb(0, 150, 136, 0.1);
+        }
+        tbody tr {
             cursor: pointer;
         }
     </style>

--- a/app/Resources/views/ambassador/phone/list.html.twig
+++ b/app/Resources/views/ambassador/phone/list.html.twig
@@ -114,15 +114,15 @@
 
     <table class="responsive-table">
         <thead>
-        <tr>
-            <th data-col="o.member_number">#</th>
-            <th data-col="b.firstname">Prénom</th>
-            <th data-col="b.lastname">Nom</th>
-            <th data-col="r.date">Dernière adhésion</th>
-            <th data-col="time">Compteur</th>
-            <th>Note(s)</th>
-            <th>Actions</th>
-        </tr>
+            <tr>
+                <th data-col="o.member_number">#</th>
+                <th data-col="b.firstname">Prénom</th>
+                <th data-col="b.lastname">Nom</th>
+                <th data-col="r.date">Dernière adhésion</th>
+                <th data-col="time">Compteur</th>
+                <th>Note(s)</th>
+                <th>Actions</th>
+            </tr>
         </thead>
         <tbody>
         {% for member in members %}
@@ -193,17 +193,15 @@
             </li>
         </ul>
     {% endif %}
-
 {% endblock %}
 
 {% block stylesheets %}
     <style>
-        td strong {
-            /*font-weight: 600;*/
-        }
-
         th.active {
-            color: #51CAE9;
+            color: {{ main_color }};
+        }
+        th[data-col] {
+            cursor: pointer;
         }
     </style>
 {% endblock %}

--- a/app/Resources/views/layout.html.twig
+++ b/app/Resources/views/layout.html.twig
@@ -16,6 +16,9 @@
             .homebox {
                 border-color: {{ main_color }};
             }
+            .main-color-text {
+                color: {{ main_color }};
+            }
         </style>
     </head>
     <body>

--- a/app/Resources/views/member/show.html.twig
+++ b/app/Resources/views/member/show.html.twig
@@ -417,6 +417,10 @@
         body {
             background-color: rgba(0, 138, 255, 0.1);
         }
+        {% elseif member.isExemptedFromShifts() %}
+        body {
+            background-color: rgb(0, 150, 136, 0.1);
+        }
         {% endif %}
     </style>
 {% endblock %}


### PR DESCRIPTION
Suite de #659 

### Quoi ?

Exemption
- mettre en valeur les comptes qui sont exemptés (à la manière des comptes fermés et gelés)
- choix de la couleur `#009688` (même que `teal`) (dans la PR suivante j'ai rendu cette couleur configurable)

Couleurs
- mettre en valeur le bouton "Gérer les adhérents" (à la manière de "Gérer les créneaux")
- petites modifications dans le header de la table "liste des utilisateurs"

### Captures d'écran

|Page|Avant|Après|
|---|---|---|
|Liste des membres|![Screenshot from 2022-12-23 11-17-39](https://user-images.githubusercontent.com/7147385/209318261-153566ce-1c12-4437-9ddc-2ea596b1823a.png)|![Screenshot from 2022-12-23 11-18-00](https://user-images.githubusercontent.com/7147385/209318299-358e49f4-acdf-47f1-aa8c-c949489d7e07.png)|
|Détail d'un membre|![Screenshot from 2022-12-23 11-15-39](https://user-images.githubusercontent.com/7147385/209317983-539f07d0-215e-4a81-aa51-3d8e8e08f598.png)|![Screenshot from 2022-12-23 11-15-25](https://user-images.githubusercontent.com/7147385/209318004-07950207-30e6-4ada-b415-59a5cc6aca07.png)|
||||
|Admin|![Screenshot from 2022-12-23 11-20-33](https://user-images.githubusercontent.com/7147385/209318645-51954a6c-5eb7-4035-ad4e-e7149eae7f0b.png)|![Screenshot from 2022-12-23 11-20-22](https://user-images.githubusercontent.com/7147385/209318682-460eaea7-d20e-4844-b5ee-3ce284f499ec.png)|
