### PR TITLE
Config : cleanup de main_color

### DIFF
--- a/app/Resources/views/_partial/footer.html.twig
+++ b/app/Resources/views/_partial/footer.html.twig
@@ -1,0 +1,8 @@
+<footer class="page-footer" style="background-color: {{ main_color }}">
+    <div class="footer-copyright">
+        <div class="container">
+            © {{ 'now'|date('Y') }} Copyright {{ project_name }}
+            <a class="grey-text text-lighten-4 right" href="{{ project_url }}">{{ project_url_display }}</a>
+        </div>
+    </div>
+</footer>

--- a/app/Resources/views/_partial/header.html.twig
+++ b/app/Resources/views/_partial/header.html.twig
@@ -1,0 +1,120 @@
+{% set frozen = app.user and app.user.beneficiary and app.user.beneficiary.membership.frozen %}
+
+<header>
+    {% if is_granted('ROLE_PREVIOUS_ADMIN') %}
+        <div class="navbar-fixed">
+            <nav class="impersonate">
+                <div class="brand-logo">{% image '@AppBundle/Resources/public/img/emoticons/072-ninja.svg' %}<img height="30px" class="emoticon" src="{{ asset_url }}" alt="ninja mode" />{% endimage %}</div>
+                <div class="nav-wrapper">
+                    <ul class="right">
+                        <li>
+                            {% if app.user.beneficiary %}
+                                <a href="{{ path('member_show', {'member_number': app.user.beneficiary.membership.memberNumber,'_login_as': '_exit'}) }}"><i class="material-icons small right">arrow_back</i>Quitter le login as {{ app.user.username }}</a>
+                            {% else %}
+                                <a href="{{ path('homepage', {'_login_as': '_exit'}) }}"><i class="material-icons small right">arrow_back</i>Quitter le login as {{ app.user.username }}</a>
+                            {% endif %}
+                        </li>
+                    </ul>
+                </div>
+            </nav>
+        </div>
+    {% endif %}
+    <nav class="main-navigation" role="navigation" style="background-color: {{ main_color }}">
+        <div class="nav-wrapper container">
+            <a id="logo-container" href="{{ path('homepage') }}" class="brand-logo hide-on-med-and-down">{{ site_name }}</a>
+            <a id="logo-container" href="{{ path('homepage') }}" class="brand-logo hide-on-large-only">{{ project_name }}</a>
+            <ul id="nav-desktop" class="right hide-on-med-and-down">
+                {% if is_granted("ROLE_ADMIN_PANEL") %}
+                    <li class="highlight">
+                        <a href="{{ path("admin") }}" title="Administration">
+                            <i class="material-icons left">build</i>
+                            <span class="show-on-xl-only">Administration</span>
+                        </a>
+                    </li>
+                {% endif %}
+                {% if is_granted("IS_AUTHENTICATED_REMEMBERED") %}
+                    {{ render(controller("AppBundle:Service:navlist")) }}
+                    {% if app.user.beneficiary %}
+                        <li>
+                            <a href="{{ path('fos_user_profile_show') }}" title="{{ app.user.firstname }}">
+                                <i class="material-icons small left">settings</i>
+                                <span class="show-on-xl-only">{{ app.user.firstname }}</span>
+                            </a>
+                        </li>
+                    {% endif %}
+                    <li>
+                        <a href="{{ path('fos_user_security_logout') }}">
+                            <i class="material-icons small right">exit_to_app</i>
+                        </a>
+                    </li>
+                {% else %}
+                    <li>
+                        <a href="{{ path('fos_user_security_login') }}">
+                            {{ 'layout.login'|trans({}, 'FOSUserBundle') }}
+                        </a>
+                    </li>
+                {% endif %}
+            </ul>
+
+            <a href="#" data-target="nav-mobile" class="sidenav-trigger show-on-medium-and-down">
+                <i class="material-icons">menu</i>
+            </a>
+            <ul id="nav-mobile" class="sidenav show-on-medium-and-down">
+                {% if is_granted("IS_AUTHENTICATED_REMEMBERED") %}
+                    <li>
+                        <div class="user-view center-align">
+                            <div class="background">
+                                {% if frozen %}
+                                    {% image '@AppBundle/Resources/public/img/frozen.png' %}
+                                        <img class="responsive-img" src="{{ asset_url }}" alt="" />
+                                    {% endimage %}
+                                {% else %}
+                                    {% image '@AppBundle/Resources/public/img/dumbo-in-the-air.jpg' %}
+                                        <img class="responsive-img" src="{{ asset_url }}" alt="" style="position: absolute;bottom: -46px;left: 0;" />
+                                    {% endimage %}
+                                {% endif %}
+                            </div>
+                            <a href="#user">
+                                <img class="circle" src="{{ gravatar(app.user.email) }}">
+                            </a>
+                            <a href="#name">
+                                <span class="{% if not frozen %}white-text{% else %}black-text{% endif %} name">{{ app.user }}</span>
+                            </a>
+                        </div>
+                    </li>
+                    <li>
+                        <a href="{{ path('homepage') }}">
+                            <i class="material-icons small">home</i>Accueil
+                        </a>
+                    </li>
+                    {% if app.user.beneficiary %}
+                        <li>
+                            <a href="{{ path('fos_user_profile_show') }}">
+                                <i class="material-icons">settings</i>Mon profil ({{ app.user.username }})
+                            </a>
+                        </li>
+                    {% endif %}
+                    {% if is_granted("ROLE_ADMIN_PANEL") %}
+                        <li class="indigo lighten-5">
+                            <a href="{{ path("admin") }}" class="">
+                                <i class="material-icons left indigo-text darken-4">build</i>Administration
+                            </a>
+                        </li>
+                    {% endif %}
+                    {{ render(controller("AppBundle:Service:navlist")) }}
+                    <li>
+                        <a href="{{ path('fos_user_security_logout') }}">
+                            <i class="material-icons small">exit_to_app</i>{{ 'layout.logout'|trans({}, 'FOSUserBundle') }}
+                        </a>
+                    </li>
+                {% else %}
+                    <li>
+                        <a href="{{ path('fos_user_security_login') }}">
+                            <span class="glyphicon glyphicon-log-in"></span> {{ 'layout.login'|trans({}, 'FOSUserBundle') }}
+                        </a>
+                    </li>
+                {% endif %}
+            </ul>
+        </div>
+    </nav>
+</header>

