### PR TITLE
Répare l'affichage des membres sans bénéficiaire

### DIFF
--- a/app/Resources/views/member/_partial/recorded_registrations.html.twig
+++ b/app/Resources/views/member/_partial/recorded_registrations.html.twig
@@ -1,4 +1,4 @@
-{% if member.mainBeneficiary.user.recordedRegistrations | length %}
+{% if member.mainBeneficiary and member.mainBeneficiary.user.recordedRegistrations | length %}
 <h6>Recorded registrations</h6>
 <ul class="collapsible">
     {% for registration in member.mainBeneficiary.user.recordedRegistrations %}

--- a/app/Resources/views/member/show.html.twig
+++ b/app/Resources/views/member/show.html.twig
@@ -17,7 +17,7 @@
     <h4>
         {% if member.withdrawn %}<del>{% endif %}
         Membre #{{ member.memberNumber }}{% if member.withdrawn %}</del>{% endif %}
-        {% if not member.mainBeneficiary.user.isEnabled %}
+        {% if member.mainBeneficiary and not member.mainBeneficiary.user.isEnabled %}
             <i class="material-icons" title="Compte pas encore activé">phonelink_off</i>
         {% endif %}
         {% if member.isExemptedFromShifts() %}<i class="material-icons" title="Compte exempté">beach_access</i>{% endif %}
@@ -25,11 +25,13 @@
         {% if member.withdrawn %}<i class="material-icons" title="Compte fermé">block</i>{% endif %}
     </h4>
 
-    <div class="row">
-        {% for beneficiary in member.beneficiariesWithMainInFirstPosition %}
-            {% include "beneficiary/_partial/beneficiary_card.html.twig" with { beneficiary: beneficiary, detach_form: detach_beneficiary_forms[beneficiary.id], delete_form: delete_beneficiary_forms[beneficiary.id] } %}
-        {% endfor %}
-    </div>
+    {% if member.beneficiaries | length %}
+        <div class="row">
+            {% for beneficiary in member.beneficiariesWithMainInFirstPosition %}
+                {% include "beneficiary/_partial/beneficiary_card.html.twig" with { beneficiary: beneficiary, detach_form: detach_beneficiary_forms[beneficiary.id], delete_form: delete_beneficiary_forms[beneficiary.id] } %}
+            {% endfor %}
+        </div>
+    {% endif %}
 
     {% if member.notes | length %}
         <h5>Note{% if member.notes | length > 1 %}s{% endif %} à propos de ce membre</h5>
@@ -82,34 +84,36 @@
                         </li>
                     {% endfor %}
                 </ul>
-                {% if member | can_register and member.mainBeneficiary.user != app.user %}
-                    <ul class="collapsible">
-                        <li>
-                            {% if not member.lastRegistration %}
-                                <div class="collapsible-header"><i class="material-icons">add_circle</i>Adhésion</div>
-                            {% else %}
-                                <div class="collapsible-header"><i class="material-icons">add_circle</i>Ré-adhésion</div>
-                            {% endif %}
-                            <div class="collapsible-body new_registration_form">
-                                {{ form_start(new_registration_form) }}
-                                {% include "user/_partial/registration_form.html.twig" with { form: new_registration_form } %}
-                                {{ form_end(new_registration_form) }}
-                            </div>
-                        </li>
-                    </ul>
-                {% elseif (member.mainBeneficiary.user != app.user ) %}
-                    <ul class="collapsible">
-                        <li>
-                            {% if not member.lastRegistration %}
-                                <div class="collapsible-header"><i class="material-icons">add_circle</i>Adhésion</div>
-                            {% else %}
-                                <div class="collapsible-header"><i class="material-icons">add_circle</i>Ré-adhésion</div>
-                            {% endif %}
-                            <div class="collapsible-body new_registration_form">
-                                Il est trop tôt pour ré-adhérer. Cette adhésion est valable encore {{ member | remainder | date('%a') }} jours.
-                            </div>
-                        </li>
-                    </ul>
+                {% if member.mainBeneficiary and (member.mainBeneficiary.user != app.user) %}
+                    {% if member | can_register %}
+                        <ul class="collapsible">
+                            <li>
+                                {% if not member.lastRegistration %}
+                                    <div class="collapsible-header"><i class="material-icons">add_circle</i>Adhésion</div>
+                                {% else %}
+                                    <div class="collapsible-header"><i class="material-icons">add_circle</i>Ré-adhésion</div>
+                                {% endif %}
+                                <div class="collapsible-body new_registration_form">
+                                    {{ form_start(new_registration_form) }}
+                                    {% include "user/_partial/registration_form.html.twig" with { form: new_registration_form } %}
+                                    {{ form_end(new_registration_form) }}
+                                </div>
+                            </li>
+                        </ul>
+                    {% else %}
+                        <ul class="collapsible">
+                            <li>
+                                {% if not member.lastRegistration %}
+                                    <div class="collapsible-header"><i class="material-icons">add_circle</i>Adhésion</div>
+                                {% else %}
+                                    <div class="collapsible-header"><i class="material-icons">add_circle</i>Ré-adhésion</div>
+                                {% endif %}
+                                <div class="collapsible-body new_registration_form">
+                                    Il est trop tôt pour ré-adhérer. Cette adhésion est valable encore {{ member | remainder | date('%a') }} jours.
+                                </div>
+                            </li>
+                        </ul>
+                    {% endif %}
                 {% endif %}
             </div>
         </li>


### PR DESCRIPTION
oui, ca existe :thinking: 

dans leur cas, `member.mainBeneficiary` est null, ce qui faisait planter l'affichage des pages "liste des membres" (réparé dans la PR #677) ainsi que la page "détail du membre"