### PR TITLE
Fix du filtre par semaine sur le planning créneaux

### DIFF
--- a/app/Resources/views/admin/booking/_partial/bucket_calendar.html.twig
+++ b/app/Resources/views/admin/booking/_partial/bucket_calendar.html.twig
@@ -9,7 +9,10 @@
 
         {# New week --------- #}
         {% if not date and previousWeekIndex != weekIndex %}
-            <h5>Semaine {{ weekCycle[((buckets|first).start | date('W') - 1) % 4] }}</h5>
+            <h5>
+                Semaine {{ weekCycle[((buckets|first).start | date('W') - 1) % 4] }}
+                <small title="Numéro de semaine">(#{{ (buckets|first).start | date('W') }})</small>
+            </h5>
             {% set previousWeekIndex = weekIndex %}
         {% endif %}
 

--- a/app/Resources/views/admin/booking/index.html.twig
+++ b/app/Resources/views/admin/booking/index.html.twig
@@ -117,7 +117,7 @@
         $(document).ready(function ($) {
             // for the filter form ------------------
             $('#SelectionTypeDropBox').on('change', function () {
-                if (this.value === "0") {
+                if (this.value === "week") {
                     $('#weekSelectionType').show();
                     $('#dateSelectionType').hide();
                 } else {

--- a/app/Resources/views/booking/_partial/list.html.twig
+++ b/app/Resources/views/booking/_partial/list.html.twig
@@ -9,13 +9,17 @@
     {% if beneficiary is not defined %}
         {% set beneficiary = null %}
     {% endif %}
-    {% set weekCycle = ["A", "B", "C", "D"] %}
     {% set previousWeekIndex = -1 %}
+    {% set weekCycle = ["A", "B", "C", "D"] %}
+
     {% for bucketsByjob in bucketsByDay %}
         {% set weekIndex = (((bucketsByjob|first|first).start | date('W') - 1) % 4) %}
         {% if previousWeekIndex != weekIndex %}
             {% if previousWeekIndex != -1 %}</ul>{% endif %}
-            <h5 style="margin-left: 3px;">Semaine {{weekCycle[((bucketsByjob|first|first).start | date('W') - 1) % 4]}}</h5>
+            <h5>
+                Semaine {{ weekCycle[((bucketsByjob|first|first).start | date('W') - 1) % 4] }}
+                <small title="Numéro de semaine">(#{{ (bucketsByjob|first|first).start | date('W') }})</small>
+            </h5>
             {% set previousWeekIndex = weekIndex %}
             <ul class="collapsible collapsible-expandable">
         {% endif %}

--- a/src/AppBundle/Controller/BookingController.php
+++ b/src/AppBundle/Controller/BookingController.php
@@ -281,9 +281,9 @@ class BookingController extends Controller
                 } else {
                     $week = $filterForm->get("week")->getData();
                     $year = $filterForm->get("year")->getData();
-
                     $from = new DateTime();
                     $from->setISODate($year, $week, 1);
+                    $from->setTime(0,0);
                     $to = clone $from;
                     $to->modify('+6 days');
                 }

--- a/src/AppBundle/Controller/BookingController.php
+++ b/src/AppBundle/Controller/BookingController.php
@@ -83,7 +83,6 @@ class BookingController extends Controller
         ));
     }
 
-
     /**
      * @Route("/", name="booking")
      * @Security("is_granted('IS_AUTHENTICATED_REMEMBERED', user)")
@@ -178,19 +177,18 @@ class BookingController extends Controller
      *      "form":FormBuilderInterface
      *      "from" => DateTime,
      *      "to" => DateTime,
-     *      "job"=> Job|null,
-     *      "filling"=>str|null,
+     *      "job" => Job|null,
+     *      "filling" => str|null,
      *      )
      */
     private function adminFilterFormFactory($em, Request $request): array
     {
-        // filter creation ----------------------
+        // default values
         $defaultFrom = new DateTime();
         $defaultFrom->setTimestamp(strtotime('last monday', strtotime('tomorrow')));
-
+        $defaultTo = null;
         $defaultWeek = (new DateTime())->format('W');
         $defaultYear = (new DateTime())->format('Y');
-
         $years = $em->getRepository(Shift::class)->getYears();
 
         $filterForm = $this->createFormBuilder()
@@ -200,29 +198,29 @@ class BookingController extends Controller
                 'required' => true,
                 'data' => "Date",
                 'choices' => array(
-                    'Date' => true,
-                    'Semaine' => false,
+                    'Date' => "date",
+                    'Semaine' => "week",
                 ),
             ))
-            ->add('from', TextType::class, [
+            ->add('from', TextType::class, array(
                 'label' => 'A partir de',
                 'required' => true,
                 'data' => $defaultFrom->format('Y-m-d'),
                 'attr' => array('class' => 'datepicker'),
-            ])
-            ->add('to', TextType::class, [
+            ))
+            ->add('to', TextType::class, array(
                 'label' => 'Jusqu\'à',
                 'required' => false,
                 'attr' => array('class' => 'datepicker'),
-            ])
-            ->add('year', ChoiceType::class, [
+            ))
+            ->add('year', ChoiceType::class, array(
                 'required' => false,
                 'choices' => array_combine($years, $years),
                 'label' => 'Année',
                 'data' =>  $defaultYear,
                 'placeholder' => false,
-            ])
-            ->add('week', IntegerType::class, [
+            ))
+            ->add('week', IntegerType::class, array(
                 'required' => false,
                 'label' => 'Numéro de semaine',
                 'scale' => 0,
@@ -231,7 +229,7 @@ class BookingController extends Controller
                     'min' => 1,
                     'max' => 52,
                 ],
-            ])
+            ))
             ->add('job', EntityType::class, array(
                 'label' => 'Type de créneau',
                 'class' => 'AppBundle:Job',
@@ -247,44 +245,40 @@ class BookingController extends Controller
                 }
             ))
             ->add('filling', ChoiceType::class, array(
-                    'label' => 'Remplissage',
-                    'required' => false,
-                    'choices' => array(
-                        'Complet' => 'full',
-                        'Partiel' => 'partial',
-                        'Vide' => 'empty',
-                    ),
+                'label' => 'Remplissage',
+                'required' => false,
+                'choices' => array(
+                    'Complet' => 'full',
+                    'Partiel' => 'partial',
+                    'Vide' => 'empty',
+                ),
             ))
-            ->add(
-                'filter',
-                SubmitType::class,
-                array('label' => 'Filtrer', 'attr' => array('class' => 'btn', 'value' => 'filtrer'))
-            )
+            ->add('filter', SubmitType::class, array(
+                'label' => 'Filtrer',
+                'attr' => array('class' => 'btn', 'value' => 'filtrer')
+            ))
             ->getForm();
 
         $filterForm->handleRequest($request);
         $from = $defaultFrom;
-        $to = null;
+        $to = $defaultTo;
         $job = null;
-        $filling=null;
+        $filling = null;
 
         try {
             if ($filterForm->isSubmitted() && $filterForm->isValid()) {
                 $job = $filterForm->get("job")->getData();
                 $filling = $filterForm->get("filling")->getData();
 
-                if ($filterForm->get("type")->getData()) {
-                    // selection mode based on dates
-
+                // selection mode based on dates
+                if ($filterForm->get("type")->getData() == "date") {
                     $from = new DateTime($filterForm->get('from')->getData());
                     $to = $filterForm->get('to')->getData();
                     if ($to) {
                         $to = new DateTime($to);
                     }
-
+                // selection mode based on week number
                 } else {
-                    // selection mode based on week number
-
                     $week = $filterForm->get("week")->getData();
                     $year = $filterForm->get("year")->getData();
 
@@ -300,13 +294,12 @@ class BookingController extends Controller
             $job = null;
         }
 
-
         return array(
             "form" => $filterForm,
             "from" => $from,
             "to" => $to,
-            "job"=> $job,
-            "filling"=>$filling,
+            "job" => $job,
+            "filling" => $filling,
         );
     }
 


### PR DESCRIPTION
Sur la page Admin > Gérer les créneaux, il y a un filtre par numéro de semaine (grâce à la PR #460)

Mais lorsqu'on utilise ce filtre, il y a parfois une partie (ou l'entièreté) de la première journée (Lundi) qui n'apparaît pas.

Modifications apportées : 
- ajout de `setTime` sur le champ `$from` pour réparer le bug
- ajout d'un `$defaultTo` manquant
- petites modifications mineurs (alignement, clarifications)