### PR TITLE
Créneaux : ajout du numéro de semaine

### DIFF
--- a/app/Resources/views/admin/booking/_partial/bucket_calendar.html.twig
+++ b/app/Resources/views/admin/booking/_partial/bucket_calendar.html.twig
@@ -9,7 +9,10 @@
 
         {# New week --------- #}
         {% if not date and previousWeekIndex != weekIndex %}
-            <h5>Semaine {{ weekCycle[((buckets|first).start | date('W') - 1) % 4] }}</h5>
+            <h5>
+                Semaine {{ weekCycle[((buckets|first).start | date('W') - 1) % 4] }}
+                <small title="Numéro de semaine">(#{{ (buckets|first).start | date('W') }})</small>
+            </h5>
             {% set previousWeekIndex = weekIndex %}
         {% endif %}
 

--- a/app/Resources/views/booking/_partial/list.html.twig
+++ b/app/Resources/views/booking/_partial/list.html.twig
@@ -9,13 +9,17 @@
     {% if beneficiary is not defined %}
         {% set beneficiary = null %}
     {% endif %}
-    {% set weekCycle = ["A", "B", "C", "D"] %}
     {% set previousWeekIndex = -1 %}
+    {% set weekCycle = ["A", "B", "C", "D"] %}
+
     {% for bucketsByjob in bucketsByDay %}
         {% set weekIndex = (((bucketsByjob|first|first).start | date('W') - 1) % 4) %}
         {% if previousWeekIndex != weekIndex %}
             {% if previousWeekIndex != -1 %}</ul>{% endif %}
-            <h5 style="margin-left: 3px;">Semaine {{weekCycle[((bucketsByjob|first|first).start | date('W') - 1) % 4]}}</h5>
+            <h5>
+                Semaine {{ weekCycle[((bucketsByjob|first|first).start | date('W') - 1) % 4] }}
+                <small title="Numéro de semaine">(#{{ (bucketsByjob|first|first).start | date('W') }})</small>
+            </h5>
             {% set previousWeekIndex = weekIndex %}
             <ul class="collapsible collapsible-expandable">
         {% endif %}


### PR DESCRIPTION
### Quoi ?

Ajout du numéro de semaine : 
- sur la page de réservation de créneau des membres
- sur la page admin de gestion des créneaux

### Pourquoi ?

- info supplémentaire utile
- un filtre par numéro de semaine existe coté admin

### Capture d'écran

|Avant|Après|
|---|---|
|![Screenshot from 2022-12-25 22-34-49](https://user-images.githubusercontent.com/7147385/209482488-127f0763-12d2-425c-8a40-b46e1aaedeed.png)|![Screenshot from 2022-12-25 22-31-07](https://user-images.githubusercontent.com/7147385/209482467-3d30d94c-4251-4354-b618-5769c28c1907.png)|