--- a/app/Resources/views/_partial/style_config.html.twig
+++ b/app/Resources/views/_partial/style_config.html.twig
@@ -1,0 +1,17 @@
+<style>
+    .homebox {
+        border-color: {{ main_color }};
+    }
+    .main-color-text {
+        color: {{ main_color }};
+    }
+    tr.withdrawn {
+        background-color: {{ member_withdrawn_background_color }};
+    }
+    tr.frozen {
+        background-color: {{ member_frozen_background_color }};
+    }
+    tr.exempted {
+        background-color: {{ member_exempted_background_color }};
+    }
+</style>

--- a/app/Resources/views/_partial/style_config.html.twig
+++ b/app/Resources/views/_partial/style_config.html.twig
@@ -1,4 +1,9 @@
 <style>
+    .btn, .btn:hover,
+    .btn-small, .btn-small:hover,
+    .btn-large, .btn-large:hover {
+        background-color: {{ main_color }};
+    }
     .homebox {
         border-color: {{ main_color }};
     }

--- a/app/Resources/views/admin/user/list.html.twig
+++ b/app/Resources/views/admin/user/list.html.twig
@@ -123,7 +123,7 @@
                                 {{ form_label(form.compteurgt) }}
                             </div>
                             <div class="col s6 center">
-                                < &nbsp; compteur &nbsp; <
+                                <span><</span>&nbsp;&nbsp;compteur&nbsp;&nbsp;<span><</span>
                             </div>
                             <div class="input-field col s3">
                                 {{ form_widget(form.compteurlt) }}
@@ -133,11 +133,9 @@
                     </div>
                     <div class="col s12 m4">
                         <h5>Bénéficiaire(s)</h5>
-                        <div>
-                            <div class="input-field">
-                                {{ form_widget(form.username) }}
-                                {{ form_label(form.username) }}
-                            </div>
+                        <div class="input-field">
+                            {{ form_widget(form.username) }}
+                            {{ form_label(form.username) }}
                         </div>
                         <div class="input-field">
                             {{ form_widget(form.firstname) }}
@@ -162,40 +160,35 @@
                         </div>
                     </div>
                     <div class="col s12 m4">
