### PR TITLE
Améliore l'affichage des logs de temps

### DIFF
--- a/app/Resources/views/member/_partial/time_logs.html.twig
+++ b/app/Resources/views/member/_partial/time_logs.html.twig
@@ -44,7 +44,7 @@
     <tbody>
         {% for timeLog in member.timeLogs %}
             <tr class="{% if timeLog.time > 0 %}green{% elseif timeLog.time < 0 %}red{% else %}grey{% endif %} lighten-5">
-                <td>{{ timeLog.createdAt | date("d/m/Y") }}</td>
+                <td title="{{ timeLog.createdAt | date_fr_with_time }}">{{ timeLog.createdAt | date("d/m/Y") }}</td>
                 <td>{{ timeLog.createdBy }}</td>
                 <td>{{ timeLog.time | duration_from_minutes }}</td>
                 <td>{{ timeLog.computedDescription }}</td>

--- a/app/Resources/views/member/_partial/time_logs.html.twig
+++ b/app/Resources/views/member/_partial/time_logs.html.twig
@@ -44,7 +44,7 @@
     <tbody>
         {% for timeLog in member.timeLogs %}
             <tr class="{% if timeLog.time > 0 %}green{% elseif timeLog.time < 0 %}red{% else %}grey{% endif %} lighten-5">
-                <td>{{ timeLog.createdAt | date_fr_full }}</td>
+                <td>{{ timeLog.createdAt | date("d/m/Y") }}</td>
                 <td>{{ timeLog.createdBy }}</td>
                 <td>{{ timeLog.time | duration_from_minutes }}</td>
                 <td>{{ timeLog.computedDescription }}</td>

--- a/src/AppBundle/Entity/TimeLog.php
+++ b/src/AppBundle/Entity/TimeLog.php
@@ -258,7 +258,7 @@ class TimeLog
             case self::TYPE_SHIFT:
                 if ($this->shift) {
                     setlocale(LC_TIME, 'fr_FR.UTF8');
-                    return strftime("Créneau de %R", $this->shift->getStart()->getTimestamp()) . ' à ' . strftime("%R", $this->shift->getEnd()->getTimestamp()) . ' [' . $this->shift->getShifter() . ']';
+                    return "Créneau " . $this->shift->getJob()->getName() . strftime(" du %d/%m/%y de %R", $this->shift->getStart()->getTimestamp()) . ' à ' . strftime("%R", $this->shift->getEnd()->getTimestamp()) . ' [' . $this->shift->getShifter() . ']';
                 } else {
                     return "Créneau (non renseigné)";
                 }


### PR DESCRIPTION
Éviter la confusion entre la date du créneau et la date de création du log de temps


| Avant | Après|
| --- | ---|
|  ![Capture d’écran_2022-12-26_10-57-24](https://user-images.githubusercontent.com/6347654/209536175-cd974a78-a93a-427e-a576-02a4e420c470.png) | ![Capture d’écran_2022-12-26_10-56-59](https://user-images.githubusercontent.com/6347654/209536149-f8167313-aab3-4885-a667-bcca516a8072.png)|

