### PR TITLE
Liste des membres : afficher les comptes ouvert par défaut

### DIFF
--- a/src/AppBundle/Controller/AdminController.php
+++ b/src/AppBundle/Controller/AdminController.php
@@ -70,7 +70,7 @@ class AdminController extends Controller
     /**
      * Lists all user entities.
      *
-     * @param Request $request , SearchUserFormHelper $formHelper
+     * @param Request $request, SearchUserFormHelper $formHelper
      * @return Response
      * @Route("/users", name="user_index")
      * @Method({"GET","POST"})
@@ -85,9 +85,11 @@ class AdminController extends Controller
 
         $qb = $formHelper->initSearchQuery($this->getDoctrine()->getManager());
 
+        # default data
+        $defaultWithdrawn = 1;  # open accounts
         $page = 1;
-        $order = 'ASC';
         $sort = 'o.member_number';
+        $order = 'ASC';
         $limit = 25;
 
         if ($form->isSubmitted() && $form->isValid()) {
@@ -100,11 +102,12 @@ class AdminController extends Controller
             if ($form->get('dir')->getData()) {
                 $order = $form->get('dir')->getData();
             }
-            $formHelper->processSearchFormData($form, $qb);
         } else {
+            $form->get('withdrawn')->setData($defaultWithdrawn);
             $form->get('sort')->setData($sort);
             $form->get('dir')->setData($order);
         }
+        $formHelper->processSearchFormData($form, $qb);
         $formHelper->processSearchQueryData($request->getQueryString(), $qb);
 
         $qb = $qb->orderBy($sort, $order);


### PR DESCRIPTION
### Quoi ?

Dans Admin > Liste des membres, afficher par défaut la liste des comptes qui sont ouvert.

### Pourquoi ?

- pour éviter un peu les fausses manip d'envoi d'e-mail à des comptes fermés
- pour refléter d'avantage la réalité des membres dans l'épicerie

### Capture d'écran

![Screenshot from 2022-12-23 17-35-30](https://user-images.githubusercontent.com/7147385/209368684-517ed8b0-d9be-4cc1-bab2-6ea53021cedc.png)