-                        <div>
-                            <h5>Formations / Commissions</h5>
-                            <div class="row">
-                                <div class="input-field col s6">
-                                    {{ form_widget(form.formations) }}
-                                    {{ form_label(form.formations) }}
-                                </div>
-                                <div class="col s6 input-field">
-                                    {{ form_widget(form.or_and_exp_formations) }}
-                                    {{ form_label(form.or_and_exp_formations) }}
-                                </div>
+                        <h5>Formations / Commissions</h5>
+                        <div class="row">
+                            <div class="input-field col s6">
+                                {{ form_widget(form.formations) }}
+                                {{ form_label(form.formations) }}
                             </div>
-                            <div class="input-field">
-                                {{ form_widget(form.commissions) }}
-                                {{ form_label(form.commissions) }}
+                            <div class="col s6 input-field">
+                                {{ form_widget(form.or_and_exp_formations) }}
+                                {{ form_label(form.or_and_exp_formations) }}
                             </div>
                         </div>
-                        <div>
-                            <h5>!Formations / !Commissions</h5>
-                            <div class="input-field">
-                                {{ form_widget(form.not_formations) }}
-                                {{ form_label(form.not_formations) }}
-                            </div>
-                            <div class="input-field">
-                                {{ form_widget(form.not_commissions) }}
-                                {{ form_label(form.not_commissions) }}
-                            </div>
+                        <div class="input-field">
+                            {{ form_widget(form.commissions) }}
+                            {{ form_label(form.commissions) }}
                         </div>
-                        <div>
-                            <h5>Actions</h5>
-                            {{ form_widget(form.submit) }}
-                            {{ form_widget(form.csv) }}
-                            {{ form_widget(form.mail) }}
+                        <h5>!Formations / !Commissions</h5>
+                        <div class="input-field">
+                            {{ form_widget(form.not_formations) }}
+                            {{ form_label(form.not_formations) }}
                         </div>
+                        <div class="input-field">
+                            {{ form_widget(form.not_commissions) }}
+                            {{ form_label(form.not_commissions) }}
+                        </div>
+                        <br />
+                        <h5>Actions</h5>
+                        {{ form_widget(form.submit) }}
+                        {{ form_widget(form.csv) }}
+                        {{ form_widget(form.mail) }}
                     </div>
                 </div>
 

--- a/app/Resources/views/admin/user/list.html.twig
+++ b/app/Resources/views/admin/user/list.html.twig
@@ -356,11 +356,7 @@
         th[data-col] {
             cursor: pointer;
         }
-        tr.withdrawn {
-            background: rgba(255, 50, 0, 0.2);
-        }
         tr.frozen {
-            background-color: rgba(0, 138, 255, 0.1);
             background-image: url({% image '@AppBundle/Resources/public/img/snowflakes.svg' %}{{ asset_url }}{% endimage %});
             background-position: top right;
             background-repeat: no-repeat;
@@ -368,10 +364,6 @@
         }
         tr.frozen td {
             background-color: rgba(255, 255, 255, 0.5);
-        }
-        tr.exempted {
-            /* teal */
-            background-color: rgb(0, 150, 136, 0.1);
         }
         tbody tr {
             cursor: pointer;

--- a/app/Resources/views/ambassador/phone/list.html.twig
+++ b/app/Resources/views/ambassador/phone/list.html.twig
@@ -20,40 +20,52 @@
                 <div class="row">
                     <div class="col s12 m4">
                         <h5>Compte</h5>
-                        <div>
-                            <div class="row">
-                                <div class="col s6">
-                                    <div class="input-field">
-                                        {{ form_widget(form.withdrawn) }}
-                                        {{ form_label(form.withdrawn) }}
-                                    </div>
-                                </div>
-                                <div class="col s6">
-                                    <div class="input-field">
-                                        {{ form_widget(form.frozen) }}
-                                        {{ form_label(form.frozen) }}
-                                    </div>
+                        <div class="row">
+                            <div class="col s6">
+                                <div class="input-field">
+                                    {{ form_widget(form.withdrawn) }}
+                                    {{ form_label(form.withdrawn) }}
                                 </div>
                             </div>
-                            <div class="row">
-                                <div class="col s4">
-                                    <div class="input-field">
-                                        {{ form_widget(form.membernumber) }}
-                                        {{ form_label(form.membernumber) }}
-                                    </div>
+                            <div class="col s6">
+                                <div class="input-field">
+                                    {{ form_widget(form.frozen) }}
+                                    {{ form_label(form.frozen) }}
                                 </div>
-                                <div class="col s4">
-                                    <div class="input-field">
-                                        {{ form_widget(form.membernumbergt) }}
-                                        {{ form_label(form.membernumbergt) }}
-                                    </div>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col s4">
+                                <div class="input-field">
+                                    {{ form_widget(form.membernumber) }}
+                                    {{ form_label(form.membernumber) }}
                                 </div>
-                                <div class="col s4">
-                                    <div class="input-field">
-                                        {{ form_widget(form.membernumberlt) }}
-                                        {{ form_label(form.membernumberlt) }}
-                                    </div>
+                            </div>
+                            <div class="col s4">
+                                <div class="input-field">
+                                    {{ form_widget(form.membernumbergt) }}
+                                    {{ form_label(form.membernumbergt) }}
                                 </div>
+                            </div>
+                            <div class="col s4">
+                                <div class="input-field">
+                                    {{ form_widget(form.membernumberlt) }}
+                                    {{ form_label(form.membernumberlt) }}
+                                </div>
+                            </div>
+                        </div>
+                        <h5>Compteur</h5>
+                        <div class="row valign-wrapper">
+                            <div class="input-field col s3">
+                                {{ form_widget(form.compteurgt) }}
+                                {{ form_label(form.compteurgt) }}
+                            </div>
+                            <div class="col s6 center">
+                                <span><</span>&nbsp;&nbsp;compteur&nbsp;&nbsp;<span><</span>
+                            </div>
+                            <div class="input-field col s3">
+                                {{ form_widget(form.compteurlt) }}
+                                {{ form_label(form.compteurlt) }}
                             </div>
                         </div>
                     </div>
@@ -88,22 +100,9 @@
                             {{ form_widget(form.email) }}
                             {{ form_label(form.email) }}
                         </div>
-                    </div>
-                    <div class="col s12 m4">
-                        <h5>Compteur</h5>
-                        <div class="row valign-wrapper">
-                            <div class="input-field col s3">
-                                {{ form_widget(form.compteurgt) }}
-                                {{ form_label(form.compteurgt) }}
-                            </div>
-                            <div class="col s6 center">
-                                <  &nbsp; compteur &nbsp; <
-                            </div>
-                            <div class="input-field col s3">
-                                {{ form_widget(form.compteurlt) }}
-                                {{ form_label(form.compteurlt) }}
-                            </div>
-                        </div>
+                        <br />
+                        <h5>Actions</h5>
+                        {{ form_widget(form.submit) }}
                     </div>
                 </div>
 
@@ -115,6 +114,7 @@
     <table class="responsive-table">
         <thead>
             <tr>
+                <th class="hide-on-med-and-down">Etat</th>
                 <th data-col="o.member_number">#</th>
                 <th data-col="b.firstname">Prénom</th>
                 <th data-col="b.lastname">Nom</th>
@@ -126,7 +126,21 @@
         </thead>
         <tbody>
         {% for member in members %}
-            <tr class="{% if member.withdrawn %}withdrawn{% endif %}">
+            <tr class="{% if member.withdrawn %}withdrawn{% elseif member.frozen %}frozen{% elseif member.isExemptedFromShifts() %}exempted{% endif %}">
+                <td class="hide-on-med-and-down">
+                    {% if member.withdrawn %}
+                        <i class="material-icons" title="Compte fermé">block</i>
+                    {% endif %}
+                    {% if member.frozen %}
+                        <i class="material-icons" title="Compte gelé">ac_unit</i>
+                    {% endif %}
+                    {% if member.isExemptedFromShifts() %}
+                        <i class="material-icons" title="Compte exempté">beach_access</i>
+                    {% endif %}
+                    {% if not member.mainBeneficiary.user.isEnabled %}
+                        <i class="material-icons" title="Compte pas encore activé">phonelink_off</i>
+                    {% endif %}
+                </td>
                 <td>
                     <a href="{{ path('member_show', { 'member_number': member.memberNumber }) }}">{{ member.membernumber }}</a>
                 </td>
@@ -202,6 +216,15 @@
         }
         th[data-col] {
             cursor: pointer;
+        }
+        tr.withdrawn {
+            background: rgba(255, 50, 0, 0.2);
+        }
+        tr.frozen {
+            background-color: rgba(0, 138, 255, 0.1);
+        }
+        tr.exempted {
+            background-color: rgb(0, 150, 136, 0.1);
         }
     </style>
 {% endblock %}

--- a/app/Resources/views/ambassador/phone/list.html.twig
+++ b/app/Resources/views/ambassador/phone/list.html.twig
@@ -217,15 +217,6 @@
         th[data-col] {
             cursor: pointer;
         }
-        tr.withdrawn {
-            background: rgba(255, 50, 0, 0.2);
-        }
-        tr.frozen {
-            background-color: rgba(0, 138, 255, 0.1);
-        }
-        tr.exempted {
-            background-color: rgb(0, 150, 136, 0.1);
-        }
     </style>
 {% endblock %}
 

--- a/app/Resources/views/layout.html.twig
+++ b/app/Resources/views/layout.html.twig
@@ -12,14 +12,7 @@
         <link rel="stylesheet" href="{{ asset('bundles/app/css/custom.css') }}?060820191303">
         <link rel="icon" type="image/x-icon" href="{{ asset('favicon-lelefan.png') }}" />
         <script src="{{ asset('bundles/app/js/vanilla_top.js') }}"></script>
-        <style>
-            .homebox {
-                border-color: {{ main_color }};
-            }
-            .main-color-text {
-                color: {{ main_color }};
-            }
-        </style>
+        {% include "_partial/style_config.html.twig" %}
     </head>
     <body>
         <header>

--- a/app/Resources/views/layout.html.twig
+++ b/app/Resources/views/layout.html.twig
@@ -1,4 +1,6 @@
 {% set frontend_cookie = app.request.cookies.get('frontend') | json_decode %}
+{% set frozen = app.user and app.user.beneficiary and app.user.beneficiary.membership.frozen %}
+
 <!DOCTYPE html>
 <html lang="fr">
     <head>
@@ -15,126 +17,7 @@
         {% include "_partial/style_config.html.twig" %}
     </head>
     <body>
-        <header>
-            {% if is_granted('ROLE_PREVIOUS_ADMIN') %}
-                <div class="navbar-fixed">
-                    <nav class="impersonate">
-                        <div class="brand-logo">{% image '@AppBundle/Resources/public/img/emoticons/072-ninja.svg' %}<img height="30px" class="emoticon" src="{{ asset_url }}" alt="ninja mode" />{% endimage %}</div>
-                        <div class="nav-wrapper">
-                            <ul class="right">
-                                <li>
-                                    {% if app.user.beneficiary %}
-                                        <a href="{{ path('member_show', {'member_number': app.user.beneficiary.membership.memberNumber,'_login_as': '_exit'}) }}"><i class="material-icons small right">arrow_back</i>Quitter le login as {{ app.user.username }}</a>
-                                    {% else %}
-                                        <a href="{{ path('homepage', {'_login_as': '_exit'}) }}"><i class="material-icons small right">arrow_back</i>Quitter le login as {{ app.user.username }}</a>
-                                    {% endif %}
-                                </li>
-                            </ul>
-                        </div>
-                    </nav>
-                </div>
-            {% endif %}
-            <nav class="main-navigation" role="navigation" style="background-color: {{ main_color }}">
-                <div class="nav-wrapper container">
-                    <a id="logo-container" href="{{ path('homepage') }}" class="brand-logo hide-on-med-and-down">{{ site_name }}</a>
-                    <a id="logo-container" href="{{ path('homepage') }}" class="brand-logo hide-on-large-only">{{ project_name }}</a>
-                    <ul id="nav-desktop" class="right hide-on-med-and-down">
-                        {% if is_granted("ROLE_ADMIN_PANEL") %}
-                            <li class="highlight">
-                                <a href="{{ path("admin") }}" title="Administration">
-                                    <i class="material-icons left">build</i>
-                                    <span class="show-on-xl-only">Administration</span>
-                                </a>
-                            </li>
-                        {% endif %}
-                        {% if is_granted("IS_AUTHENTICATED_REMEMBERED") %}
-                            {{ render(controller("AppBundle:Service:navlist")) }}
-                            {% if app.user.beneficiary %}
-                                <li>
-                                    <a href="{{ path('fos_user_profile_show') }}" title="{{ app.user.firstname }}">
-                                        <i class="material-icons small left">settings</i>
-                                        <span class="show-on-xl-only">{{ app.user.firstname }}</span>
-                                    </a>
-                                </li>
-                            {% endif %}
-                            <li>
-                                <a href="{{ path('fos_user_security_logout') }}">
-                                    <i class="material-icons small right">exit_to_app</i>
-                                </a>
-                            </li>
-                        {% else %}
-                            <li>
-                                <a href="{{ path('fos_user_security_login') }}">
-                                    {{ 'layout.login'|trans({}, 'FOSUserBundle') }}
-                                </a>
-                            </li>
-                        {% endif %}
-                    </ul>
-
-                    <a href="#" data-target="nav-mobile" class="sidenav-trigger show-on-medium-and-down">
-                        <i class="material-icons">menu</i>
-                    </a>
-                    <ul id="nav-mobile" class="sidenav show-on-medium-and-down">
-                        {% if is_granted("IS_AUTHENTICATED_REMEMBERED") %}
-                            {% set frozen = app.user.beneficiary and app.user.beneficiary.membership.frozen %}
-                            <li>
-                                <div class="user-view center-align">
-                                    <div class="background">
-                                        {% if frozen %}
-                                        {% image '@AppBundle/Resources/public/img/frozen.png' %}
-                                            <img class="responsive-img" src="{{ asset_url }}" alt="" />
-                                        {% endimage %}
-                                        {% else %}
-                                        {% image '@AppBundle/Resources/public/img/dumbo-in-the-air.jpg' %}
-                                            <img class="responsive-img" src="{{ asset_url }}" alt="" style="position: absolute;bottom: -46px;left: 0;" />
-                                        {% endimage %}
-                                        {% endif %}
-                                    </div>
-                                    <a href="#user">
-                                        <img class="circle" src="{{ gravatar(app.user.email) }}">
-                                    </a>
-                                    <a href="#name">
-                                        <span class="{% if not frozen %}white-text{% else %}black-text{% endif %} name">{{ app.user }}</span>
-                                    </a>
-                                </div>
-                            </li>
-                            <li>
-                                <a href="{{ path('homepage') }}">
-                                    <i class="material-icons small">home</i>Accueil
-                                </a>
-                            </li>
-                            {% if app.user.beneficiary %}
-                                <li>
-                                    <a href="{{ path('fos_user_profile_show') }}">
-                                        <i class="material-icons">settings</i>Mon profil ({{ app.user.username}})
-                                    </a>
-                                </li>
-                            {% endif %}
-                            {% if is_granted("ROLE_ADMIN_PANEL") %}
-                                <li class="indigo lighten-5">
-                                    <a href="{{ path("admin") }}" class="">
-                                        <i class="material-icons left indigo-text darken-4">build</i>Administration
-                                    </a>
-                                </li>
-                            {% endif %}
-                            {{ render(controller("AppBundle:Service:navlist")) }}
-                            <li>
-                                <a href="{{ path('fos_user_security_logout') }}">
-                                    <i class="material-icons small">exit_to_app</i>{{ 'layout.logout'|trans({}, 'FOSUserBundle') }}
-                                </a>
-                            </li>
-                        {% else %}
-                            <li>
-                                <a href="{{ path('fos_user_security_login') }}">
-                                    <span class="glyphicon glyphicon-log-in"></span> {{ 'layout.login'|trans({}, 'FOSUserBundle') }}
-                                </a>
-                            </li>
-                        {% endif %}
-                    </ul>
-                </div>
-            </nav>
-        </header>
-
+        {% include "_partial/header.html.twig" %}
         <main>
             {% if is_granted("IS_AUTHENTICATED_REMEMBERED") %}
                 {% if frozen %}
@@ -182,14 +65,7 @@
             {% endblock %}
         </main>
 
-        <footer class="page-footer" style="background-color: {{ main_color }}">
-            <div class="footer-copyright">
-                <div class="container">
-                    © {{ 'now'|date('Y') }} Copyright {{ project_name }}
-                    <a class="grey-text text-lighten-4 right" href="{{ project_url }}">{{ project_url_display }}</a>
-                </div>
-            </div>
-        </footer>
+        {% include "_partial/footer.html.twig" %}
 
         <script src="{{ asset('bundles/app/js/jquery-3.6.min.js') }}"></script>
         <script src="{{ asset('bundles/app/materialize/js/materialize-1.1.0.min.js') }}"></script>

--- a/app/Resources/views/layoutlight.html.twig
+++ b/app/Resources/views/layoutlight.html.twig
@@ -10,6 +10,7 @@
         <link rel="stylesheet" href="{{ asset('bundles/app/css/custom.css') }}">
         <link rel="icon" type="image/x-icon" href="{{ asset('favicon-lelefan.png') }}" />
         <script src="{{ asset('bundles/app/js/vanilla_top.js') }}"></script>
+        {% include "_partial/style_config.html.twig" %}
     </head>
     <body>
         <header>

--- a/app/Resources/views/member/show.html.twig
+++ b/app/Resources/views/member/show.html.twig
@@ -415,11 +415,11 @@
         }
         {% elseif member.frozen %}
         body {
-            background-color: rgba(0, 138, 255, 0.1);
+            background-color: {{ member_frozen_background_color }};
         }
         {% elseif member.isExemptedFromShifts() %}
         body {
-            background-color: rgb(0, 150, 136, 0.1);
+            background-color: {{ member_exempted_background_color }};
         }
         {% endif %}
     </style>

--- a/app/Resources/views/member/show.html.twig
+++ b/app/Resources/views/member/show.html.twig
@@ -411,7 +411,7 @@
 
         {% if member.withdrawn %}
         body {
-            background: rgba(255, 50, 0, 0.2);
+            background-color: {{ member_withdrawn_background_color }};
         }
         {% elseif member.frozen %}
         body {

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -66,6 +66,11 @@ twig:
     display_gauge: '%display_gauge%'
     profile_display_task_list: '%profile_display_task_list%'
     profile_display_time_log: '%profile_display_time_log%'
+    # member
+    member_withdrawn_background_color: '%member_withdrawn_background_color%'
+    member_frozen_background_color: '%member_frozen_background_color%'
+    member_exempted_background_color: '%member_exempted_background_color%'
+    # swipe card
     display_swipe_cards_settings: '%display_swipe_cards_settings%'
     display_freeze_account: '%display_freeze_account%'
     display_freeze_account_false_message: '%display_freeze_account_false_message%'

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -110,6 +110,11 @@ parameters:
     profile_display_task_list: true
     profile_display_time_log: true
 
+    # Member configuration
+    member_withdrawn_background_color: rgba(255, 50, 0, 0.2)
+    member_frozen_background_color: rgba(0, 138, 255, 0.1)
+    member_exempted_background_color: rgb(0, 150, 136, 0.1)
+
     # Swipe card configuration
     swipe_card_logging: true
     swipe_card_logging_anonymous: true

--- a/src/AppBundle/Resources/public/css/custom.css
+++ b/src/AppBundle/Resources/public/css/custom.css
@@ -138,12 +138,7 @@ main {
 .btn,
 .btn-large {
   color: #fff;
-  background-color: #51CAE9;
   margin-bottom: 5px;
-}
-.btn:hover,
-.btn-large:hover {
-  background-color: #189bbc;
 }
 .breadcrumbs {
   font-size: 12px;

--- a/src/AppBundle/Resources/public/css/custom.css
+++ b/src/AppBundle/Resources/public/css/custom.css
@@ -114,17 +114,11 @@ body {
 main {
   flex: 1 0 auto;
 }
-.main-navigation {
-  background-color: #51CAE9;
-}
 .impersonate {
   background: black;
 }
 .impersonate .brand-logo {
   margin-left: 10px;
-}
-footer.page-footer {
-  background-color: #51CAE9;
 }
 #logo-container {
   font-family: 'black_jackregular';

--- a/src/AppBundle/Resources/public/css/custom.less
+++ b/src/AppBundle/Resources/public/css/custom.less
@@ -41,20 +41,12 @@ main {
   flex: 1 0 auto;
 }
 
-.main-navigation {
-  background-color: @bluelelefan;
-}
-
 .impersonate {
   background: black;
 
   .brand-logo {
     margin-left: 10px;
   }
-}
-
-footer.page-footer {
-  background-color: @bluelelefan;
 }
 
 #logo-container {
@@ -79,12 +71,7 @@ footer.page-footer {
 
 .btn, .btn-large {
   color: #fff;
-  background-color: @bluelelefan;
   margin-bottom: 5px;
-}
-
-.btn:hover, .btn-large:hover {
-  background-color: darken(@bluelelefan, 20%);
 }
 
 .breadcrumbs {


### PR DESCRIPTION
Suite de #677

### Quoi ?

Il y a pas mal d'endroits où la couleur `#51CAE9` est utilisé en dure dans les stylesheet, alors que ca correspond au paramètre `main_color`

- j'ai basculé un maximum de ces styles dans un nouveau template `style_config.html.twig`
- j'en ai profité pour basculer le `header` et le `footer` dans leur propre template pour modulariser + réduire la taille du template `layout` de base