### PR TITLE
update routing annotations en vu de SF4

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -134,6 +134,10 @@ doctrine_migrations:
   column_length: 191
   organize_migrations: false # Version >=1.2 Possible values are: "BY_YEAR", "BY_YEAR_AND_MONTH", false
 
+sensio_framework_extra:
+  router:
+    annotations: false
+
 # Swiftmailer Configuration
 swiftmailer:
   transport: '%mailer_transport%'

--- a/src/AppBundle/Controller/AdminController.php
+++ b/src/AppBundle/Controller/AdminController.php
@@ -39,8 +39,7 @@ use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
 use Symfony\Component\Validator\Constraints\Email as EmailConstraint;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpFoundation\Request;
 use DateTime;
 use Symfony\Component\Validator\Constraints\NotBlank;
@@ -57,8 +56,7 @@ class AdminController extends Controller
     /**
      * Admin panel
      *
-     * @Route("/", name="admin")
-     * @Method("GET")
+     * @Route("/", name="admin", methods={"GET"})
      * @Security("has_role('ROLE_ADMIN_PANEL')")
      */
     public function indexAction()
@@ -71,8 +69,7 @@ class AdminController extends Controller
      *
      * @param Request $request, SearchUserFormHelper $formHelper
      * @return Response
-     * @Route("/users", name="user_index")
-     * @Method({"GET","POST"})
+     * @Route("/users", name="user_index", methods={"GET","POST"})
      * @Security("has_role('ROLE_USER_MANAGER')")
      */
     public function usersAction(Request $request, SearchUserFormHelper $formHelper)
@@ -160,8 +157,7 @@ class AdminController extends Controller
      * @param Request $request , SearchUserFormHelper $formHelper
      * @param SearchUserFormHelper $formHelper
      * @return Response
-     * @Route("/admin_users", name="admins_list")
-     * @Method({"GET","POST"})
+     * @Route("/admin_users", name="admins_list", methods={"GET","POST"})
      * @Security("has_role('ROLE_ADMIN')")
      */
     public function adminUsersAction(Request $request, SearchUserFormHelper $formHelper)
@@ -188,8 +184,7 @@ class AdminController extends Controller
      *
      * @param Request $request
      * @return Response
-     * @Route("/roles", name="roles_list")
-     * @Method({"GET"})
+     * @Route("/roles", name="roles_list", methods={"GET"})
      * @Security("has_role('ROLE_ADMIN')")
      */
     public function rolesListAction(Request $request)
@@ -220,8 +215,7 @@ class AdminController extends Controller
     /**
      * Widget generator
      *
-     * @Route("/widget", name="widget_generator")
-     * @Method({"GET","POST"})
+     * @Route("/widget", name="widget_generator", methods={"GET","POST"})
      * @Security("has_role('ROLE_PROCESS_MANAGER')")
      */
     public function widgetBuilderAction(Request $request){
@@ -255,8 +249,7 @@ class AdminController extends Controller
     /**
      * Import from CSV
      *
-     * @Route("/importcsv", name="user_import_csv")
-     * @Method({"GET","POST"})
+     * @Route("/importcsv", name="user_import_csv", methods={"GET","POST"})
      * @Security("has_role('ROLE_SUPER_ADMIN')")
      */
     public function csvImportAction(Request $request, KernelInterface $kernel)

--- a/src/AppBundle/Controller/AmbassadorController.php
+++ b/src/AppBundle/Controller/AmbassadorController.php
@@ -13,8 +13,7 @@ use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\Tools\Pagination\Paginator;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpFoundation\Request;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Session\Session;
@@ -37,8 +36,7 @@ class AmbassadorController extends Controller
     /**
      * Lists all users with a registration date older than one year.
      *
-     * @Route("/membership", name="ambassador_membership_list")
-     * @Method({"GET","POST"})
+     * @Route("/membership", name="ambassador_membership_list", methods={"GET","POST"})
      * @Security("has_role('ROLE_USER_VIEWER')")
      * @param request $request , searchuserformhelper $formhelper
      * @return response
@@ -113,8 +111,7 @@ class AmbassadorController extends Controller
     /**
      * Lists all users with shift time logs older than 9 hours.
      *
-     * @Route("/shifttimelog", name="ambassador_shifttimelog_list")
-     * @Method({"GET", "POST"})
+     * @Route("/shifttimelog", name="ambassador_shifttimelog_list", methods={"GET","POST"})
      * @Security("has_role('ROLE_USER_MANAGER')")
      * @param request $request , searchuserformhelper $formhelper
      * @return response
@@ -189,8 +186,7 @@ class AmbassadorController extends Controller
     /**
      * display a member phones.
      *
-     * @Route("/phone/{member_number}", name="ambassador_phone_show")
-     * @Method("GET")
+     * @Route("/phone/{member_number}", name="ambassador_phone_show", methods={"GET"})
      * @param Membership $member
      * @return \Symfony\Component\HttpFoundation\RedirectResponse
      */
@@ -216,8 +212,7 @@ class AmbassadorController extends Controller
 
     /**
      *
-     * @Route("/note/{member_number}", name="ambassador_new_note")
-     * @Method("POST")
+     * @Route("/note/{member_number}", name="ambassador_new_note", methods={"POST"})
      * @param Membership $member
      * @param Request $request
      * @return \Symfony\Component\HttpFoundation\RedirectResponse

--- a/src/AppBundle/Controller/ApiController.php
+++ b/src/AppBundle/Controller/ApiController.php
@@ -11,7 +11,6 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 
 /**
@@ -38,8 +37,7 @@ class ApiController extends Controller
     }
 
     /**
-     * @Route("/swipe/in", name="api_swipe_in")
-     * @Method({"POST"})
+     * @Route("/swipe/in", name="api_swipe_in",  methods={"POST"})
      * @Security("has_role('ROLE_OAUTH_LOGIN')")
      */
     public function swipeInAction(){
@@ -49,8 +47,7 @@ class ApiController extends Controller
     }
 
     /**
-     * @Route("/oauth/user", name="api_user")
-     * @Method({"GET"})
+     * @Route("/oauth/user", name="api_user",  methods={"GET"})
      * @Security("has_role('ROLE_OAUTH_LOGIN')")
      */
     public function userAction()
@@ -69,8 +66,7 @@ class ApiController extends Controller
     }
 
     /**
-     * @Route("/oauth/nextcloud_user", name="api_nextcloud_user")
-     * @Method({"GET"})
+     * @Route("/oauth/nextcloud_user", name="api_nextcloud_user",  methods={"GET"})
      * @Security("has_role('ROLE_OAUTH_LOGIN')")
      */
     public function nextcloudUserAction()
@@ -90,8 +86,7 @@ class ApiController extends Controller
     }
 
     /**
-     * @Route("/v4/user", name="api_gitlab_user")
-     * @Method({"GET"})
+     * @Route("/v4/user", name="api_gitlab_user",  methods={"GET"})
      */
     public function gitlabUserAction()
     {

--- a/src/AppBundle/Controller/BeneficiaryController.php
+++ b/src/AppBundle/Controller/BeneficiaryController.php
@@ -5,18 +5,16 @@ namespace AppBundle\Controller;
 use AppBundle\Entity\Beneficiary;
 use AppBundle\Entity\Membership;
 use AppBundle\Form\BeneficiaryType;
-use Doctrine\ORM\Query\ResultSetMappingBuilder;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Form;
-use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpFoundation\Request;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
+use Symfony\Component\Security\Core\User\UserInterface;
 
 
 /**
@@ -28,7 +26,11 @@ class BeneficiaryController extends Controller
 {
     private $_current_app_user;
 
-    public function getCurrentAppUser()
+    /**
+     * Returns a user current representation.
+     * @return UserInterface
+     */
+    public function getCurrentAppUser(): UserInterface
     {
         if (!$this->_current_app_user){
             $this->_current_app_user = $this->get('security.token_storage')->getToken()->getUser();
@@ -39,11 +41,10 @@ class BeneficiaryController extends Controller
     /**
      * Displays a form to edit an existing user entity.
      *
-     * @Route("/{id}/edit", name="beneficiary_edit")
-     * @Method({"GET", "POST"})
+     * @Route("/{id}/edit", name="beneficiary_edit", methods={"GET", "POST"})
      * @param Request $request
      * @param Beneficiary $beneficiary
-     * @return \Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\Response
+     * @return RedirectResponse|Response
      */
     public function editBeneficiaryAction(Request $request, Beneficiary $beneficiary)
     {
@@ -72,12 +73,11 @@ class BeneficiaryController extends Controller
     /**
      * Set as main beneficiary
      *
-     * @Route("/beneficiary/{id}", name="beneficiary_set_main")
-     * @Method("GET")
+     * @Route("/beneficiary/{id}/set_main", name="beneficiary_set_main", methods={"GET"})
      * @param Beneficiary $beneficiary
-     * @return \Symfony\Component\HttpFoundation\RedirectResponse
+     * @return RedirectResponse
      */
-    public function setAsMainBeneficiaryAction(Beneficiary $beneficiary)
+    public function setAsMainBeneficiaryAction(Beneficiary $beneficiary): RedirectResponse
     {
         $session = new Session();
         $member = $beneficiary->getMembership();
@@ -93,13 +93,12 @@ class BeneficiaryController extends Controller
     /**
      * Detaches a beneficiary entity.
      *
-     * @Route("/{id}/detach", name="beneficiary_detach")
-     * @Method("POST")
+     * @Route("/{id}/detach", name="beneficiary_detach", methods={"GET", "POST"})
      * @param Request $request
      * @param Beneficiary $beneficiary
-     * @return \Symfony\Component\HttpFoundation\RedirectResponse
+     * @return RedirectResponse
      */
-    public function detachBeneficiaryAction(Request $request, Beneficiary $beneficiary)
+    public function detachBeneficiaryAction(Request $request, Beneficiary $beneficiary): RedirectResponse
     {
         $session = new Session();
         $member = $beneficiary->getMembership();
@@ -160,13 +159,12 @@ class BeneficiaryController extends Controller
     /**
      * Deletes a beneficiary entity.
      *
-     * @Route("/beneficiary/{id}", name="beneficiary_delete")
-     * @Method("DELETE")
+     * @Route("/beneficiary/{id}", name="beneficiary_delete", methods={"GET", "POST"})
      * @param Request $request
      * @param Beneficiary $beneficiary
-     * @return \Symfony\Component\HttpFoundation\RedirectResponse
+     * @return RedirectResponse
      */
-    public function deleteBeneficiaryAction(Request $request, Beneficiary $beneficiary)
+    public function deleteBeneficiaryAction(Request $request, Beneficiary $beneficiary): RedirectResponse
     {
         $member = $beneficiary->getMembership();
 
@@ -187,7 +185,8 @@ class BeneficiaryController extends Controller
         return $this->redirectToShow($member);
     }
 
-    private function getErrorMessages(Form $form)
+    // TODO: check if this function is ever used ?!
+    private function getErrorMessages(Form $form): array
     {
         $errors = array();
 
@@ -212,9 +211,9 @@ class BeneficiaryController extends Controller
     /**
      * @Route("/find_member_number", name="find_member_number")
      * @param Request $request
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
-    public function findMemberNumberAction(Request $request)
+    public function findMemberNumberAction(Request $request): Response
     {
         $securityContext = $this->container->get('security.authorization_checker');
         if ($securityContext->isGranted('IS_AUTHENTICATED_REMEMBERED')) {
@@ -259,18 +258,17 @@ class BeneficiaryController extends Controller
     }
 
     /**
-     * @Route("/{id}/confirm", name="confirm")
-     * @Method({"POST"})
+     * @Route("/{id}/confirm", name="confirm", methods={"POST"})
      * @param Beneficiary $beneficiary
      * @param Request $request
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
-    public function confirmAction(Beneficiary $beneficiary, Request $request)
+    public function confirmAction(Beneficiary $beneficiary, Request $request): Response
     {
         return $this->render('beneficiary/confirm.html.twig', array('beneficiary' => $beneficiary));
     }
 
-    private function redirectToShow(Membership $member)
+    private function redirectToShow(Membership $member):RedirectResponse
     {
         $user = $member->getMainBeneficiary()->getUser(); // FIXME
         $session = new Session();

--- a/src/AppBundle/Controller/BookingController.php
+++ b/src/AppBundle/Controller/BookingController.php
@@ -27,8 +27,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Session;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 
 /**
@@ -84,12 +83,11 @@ class BookingController extends Controller
     }
 
     /**
-     * @Route("/", name="booking")
+     * @Route("/", name="booking", methods={"GET","POST"})
      * @Security("is_granted('IS_AUTHENTICATED_REMEMBERED', user)")
-     * @Method({"GET","POST"})
      * @param Request $request
      * @return RedirectResponse|Response
-     * @throws \Exception
+     * @throws Exception
      */
     public function indexAction(Request $request)
     {
@@ -306,6 +304,7 @@ class BookingController extends Controller
     /**
      * build the bucket (regrouping all the shift at the same time with the same job)
      * // TODO Maybe it should be in the BucketRepository...
+     *
      * @param array $shifts
      * @param string|null $filling
      * @return array
@@ -361,9 +360,9 @@ class BookingController extends Controller
 
     /**
      * main administration page for booking shift
-     * @Route("/admin", name="booking_admin")
+     *
+     * @Route("/admin", name="booking_admin", methods={"GET","POST"})
      * @Security("has_role('ROLE_SHIFT_MANAGER')")
-     * @Method({"GET","POST"})
      */
     public function adminAction(Request $request): Response
     {
@@ -387,9 +386,8 @@ class BookingController extends Controller
     }
 
     /**
-     * @Route("/bucket/{id}/show", name="bucket_show")
+     * @Route("/bucket/{id}/show", name="bucket_show", methods={"GET"})
      * @Security("has_role('ROLE_SHIFT_MANAGER')")
-     * @Method({"GET"})
      */
     public function showBucketAction(Request $request, Shift $bucket)
     {
@@ -430,9 +428,11 @@ class BookingController extends Controller
     }
 
     /**
+     * When the user click on the 'edit' button on the bucket popup.
+     *
+     * @Route("/bucket/{id}/edit", name="bucket_edit", methods={"GET", "POST"})
      * @Route("/bucket/{id}/edit", name="bucket_edit")
      * @Security("has_role('ROLE_SHIFT_MANAGER')")
-     * @Method({"GET", "POST"})
      */
     public function editBucketAction(Request $request,Shift $shift)
     {
@@ -469,10 +469,10 @@ class BookingController extends Controller
     }
 
     /**
-     * lock a bucket
+     * lock a bucket, used when the user click on the 'verouiller' button
+     * on the bucket popup.
      *
-     * @Route("/bucket/{id}/lock", name="bucket_lock_unlock")
-     * @Method("POST")
+     * @Route("/bucket/{id}/lock", name="bucket_lock_unlock", methods={"POST"})
      */
     public function lockUnlockBucketAction(Request $request, Shift $shift)
     {
@@ -525,11 +525,11 @@ class BookingController extends Controller
     }
 
     /**
-     * delete all shifts in bucket.
+     * delete all shifts in bucket, used when the user click on the 'supprimer'
+     * button on the bucket popup.
      *
-     * @Route("/bucket/{id}", name="bucket_delete")
+     * @Route("/bucket/{id}", name="bucket_delete", methods={"DELETE"})
      * @Security("has_role('ROLE_SHIFT_MANAGER')")
-     * @Method("DELETE")
      */
     public function deleteBucketAction(Request $request, Shift $bucket)
     {

--- a/src/AppBundle/Controller/ClientController.php
+++ b/src/AppBundle/Controller/ClientController.php
@@ -8,8 +8,7 @@ use AppBundle\Entity\Service;
 use AppBundle\Entity\Task;
 use AppBundle\Form\ClientType;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpFoundation\Request;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Session\Session;
@@ -27,8 +26,7 @@ class ClientController extends Controller
     /**
      * Lists all clients.
      *
-     * @Route("/", name="admin_clients")
-     * @Method("GET")
+     * @Route("/", name="admin_clients", methods={"GET"})
      * @Security("has_role('ROLE_SUPER_ADMIN')")
      */
     public function listAction()
@@ -40,8 +38,7 @@ class ClientController extends Controller
     /**
      * Add new Client //todo put this auto in service création
      *
-     * @Route("/client_new", name="client_new")
-     * @Method({"GET","POST"})
+     * @Route("/client_new", name="client_new", methods={"GET","POST"})
      * @Security("has_role('ROLE_ADMIN')")
      */
     public function newAction(Request $request){
@@ -83,8 +80,7 @@ class ClientController extends Controller
     /**
      * edit client.
      *
-     * @Route("/edit/{id}", name="client_edit")
-     * @Method({"GET","POST"})
+     * @Route("/edit/{id}", name="client_edit", methods={"GET","POST"})
      * @Security("has_role('ROLE_SUPER_ADMIN')")
      */
     public function editAction(Request $request,Client $client){
@@ -135,8 +131,7 @@ class ClientController extends Controller
     /**
      * remove client.
      *
-     * @Route("/remove/{id}", name="client_remove")
-     * @Method({"DELETE"})
+     * @Route("/remove/{id}", name="client_remove", methods={"DELETE"})
      * @Security("has_role('ROLE_SUPER_ADMIN')")
      */
     public function removeAction(Request $request,Client $client)

--- a/src/AppBundle/Controller/CodeController.php
+++ b/src/AppBundle/Controller/CodeController.php
@@ -7,8 +7,7 @@ use AppBundle\Entity\Code;
 use AppBundle\Event\CodeNewEvent;
 use AppBundle\Security\CodeVoter;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -40,8 +39,7 @@ class CodeController extends Controller
     /**
      * Lists all codes.
      *
-     * @Route("/", name="codes_list")
-     * @Method("GET")
+     * @Route("/", name="codes_list", methods={"GET"})
      * @Security("has_role('ROLE_USER')")
      */
     public function listAction(Request $request){
@@ -76,8 +74,7 @@ class CodeController extends Controller
     /**
      * add new code.
      *
-     * @Route("/new", name="code_edit")
-     * @Method({"GET","POST"})
+     * @Route("/new", name="code_edit", methods={"GET","POST"})
      * @Security("has_role('ROLE_USER')")
      */
     public function newAction(Request $request)
@@ -133,8 +130,7 @@ class CodeController extends Controller
     /**
      * add new code.
      *
-     * @Route("/generate", name="code_generate")
-     * @Method({"GET","POST"})
+     * @Route("/generate", name="code_generate", methods={"GET","POST"})
      * @Security("has_role('ROLE_USER')")
      */
     public function generateAction(Request $request){
@@ -209,8 +205,7 @@ class CodeController extends Controller
 
     /**
      *
-     * @Route("/toggle/{id}", name="code_toggle")
-     * @Method({"GET"})
+     * @Route("/toggle/{id}", name="code_toggle",methods={"GET","POST"})
      * @Security("has_role('ROLE_USER')")
      */
     public function toggleAction(Request $request,Code $code){
@@ -236,8 +231,7 @@ class CodeController extends Controller
     /**
      * close all codes.
      *
-     * @Route("/close_all", name="code_change_done")
-     * @Method("GET")
+     * @Route("/close_all", name="code_change_done", methods={"GET"})
      */
     public function closeAllButMineAction(Request $request){
         $session = new Session();
@@ -296,8 +290,7 @@ class CodeController extends Controller
     /**
      * code delete
      *
-     * @Route("/{id}", name="code_delete")
-     * @Method({"DELETE"})
+     * @Route("/{id}", name="code_delete", methods={"DELETE"})
      */
     public function removeAction(Request $request,Code $code)
     {

--- a/src/AppBundle/Controller/CommissionController.php
+++ b/src/AppBundle/Controller/CommissionController.php
@@ -18,8 +18,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpFoundation\Request;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 
@@ -34,8 +33,7 @@ class CommissionController extends Controller
     /**
      * Comissions list
      *
-     * @Route("/", name="admin_commissions")
-     * @Method("GET")
+     * @Route("/", name="admin_commissions", methods={"GET"})
      * @Security("has_role('ROLE_ADMIN')")
      */
     public function indexAction(Request $request)
@@ -47,8 +45,7 @@ class CommissionController extends Controller
     /**
      * Comission new
      *
-     * @Route("/new", name="commission_new")
-     * @Method({"GET", "POST"})
+     * @Route("/new", name="commission_new", methods={"GET","POST"})
      * @Security("has_role('ROLE_SUPER_ADMIN')")
      */
     public function newAction(Request $request)
@@ -82,9 +79,8 @@ class CommissionController extends Controller
     /**
      * Commission edit
      *
-     * @Route("/{id}/edit", name="commission_edit")
-     * @Method({"GET", "POST"})
-     * @Security("has_role('ROLE_USER')")
+     * @Route("/{id}/edit", name="commission_edit", methods={"GET","POST"})
+     * @Security("has_role('ROLE_ADMIN')")
      */
     public function editAction(Request $request,Commission $commission)
     {
@@ -92,7 +88,7 @@ class CommissionController extends Controller
         $current_app_user = $this->get('security.token_storage')->getToken()->getUser();
         $beneficiary = $current_app_user->getBeneficiary();
 
-        if (! $current_app_user->hasRole('ROLE_SUPER_ADMIN') && ! $beneficiary->getOwnedCommissions()->contains($commission)) {
+        if (! $current_app_user->hasRole('ROLE_ADMIN') && ! $beneficiary->getOwnedCommissions()->contains($commission)) {
             throw $this->createAccessDeniedException();
         }
 
@@ -144,15 +140,9 @@ class CommissionController extends Controller
     }
 
     /**
-     * Commission add beneficiary'query_builder' => function (EntityRepository $er) {
-                    return $er->createQueryBuilder('b')
-                        ->join("b.user", "u")
-                        ->addSelect("u")
-                        ->where('u.withdrawn = 0');
-                },
+     * Commission add a beneficiary
      *
-     * @Route("/{id}/add_beneficiary/", name="commission_add_beneficiary")
-     * @Method({"POST"})
+     * @Route("/{id}/add_beneficiary/", name="commission_add_beneficiary", methods={"POST"})
      */
     public function addBeneficiaryAction(Request $request,Commission $commission)
     {
@@ -200,8 +190,7 @@ class CommissionController extends Controller
     /**
      * Commission remove beneficiary
      *
-     * @Route("/{id}/remove_beneficiary/", name="commission_remove_beneficiary")
-     * @Method({"POST"})
+     * @Route("/{id}/remove_beneficiary/", name="commission_remove_beneficiary", methods={"POST"})
      */
     public function removeBeneficiaryAction(Request $request,Commission $commission)
     {
@@ -237,8 +226,7 @@ class CommissionController extends Controller
     /**
      * Comission delete
      *
-     * @Route("/{id}", name="commission_delete")
-     * @Method({"DELETE"})
+     * @Route("/{id}", name="commission_delete", methods={"DELETE"})
      * @Security("has_role('ROLE_SUPER_ADMIN')")
      */
     public function removeAction(Request $request,Commission $commission)

--- a/src/AppBundle/Controller/DefaultController.php
+++ b/src/AppBundle/Controller/DefaultController.php
@@ -22,7 +22,7 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
@@ -31,7 +31,6 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Serializer\Encoder\JsonDecode;
 
@@ -138,9 +137,8 @@ class DefaultController extends Controller
     }
 
     /**
-     * @Route("/schedule", name="schedule")
+     * @Route("/schedule", name="schedule", methods={"GET","POST"})
      * @Security("is_granted('IS_AUTHENTICATED_REMEMBERED', user)")
-     * @Method({"GET","POST"})
      * @param Request $request
      * @return \Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\Response
      */
@@ -213,8 +211,7 @@ class DefaultController extends Controller
     }
 
     /**
-     * @Route("/check", name="check")
-     * @Method({"POST","GET"})
+     * @Route("/check", name="check", methods={"GET","POST"})
      */
     public function checkAction(Request $request)
     {
@@ -263,8 +260,7 @@ class DefaultController extends Controller
     }
 
     /**
-     * @Route("/helloassoNotify", name="helloasso_notify")
-     * @Method({"POST"})
+     * @Route("/helloassoNotify", name="helloasso_notify", methods={"POST"})
      * inspiré de
      * https://github.com/Breizhicoop/HelloDoli/blob/master/adhesion.php
      * https://github.com/Mailforgood/HelloAsso.Api.Doc/blob/master/HelloAsso.Api.Samples/php/helloasso_stat.php
@@ -346,8 +342,7 @@ class DefaultController extends Controller
     }
 
     /**
-     * @Route("/shift/{id}/contact_form", name="shift_contact_form")
-     * @Method({"GET","POST"})
+     * @Route("/shift/{id}/contact_form", name="shift_contact_form", methods={"GET","POST"})
      */
     public function shiftContactFormAction(Shift $shift, Request $request, \Swift_Mailer $mailer)
     {
@@ -414,8 +409,7 @@ class DefaultController extends Controller
     }
 
     /**
-     * @Route("/widget", name="widget")
-     * @Method({"GET"})
+     * @Route("/widget", name="widget", methods={"GET"})
      */
     public function widgetAction(Request $request)
     {

--- a/src/AppBundle/Controller/DynamicContentController.php
+++ b/src/AppBundle/Controller/DynamicContentController.php
@@ -6,8 +6,7 @@ use AppBundle\Entity\DynamicContent;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
+use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 
 /**
@@ -30,8 +29,7 @@ class DynamicContentController extends Controller
     /**
      * Lists all dynamic contents.
      *
-     * @Route("/", name="dynamic_content_list")
-     * @Method("GET")
+     * @Route("/", name="dynamic_content_list", methods={"GET"})
      * @Security("has_role('ROLE_PROCESS_MANAGER')")
      */
     public function listAction(Request $request)
@@ -56,8 +54,7 @@ class DynamicContentController extends Controller
     /**
      * Edit a dynamic content
      *
-     * @Route("/{id}/edit", name="dynamic_content_edit")
-     * @Method({"GET","POST"})
+     * @Route("/{id}/edit", name="dynamic_content_edit", methods={"GET","POST"})
      * @Security("has_role('ROLE_PROCESS_MANAGER')")
      */
     public function dynamicContentEditAction(Request $request, DynamicContent $dynamicContent)

--- a/src/AppBundle/Controller/EmailTemplateController.php
+++ b/src/AppBundle/Controller/EmailTemplateController.php
@@ -7,8 +7,7 @@ use AppBundle\Form\EmailTemplateType;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
+use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 
 /**
@@ -31,8 +30,7 @@ class EmailTemplateController extends Controller
     /**
      * Lists all email templates.
      *
-     * @Route("/", name="email_template_list")
-     * @Method("GET")
+     * @Route("/", name="email_template_list", methods={"GET"})
      * @Security("has_role('ROLE_PROCESS_MANAGER')")
      */
     public function listAction(Request $request)
@@ -49,8 +47,7 @@ class EmailTemplateController extends Controller
     /**
      * Create an email template
      *
-     * @Route("/new", name="email_template_new")
-     * @Method({"GET","POST"})
+     * @Route("/new", name="email_template_new", methods={"GET","POST"})
      * @Security("has_role('ROLE_PROCESS_MANAGER')")
      */
     public function newAction(Request $request)
@@ -76,8 +73,7 @@ class EmailTemplateController extends Controller
     /**
      * Edit an email template
      *
-     * @Route("/{id}/edit", name="email_template_edit")
-     * @Method({"GET","POST"})
+     * @Route("/{id}/edit", name="email_template_edit", methods={"GET","POST"})
      * @Security("has_role('ROLE_PROCESS_MANAGER')")
      */
     public function editAction(Request $request, EmailTemplate $emailTemplate)

--- a/src/AppBundle/Controller/EventController.php
+++ b/src/AppBundle/Controller/EventController.php
@@ -10,8 +10,7 @@ use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\Request;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
+use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Session;
@@ -28,8 +27,7 @@ class EventController extends Controller
     /**
      * Lists all events.
      *
-     * @Route("/", name="event_list")
-     * @Method("GET")
+     * @Route("/", name="event_list", methods={"GET"})
      * @Security("has_role('ROLE_PROCESS_MANAGER')")
      */
     public function listAction(Request $request) {
@@ -43,8 +41,7 @@ class EventController extends Controller
     /**
      * Lists all proxy
      *
-     * @Route("/proxies_list", name="proxies_list")
-     * @Method("GET")
+     * @Route("/proxies_list", name="proxies_list", methods={"GET"})
      * @Security("has_role('ROLE_ADMIN')")
      */
     public function listProxiesAction(){
@@ -64,8 +61,7 @@ class EventController extends Controller
     /**
      * Lists all proxy for one event.
      *
-     * @Route("/{id}/proxies_list", name="event_proxies_list")
-     * @Method("GET")
+     * @Route("/{id}/proxies_list", name="event_proxies_list", methods={"GET"})
      * @Security("has_role('ROLE_ADMIN')")
      */
     public function listEventProxiesAction(Event $event,Request $request){
@@ -85,8 +81,7 @@ class EventController extends Controller
     /**
      * Event new
      *
-     * @Route("/new", name="event_new")
-     * @Method({"GET", "POST"})
+     * @Route("/new", name="event_new", methods={"GET","POST"})
      * @Security("has_role('ROLE_ADMIN')")
      */
     public function newAction(Request $request)
@@ -112,8 +107,7 @@ class EventController extends Controller
     /**
      * Event edit
      *
-     * @Route("/{id}/edit", name="event_edit")
-     * @Method({"GET", "POST"})
+     * @Route("/{id}/edit", name="event_edit", methods={"GET","POST"})
      * @Security("has_role('ROLE_ADMIN')")
      */
     public function editAction(Request $request,Event $event)
@@ -146,8 +140,7 @@ class EventController extends Controller
     /**
      * Event delete
      *
-     * @Route("/{id}", name="event_delete")
-     * @Method({"DELETE"})
+     * @Route("/{id}", name="event_delete", methods={"DELETE"})
      * @Security("has_role('ROLE_ADMIN')")
      */
     public function removeAction(Request $request,Event $event)
@@ -168,8 +161,7 @@ class EventController extends Controller
     /**
      * Proxy delete
      *
-     * @Route("/proxy/{id}", name="proxy_delete")
-     * @Method({"DELETE"})
+     * @Route("/proxy/{id}", name="proxy_delete", methods={"DELETE"})
      * @Security("has_role('ROLE_SUPER_ADMIN')")
      */
     public function removeProxyAction(Request $request,Proxy $proxy)
@@ -190,8 +182,7 @@ class EventController extends Controller
     /**
      * Proxy edit
      *
-     * @Route("/proxy/{id}", name="proxy_edit")
-     * @Method({"GET","POST"})
+     * @Route("/proxy/{id}", name="proxy_edit", methods={"GET","POST"})
      * @Security("has_role('ROLE_SUPER_ADMIN')")
      */
     public function editProxyAction(Request $request,Proxy $proxy,\Swift_Mailer $mailer)
@@ -294,8 +285,7 @@ class EventController extends Controller
     /**
      * Proxy new
      *
-     * @Route("/{id}/proxy/give", name="event_proxy_give")
-     * @Method({"GET", "POST"})
+     * @Route("/{id}/proxy/give", name="event_proxy_give", methods={"GET","POST"})
      */
     public function giveProxyAction(Event $event,Request $request,\Swift_Mailer $mailer){
         $session = new Session();
@@ -451,8 +441,7 @@ class EventController extends Controller
      * is defined, the member with an expired registration.
      *
      * Goes with the Twig template views/beneficiary/find_member_number.html.twig
-     * @Route("/{id}/proxy/find_beneficiary", name="event_proxy_find_beneficiary")
-     * @Method({"POST"})
+     * @Route("/{id}/proxy/find_beneficiary", name="event_proxy_find_beneficiary", methods={"POST"})
      */
     public function findBeneficiaryAction(Event $event,Request $request){
         $current_app_user = $this->get('security.token_storage')->getToken()->getUser();
@@ -523,8 +512,7 @@ class EventController extends Controller
     /**
      * Proxy take
      *
-     * @Route("/{event}/proxy/remove/{proxy}", name="event_proxy_lite_remove")
-     * @Method({"GET"})
+     * @Route("/{event}/proxy/remove/{proxy}", name="event_proxy_lite_remove", methods={"GET"})
      */
     public function removeProxyLiteAction(Event $event,Proxy $proxy,Request $request){
         $session = new Session();
@@ -541,8 +529,7 @@ class EventController extends Controller
     /**
      * Proxy take
      *
-     * @Route("/{id}/proxy/take", name="event_proxy_take")
-     * @Method({"GET","POST"})
+     * @Route("/{id}/proxy/take", name="event_proxy_take", methods={"GET","POST"})
      */
     public function acceptProxyAction(Event $event,Request $request,\Swift_Mailer $mailer){
 
@@ -650,8 +637,7 @@ class EventController extends Controller
      *
      * Goes with the twig template views/admin/event/signatures.html.twig
      *
-     * @Route("/{id}/signatures/", name="event_signatures")
-     * @Method({"GET","POST"})
+     * @Route("/{id}/signatures/", name="event_signatures", methods={"GET","POST"})
      */
     public function signaturesListAction(Request $request,Event $event): Response
     {

--- a/src/AppBundle/Controller/FormationController.php
+++ b/src/AppBundle/Controller/FormationController.php
@@ -6,8 +6,7 @@ use AppBundle\Entity\Formation;
 use AppBundle\Form\FormationType;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpFoundation\Request;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 
@@ -23,8 +22,7 @@ class FormationController extends Controller
     /**
      * Formations list
      *
-     * @Route("/", name="admin_formations")
-     * @Method("GET")
+     * @Route("/", name="admin_formations", methods={"GET"})
      * @Security("has_role('ROLE_ADMIN')")
      */
     public function indexAction()
@@ -36,8 +34,7 @@ class FormationController extends Controller
     /**
      * Formation new
      *
-     * @Route("/new", name="formation_new")
-     * @Method({"GET", "POST"})
+     * @Route("/new", name="formation_new", methods={"GET","POST"})
      * @Security("has_role('ROLE_ADMIN')")
      */
     public function newAction(Request $request)
@@ -68,8 +65,7 @@ class FormationController extends Controller
     /**
      * Formation edit
      *
-     * @Route("/{id}/edit", name="formation_edit")
-     * @Method({"GET", "POST"})
+     * @Route("/{id}/edit", name="formation_edit", methods={"GET","POST"})
      * @Security("has_role('ROLE_ADMIN')")
      */
     public function editAction(Request $request, Formation $formation)
@@ -99,8 +95,7 @@ class FormationController extends Controller
     /**
      * Formation delete
      *
-     * @Route("/{id}", name="formation_delete")
-     * @Method({"DELETE"})
+     * @Route("/{id}", name="formation_delete", methods={"DELETE"})
      * @Security("has_role('ROLE_SUPER_ADMIN')")
      */
     public function removeAction(Request $request, Formation $formation)

--- a/src/AppBundle/Controller/HelloassoController.php
+++ b/src/AppBundle/Controller/HelloassoController.php
@@ -35,8 +35,7 @@ use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
 use Symfony\Component\Validator\Constraints\Email as EmailConstraint;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpFoundation\Request;
 use DateTime;
 use Symfony\Component\Validator\Constraints\NotBlank;
@@ -53,22 +52,24 @@ class HelloassoController extends Controller
     /**
      * Helloasso payments list
      *
-     * @Route("/payments", name="helloasso_payments")
-     * @Method("GET")
+     * @Route("/payments", name="helloasso_payments", methods={"GET"})
      * @Security("has_role('ROLE_FINANCE_MANAGER')")
      */
     public function helloassoPaymentsAction(Request $request)
     {
-        if (!($page = $request->get('page')))
+        if (!($page = $request->get('page'))) {
             $page = 1;
+        }
         $limit = 50;
         $max = $this->getDoctrine()->getManager()->createQueryBuilder()->from('AppBundle\Entity\HelloassoPayment', 'n')
             ->select('count(n.id)')
             ->getQuery()
             ->getSingleScalarResult();
+
         $nb_of_pages = intval($max / $limit);
-        if ($max > 0)
+        if ($max > 0) {
             $nb_of_pages += (($max % $limit) > 0) ? 1 : 0;
+        }
         $payments = $this->getDoctrine()->getManager()
             ->getRepository('AppBundle:HelloassoPayment')
             ->findBy(array(), array('createdAt' => 'DESC', 'date' => 'DESC'), $limit, ($page - 1) * $limit);
@@ -79,6 +80,7 @@ class HelloassoController extends Controller
 
         //todo: save this somewhere ?
         $campaigns_json = $this->container->get('AppBundle\Helper\Helloasso')->get('campaigns');
+
         $campaigns = array();
         foreach ($campaigns_json->resources as $c) {
             $campaigns[intval($c->id)] = $c;
@@ -96,8 +98,7 @@ class HelloassoController extends Controller
     /**
      * Helloasso browser
      *
-     * @Route("/browser", name="helloasso_browser")
-     * @Method("GET")
+     * @Route("/browser", name="helloasso_browser", methods={"GET"})
      * @Security("has_role('ROLE_FINANCE_MANAGER')")
      */
     public function helloassoBrowserAction(Request $request)
@@ -136,8 +137,7 @@ class HelloassoController extends Controller
     /**
      * Helloasso manual paiement add
      *
-     * @Route("/manualPaimentAdd/", name="helloasso_manual_paiement_add")
-     * @Method("POST")
+     * @Route("/manualPaimentAdd/", name="helloasso_manual_paiement_add", methods={"POST"})
      * @Security("has_role('ROLE_FINANCE_MANAGER')")
      */
     public function helloassoManualPaimentAddAction(Request $request)
@@ -190,8 +190,7 @@ class HelloassoController extends Controller
     /**
      * remove payment
      *
-     * @Route("/payments/{id}", name="helloasso_payment_remove")
-     * @Method({"DELETE"})
+     * @Route("/payments/{id}", name="helloasso_payment_remove", methods={"DELETE"})
      * @Security("has_role('ROLE_SUPER_ADMIN')")
      */
     public function removePaymentAction(Request $request, HelloassoPayment $payment)
@@ -227,8 +226,7 @@ class HelloassoController extends Controller
     /**
      * resolve orphan payment
      *
-     * @Route("/payment/{id}/resolve_orphan/{code}", name="helloasso_resolve_orphan")
-     * @Method({"GET"})
+     * @Route("/payment/{id}/resolve_orphan/{code}", name="helloasso_resolve_orphan", methods={"GET"})
      * @Security("has_role('ROLE_USER')")
      */
     public function resolveOrphan(HelloassoPayment $payment,$code){
@@ -252,8 +250,7 @@ class HelloassoController extends Controller
     /**
      * confirm resolve orphan payment
      *
-     * @Route("/payment/{id}/confirm_resolve_orphan/{code}", name="helloasso_confirm_resolve_orphan")
-     * @Method({"GET"})
+     * @Route("/payment/{id}/confirm_resolve_orphan/{code}", name="helloasso_confirm_resolve_orphan", methods={"GET"})
      * @Security("has_role('ROLE_USER')")
      */
     public function confirmOrphan(HelloassoPayment $payment,$code){
@@ -276,8 +273,7 @@ class HelloassoController extends Controller
     /**
      * exit app and redirect to resolve
      *
-     * @Route("/payment/{id}/orphan_exit_and_back/{code}", name="helloasso_orphan_exit_and_back")
-     * @Method({"GET"})
+     * @Route("/payment/{id}/orphan_exit_and_back/{code}", name="helloasso_orphan_exit_and_back", methods={"GET"})
      * @Security("has_role('ROLE_USER')")
      */
     public function orphanExitAndConfirm(Request $request,HelloassoPayment $payment,$code){

--- a/src/AppBundle/Controller/JobController.php
+++ b/src/AppBundle/Controller/JobController.php
@@ -5,8 +5,7 @@ namespace AppBundle\Controller;
 use AppBundle\Entity\Job;
 use AppBundle\Form\JobType;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpFoundation\Request;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Session\Session;
@@ -57,8 +56,7 @@ class JobController extends Controller
     /**
      * Lists all jobs.
      *
-     * @Route("/", name="job_list")
-     * @Method({"GET","POST"})
+     * @Route("/", name="job_list", methods={"GET","POST"})
      * @Security("has_role('ROLE_ADMIN')")
      */
     public function listAction(Request $request)
@@ -82,8 +80,7 @@ class JobController extends Controller
     /**
      * add new job.
      *
-     * @Route("/new", name="job_new")
-     * @Method({"GET","POST"})
+     * @Route("/new", name="job_new", methods={"GET","POST"})
      * @Security("has_role('ROLE_ADMIN')")
      */
     public function newAction(Request $request)
@@ -114,8 +111,7 @@ class JobController extends Controller
     /**
      * Edit job.
      *
-     * @Route("/edit/{id}", name="job_edit")
-     * @Method({"GET","POST"})
+     * @Route("/edit/{id}", name="job_edit", methods={"GET","POST"})
      * @Security("has_role('ROLE_ADMIN')")
      */
     public function editAction(Request $request, Job $job)
@@ -144,8 +140,7 @@ class JobController extends Controller
     /**
      * Delete job.
      *
-     * @Route("/{id}", name="job_delete")
-     * @Method({"DELETE"})
+     * @Route("/{id}", name="job_delete", methods={"DELETE"})
      * @Security("has_role('ROLE_SUPER_ADMIN')")
      */
     public function removeAction(Request $request,Job $job)

--- a/src/AppBundle/Controller/MailController.php
+++ b/src/AppBundle/Controller/MailController.php
@@ -9,7 +9,6 @@ use AppBundle\Form\AutocompleteBeneficiaryCollectionType;
 use AppBundle\Form\MarkdownEditorType;
 use AppBundle\Service\SearchUserFormHelper;
 use Michelf\Markdown;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
@@ -32,8 +31,7 @@ class MailController extends Controller
     /**
      * Edit a message
      *
-     * @Route("/to/{id}", name="mail_edit_one_beneficiary")
-     * @Method({"GET","POST"})
+     * @Route("/to/{id}", name="mail_edit_one_beneficiary", methods={"GET","POST"})
      */
     public function editActionOneBeneficiary(Request $request, Beneficiary $beneficiary)
     {
@@ -46,8 +44,7 @@ class MailController extends Controller
     }
 
     /**
-     * @Route("/to_bucket/{id}", name="mail_bucketshift")
-     * @Method({"GET","POST"})
+     * @Route("/to_bucket/{id}", name="mail_bucketshift", methods={"GET","POST"})
      */
     public function mailBucketShift(Request $request, Shift $shift)
     {
@@ -72,8 +69,7 @@ class MailController extends Controller
     /**
      * Edit a message
      *
-     * @Route("/", name="mail_edit")
-     * @Method({"GET","POST"})
+     * @Route("/", name="mail_edit", methods={"GET","POST"})
      */
     public function editAction(Request $request, SearchUserFormHelper $formHelper)
     {
@@ -104,8 +100,7 @@ class MailController extends Controller
     /**
      * Send a message
      *
-     * @Route("/send", name="mail_send")
-     * @Method({"POST"})
+     * @Route("/send", name="mail_send", methods={"POST"})
      */
     public function sendAction(Request $request, \Swift_Mailer $mailer)
     {

--- a/src/AppBundle/Controller/MembershipController.php
+++ b/src/AppBundle/Controller/MembershipController.php
@@ -40,8 +40,7 @@ use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Validator\Constraints\Email as EmailConstraint;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpFoundation\Request;
 use DateTime;
 use Symfony\Component\Validator\Constraints\NotBlank;
@@ -73,8 +72,7 @@ class MembershipController extends Controller
      * Finds and displays a membership entity.
      * Why the '/show' in the route? Because routing conflict if not
      *
-     * @Route("/{member_number}/show", name="member_show")
-     * @Method("GET")
+     * @Route("/{member_number}/show", name="member_show", methods={"GET"})
      * @param Membership $member
      * @return \Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\Response
      */
@@ -211,8 +209,7 @@ class MembershipController extends Controller
     /**
      * Add a new registration.
      *
-     * @Route("/newRegistration/{member_number}/", name="member_new_registration")
-     * @Method({"GET", "POST"})
+     * @Route("/newRegistration/{member_number}/", name="member_new_registration", methods={"GET","POST"})
      * @param Request $request
      * @param Membership $member
      * @return \Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\Response
@@ -296,8 +293,7 @@ class MembershipController extends Controller
     /**
      * Add a beneficiary from admin to a member
      *
-     * @Route("/newBeneficiary/{member_number}/", name="member_new_beneficiary")
-     * @Method({"GET", "POST"})
+     * @Route("/newBeneficiary/{member_number}/", name="member_new_beneficiary", methods={"GET","POST"})
      * @param Request $request
      * @param Membership $member
      * @return \Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\Response
@@ -360,8 +356,7 @@ class MembershipController extends Controller
     /**
      * Displays a form to edit an existing member entity.
      *
-     * @Route("/edit", name="member_edit_firewall")
-     * @Method({"GET", "POST"})
+     * @Route("/edit", name="member_edit_firewall", methods={"GET","POST"})
      * @Security("has_role('ROLE_USER_VIEWER')")
      * @param Request $request
      * @return \Symfony\Component\HttpFoundation\RedirectResponse|Response
@@ -419,8 +414,7 @@ class MembershipController extends Controller
     }
 
     /**
-     * @Route("/{id}/set_email", name="set_email")
-     * @Method({"POST"})
+     * @Route("/{id}/set_email", name="set_email", methods={"POST"})
      * @param Beneficiary $beneficiary
      * @param Request $request
      * @return Response
@@ -505,8 +499,7 @@ class MembershipController extends Controller
     /**
      * Close member
      *
-     * @Route("/{id}/close", name="member_close")
-     * @Method({"POST"})
+     * @Route("/{id}/close", name="member_close", methods={"POST"})
      * @param Request $request
      * @param Membership $member
      * @return \Symfony\Component\HttpFoundation\RedirectResponse
@@ -538,8 +531,7 @@ class MembershipController extends Controller
     /**
      * Open member
      *
-     * @Route("/{id}/open", name="member_open")
-     * @Method({"POST"})
+     * @Route("/{id}/open", name="member_open", methods={"POST"})
      * @param Request $request
      * @param Membership $member
      * @return \Symfony\Component\HttpFoundation\RedirectResponse
@@ -568,8 +560,7 @@ class MembershipController extends Controller
     /**
      * freeze member
      *
-     * @Route("/{id}/freeze", name="member_freeze")
-     * @Method({"POST"})
+     * @Route("/{id}/freeze", name="member_freeze", methods={"POST"})
      * @param Request $request
      * @param Membership $member
      * @return \Symfony\Component\HttpFoundation\RedirectResponse
@@ -599,8 +590,7 @@ class MembershipController extends Controller
     /**
      * Unfreeze member
      *
-     * @Route("/{id}/unfreeze", name="member_unfreeze")
-     * @Method({"POST"})
+     * @Route("/{id}/unfreeze", name="member_unfreeze", methods={"POST"})
      * @param Request $request
      * @param Membership $member
      * @return \Symfony\Component\HttpFoundation\RedirectResponse
@@ -630,8 +620,7 @@ class MembershipController extends Controller
     /**
      * Ask freeze status change for user
      *
-     * @Route("/{id}/freeze_change", name="member_freeze_change")
-     * @Method({"POST"})
+     * @Route("/{id}/freeze_change", name="member_freeze_change", methods={"POST"})
      * @param Request $request
      * @param Membership $member
      * @return \Symfony\Component\HttpFoundation\RedirectResponse
@@ -676,8 +665,7 @@ class MembershipController extends Controller
     /**
      * Delete member
      *
-     * @Route("/{id}", name="member_delete")
-     * @Method("DELETE")
+     * @Route("/{id}", name="member_delete", methods={"DELETE"})
      * @Security("has_role('ROLE_SUPER_ADMIN')")
      * @param Request $request
      * @param Membership $member
@@ -704,8 +692,7 @@ class MembershipController extends Controller
     /**
      * Creates a new membership entity
      *
-     * @Route("/new", name="member_new")
-     * @Method({"GET", "POST"})
+     * @Route("/new", name="member_new", methods={"GET","POST"})
      */
     public function newAction(Request $request)
     {
@@ -830,8 +817,7 @@ class MembershipController extends Controller
     /**
      * Add a new beneficiary from an anonymous one to an existing membership.
      *
-     * @Route("/add_beneficiary", name="member_add_beneficiary")
-     * @Method({"GET", "POST"})
+     * @Route("/add_beneficiary", name="member_add_beneficiary", methods={"GET","POST"})
      * @param Request $request
      * @return Response
      * @throws
@@ -926,8 +912,7 @@ class MembershipController extends Controller
     /**
      * Join two members
      *
-     * @Route("/join", name="member_join")
-     * @Method({"GET","POST"})
+     * @Route("/join", name="member_join", methods={"GET","POST"})
      * @Security("has_role('ROLE_ADMIN')")
      */
     public function joinAction(Request $request)
@@ -977,8 +962,7 @@ class MembershipController extends Controller
     /**
      * Office tools: membership creation & management
      *
-     * @Route("/office_tools", name="user_office_tools")
-     * @Method({"GET","POST"})
+     * @Route("/office_tools", name="user_office_tools", methods={"GET","POST"})
      * @Security("has_role('ROLE_USER_VIEWER')")
      */
     public function officeToolsAction(Request $request)
@@ -1034,8 +1018,7 @@ class MembershipController extends Controller
     /**
      * Export all emails of members (including beneficiary)
      *
-     * @Route("/emails_csv", name="admin_emails_csv")
-     * @Method({"GET"})
+     * @Route("/emails_csv", name="admin_emails_csv", methods={"GET"})
      * @Security("has_role('ROLE_SUPER_ADMIN')")
      */
     public function exportEmails(Request $request)

--- a/src/AppBundle/Controller/MembershipShiftExemptionController.php
+++ b/src/AppBundle/Controller/MembershipShiftExemptionController.php
@@ -5,8 +5,7 @@ namespace AppBundle\Controller;
 use AppBundle\Entity\Beneficiary;
 use AppBundle\Entity\MembershipShiftExemption;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
@@ -22,9 +21,8 @@ class MembershipShiftExemptionController extends Controller
     /**
      * Lists all membershipShiftExemption entities.
      *
-     * @Route("/", name="admin_membershipshiftexemption_index")
+     * @Route("/", name="admin_membershipshiftexemption_index", methods={"GET"})
      * @Security("has_role('ROLE_USER_MANAGER')")
-     * @Method("GET")
      */
     public function indexAction(Request $request)
     {
@@ -52,9 +50,8 @@ class MembershipShiftExemptionController extends Controller
     /**
      * Creates a new membershipShiftExemption entity.
      *
-     * @Route("/new", name="admin_membershipshiftexemption_new")
+     * @Route("/new", name="admin_membershipshiftexemption_new", methods={"GET","POST"})
      * @Security("has_role('ROLE_USER_MANAGER')")
-     * @Method({"GET", "POST"})
      */
     public function newAction(Request $request)
     {
@@ -91,9 +88,8 @@ class MembershipShiftExemptionController extends Controller
     /**
      * Displays a form to edit an existing membershipShiftExemption entity.
      *
-     * @Route("/{id}/edit", name="admin_membershipshiftexemption_edit")
+     * @Route("/{id}/edit", name="admin_membershipshiftexemption_edit", methods={"GET","POST"})
      * @Security("has_role('ROLE_USER_MANAGER')")
-     * @Method({"GET", "POST"})
      */
     public function editAction(Request $request, MembershipShiftExemption $membershipShiftExemption)
     {
@@ -123,9 +119,8 @@ class MembershipShiftExemptionController extends Controller
     /**
      * Deletes a membershipShiftExemption entity.
      *
-     * @Route("/{id}", name="admin_membershipshiftexemption_delete")
+     * @Route("/{id}", name="admin_membershipshiftexemption_delete", methods={"DELETE"})
      * @Security("has_role('ROLE_USER_MANAGER')")
-     * @Method("DELETE")
      */
     public function deleteAction(Request $request, MembershipShiftExemption $membershipShiftExemption)
     {

--- a/src/AppBundle/Controller/NoteController.php
+++ b/src/AppBundle/Controller/NoteController.php
@@ -17,8 +17,7 @@ use Symfony\Component\Form\Form;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Validator\Constraints\Email as EmailConstraint;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpFoundation\Request;
 use DateTime;
 use Symfony\Component\Validator\Constraints\NotBlank;
@@ -45,8 +44,7 @@ class NoteController extends Controller
     /**
      * reply to a note
      *
-     * @Route("/note/{id}/reply", name="note_reply")
-     * @Method({"POST"})
+     * @Route("/note/{id}/reply", name="note_reply", methods={"POST"})
      * @Security("has_role('ROLE_USER_VIEWER')")
      */
     public function noteReplyAction(Request $request, Note $note)
@@ -76,8 +74,7 @@ class NoteController extends Controller
     /**
      * edit a note
      *
-     * @Route("/note/{id}/edit", name="note_edit")
-     * @Method({"GET","POST"})
+     * @Route("/note/{id}/edit", name="note_edit", methods={"GET","POST"})
      */
     public function noteEditAction(Request $request, Note $note)
     {
@@ -118,8 +115,7 @@ class NoteController extends Controller
     /**
      * Delete a note.
      *
-     * @Route("/note/{id}", name="note_delete")
-     * @Method("DELETE")
+     * @Route("/note/{id}", name="note_delete", methods={"DELETE"})
      */
     public function deleteNoteAction(Request $request, Note $note)
     {

--- a/src/AppBundle/Controller/PeriodController.php
+++ b/src/AppBundle/Controller/PeriodController.php
@@ -13,7 +13,7 @@ use AppBundle\Form\PeriodType;
 use AppBundle\Repository\JobRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
@@ -23,7 +23,7 @@ use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\Request;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
+
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
@@ -139,9 +139,8 @@ class PeriodController extends Controller
     }
 
     /**
-     * @Route("/new", name="period_new")
+     * @Route("/new", name="period_new", methods={"GET","POST"})
      * @Security("has_role('ROLE_SHIFT_MANAGER')")
-     * @Method({"GET", "POST"})
      */
     public function newAction(Request $request)
     {
@@ -178,9 +177,8 @@ class PeriodController extends Controller
     }
 
     /**
-     * @Route("/{id}/edit", name="period_edit")
+     * @Route("/{id}/edit", name="period_edit", methods={"GET","POST"})
      * @Security("has_role('ROLE_SHIFT_MANAGER')")
-     * @Method({"GET", "POST"})
      */
     public function editAction(Request $request, Period $period)
     {
@@ -243,9 +241,8 @@ class PeriodController extends Controller
     }
 
     /**
-     * @Route("/{id}/position/add", name="add_position_to_period")
+     * @Route("/{id}/position/add", name="add_position_to_period", methods={"POST"})
      * @Security("has_role('ROLE_SHIFT_MANAGER')")
-     * @Method({"POST"})
      */
     public function addPositionToPeriodAction(Request $request, Period $period)
     {
@@ -277,9 +274,8 @@ class PeriodController extends Controller
     }
 
     /**
-     * @Route("/{id}/position/{position}", name="remove_position_from_period")
+     * @Route("/{id}/position/{position}", name="remove_position_from_period", methods={"DELETE"})
      * @Security("has_role('ROLE_SHIFT_MANAGER')")
-     * @Method({"DELETE"})
      */
     public function removePositionToPeriodAction(Request $request, Period $period, PeriodPosition $position)
     {
@@ -302,9 +298,8 @@ class PeriodController extends Controller
     /**
      * Book a period.
      *
-     * @Route("/{id}/position/{position}/book", name="book_position_from_period")
+     * @Route("/{id}/position/{position}/book", name="book_position_from_period", methods={"POST"})
      * @Security("has_role('ROLE_SHIFT_MANAGER')")
-     * @Method("POST")
      */
     public function bookPositionToPeriodAction(Request $request, Period $period, PeriodPosition $position): Response
     {
@@ -347,9 +342,8 @@ class PeriodController extends Controller
     /**
      * free a position.
      *
-     * @Route("/{id}/position/{position}/free", name="free_position_from_period")
+     * @Route("/{id}/position/{position}/free", name="free_position_from_period", methods={"POST"})
      * @Security("has_role('ROLE_SHIFT_MANAGER')")
-     * @Method("POST")
      */
     public function freePositionToPeriodAction(Request $request, Period $period, PeriodPosition $position)
     {
@@ -367,9 +361,8 @@ class PeriodController extends Controller
     /**
      * Deletes a period entity.
      *
-     * @Route("/{id}", name="period_delete")
+     * @Route("/{id}", name="period_delete", methods={"DELETE"})
      * @Security("has_role('ROLE_ADMIN')")
-     * @Method("DELETE")
      */
     public function deleteAction(Request $request, Period $period)
     {
@@ -393,9 +386,8 @@ class PeriodController extends Controller
     }
 
     /**
-     * @Route("/copyPeriod/", name="period_copy")
+     * @Route("/copyPeriod/", name="period_copy", methods={"GET","POST"})
      * @Security("has_role('ROLE_ADMIN')")
-     * @Method({"GET","POST"})
      */
     public function periodCopyAction(Request $request){
         $days = array(
@@ -446,9 +438,8 @@ class PeriodController extends Controller
     }
 
     /**
-     * @Route("/generateShifts/", name="shifts_generation")
+     * @Route("/generateShifts/", name="shifts_generation", methods={"GET","POST"})
      * @Security("has_role('ROLE_ADMIN')")
-     * @Method({"GET","POST"})
      */
     public function generateShiftsForDateAction(Request $request, KernelInterface $kernel){
         $form = $this->createFormBuilder()

--- a/src/AppBundle/Controller/ProcessUpdateController.php
+++ b/src/AppBundle/Controller/ProcessUpdateController.php
@@ -11,13 +11,13 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Session;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
+use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\Validator\Constraints\Date;
 
 /**
- * Process update controller.
+ * Process update controller. Correspond to the pages
+ * "Gérer les nouveautés" -> Liste des procédures / nouveautés
  *
  * @Route("process/updates")
  */
@@ -27,8 +27,7 @@ class ProcessUpdateController extends Controller
     /**
      * Lists all process updates.
      *
-     * @Route("/", name="process_update_list")
-     * @Method("GET")
+     * @Route("/", name="process_update_list", methods={"GET"})
      * @Security("has_role('ROLE_USER')")
      */
     public function listAction(Request $request)
@@ -64,8 +63,7 @@ class ProcessUpdateController extends Controller
     }
 
     /**
-     * @Route("/count_unread", name="process_update_count_unread")
-     * @Method("POST")
+     * @Route("/count_unread", name="process_update_count_unread", methods={"POST"})
      * @param Request $request
      * @return Response | JsonResponse
      * @throws
@@ -87,8 +85,7 @@ class ProcessUpdateController extends Controller
     /**
      * Create a process update
      *
-     * @Route("/new", name="process_update_new")
-     * @Method({"GET","POST"})
+     * @Route("/new", name="process_update_new", methods={"GET","POST"})
      * @Security("has_role('ROLE_PROCESS_MANAGER')")
      */
     public function newAction(Request $request)
@@ -119,8 +116,7 @@ class ProcessUpdateController extends Controller
     /**
      * Edit a process update
      *
-     * @Route("/{id}/edit", name="process_update_edit")
-     * @Method({"GET","POST"})
+     * @Route("/{id}/edit", name="process_update_edit", methods={"GET","POST"})
      * @Security("has_role('ROLE_PROCESS_MANAGER')")
      */
     public function editAction(Request $request, ProcessUpdate $processUpdate)
@@ -163,8 +159,7 @@ class ProcessUpdateController extends Controller
     /**
      * Delete a process update.
      *
-     * @Route("/{id}", name="process_update_delete")
-     * @Method("DELETE")
+     * @Route("/{id}", name="process_update_delete", methods={"DELETE"})
      */
     public function deleteAction(Request $request, ProcessUpdate $processUpdate)
     {

--- a/src/AppBundle/Controller/RegistrationsController.php
+++ b/src/AppBundle/Controller/RegistrationsController.php
@@ -35,8 +35,7 @@ use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
 use Symfony\Component\Validator\Constraints\Email as EmailConstraint;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpFoundation\Request;
 use DateTime;
 use Symfony\Component\Validator\Constraints\NotBlank;
@@ -53,8 +52,7 @@ class RegistrationsController extends Controller
     /**
      * Registrations list
      *
-     * @Route("/", name="registrations")
-     * @Method({"POST","GET"})
+     * @Route("/", name="registrations", methods={"GET","POST"})
      * @Security("has_role('ROLE_FINANCE_MANAGER')")
      */
     public function registrationsAction(Request $request)
@@ -192,8 +190,7 @@ WHERE date >= :from ".(($to) ? "AND date <= :to" : "").";");
     /**
      * edit registration
      *
-     * @Route("/{id}/edit", name="registration_edit")
-     * @Method({"GET","POST"})
+     * @Route("/{id}/edit", name="registration_edit", methods={"GET","POST"})
      * @Security("has_role('ROLE_FINANCE_MANAGER')")
      */
     public function editRegistrationAction(Request $request, Registration $registration)
@@ -220,8 +217,7 @@ WHERE date >= :from ".(($to) ? "AND date <= :to" : "").";");
     /**
      * remove registration
      *
-     * @Route("/{id}/remove", name="registration_remove")
-     * @Method({"DELETE"})
+     * @Route("/{id}/remove", name="registration_remove", methods={"DELETE"})
      * @Security("has_role('ROLE_SUPER_ADMIN')")
      */
     public function removeRegistrationAction(Request $request, Registration $registration)

--- a/src/AppBundle/Controller/ServiceController.php
+++ b/src/AppBundle/Controller/ServiceController.php
@@ -7,8 +7,7 @@ use AppBundle\Entity\Service;
 use AppBundle\Entity\Task;
 use AppBundle\Form\ServiceType;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Form\Form;
@@ -28,8 +27,7 @@ class ServiceController extends Controller
     /**
      * Lists all services.
      *
-     * @Route("/", name="admin_services")
-     * @Method("GET")
+     * @Route("/", name="admin_services", methods={"GET"})
      * @Security("has_role('ROLE_SUPER_ADMIN')")
      */
     public function listAction(Request $request)
@@ -45,8 +43,7 @@ class ServiceController extends Controller
     /**
      * Lists all services.
      *
-     * @Route("/navlist", name="nav_list_services")
-     * @Method("GET")
+     * @Route("/navlist", name="nav_list_services", methods={"GET"})
      * @Security("has_role('ROLE_USER')")
      */
     public function navlistAction()
@@ -61,8 +58,7 @@ class ServiceController extends Controller
     /**
      * add new services.
      *
-     * @Route("/new", name="service_new")
-     * @Method({"GET","POST"})
+     * @Route("/new", name="service_new", methods={"GET","POST"})
      * @Security("has_role('ROLE_SUPER_ADMIN')")
      */
     public function newAction(Request $request)
@@ -99,8 +95,7 @@ class ServiceController extends Controller
     /**
      * edit service.
      *
-     * @Route("/edit/{id}", name="service_edit")
-     * @Method({"GET","POST"})
+     * @Route("/edit/{id}", name="service_edit", methods={"GET","POST"})
      * @Security("has_role('ROLE_SUPER_ADMIN')")
      */
     public function editAction(Request $request,Service $service)
@@ -138,8 +133,7 @@ class ServiceController extends Controller
     /**
      * delete service.
      *
-     * @Route("/{id}", name="service_remove")
-     * @Method({"DELETE"})
+     * @Route("/{id}", name="service_remove", methods={"DELETE"})
      * @Security("has_role('ROLE_SUPER_ADMIN')")
      */
     public function removeAction(Request $request,Service $service)

--- a/src/AppBundle/Controller/ShiftController.php
+++ b/src/AppBundle/Controller/ShiftController.php
@@ -24,9 +24,9 @@ use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Form\Extension\Core\Type\RadioType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
+
 
 /**
  * @Route("shift")
@@ -44,9 +44,8 @@ class ShiftController extends Controller
     }
 
     /**
-     * @Route("/new", name="shift_new")
+     * @Route("/new", name="shift_new", methods={"GET","POST"})
      * @Security("has_role('ROLE_SHIFT_MANAGER')")
-     * @Method({"GET", "POST"})
      */
     public function newAction(Request $request)
     {
@@ -114,8 +113,7 @@ class ShiftController extends Controller
     /**
      * Book a shift.
      *
-     * @Route("/{id}/book", name="shift_book")
-     * @Method("POST")
+     * @Route("/{id}/book", name="shift_book", methods={"POST"})
      */
     public function bookShiftAction(Request $request, Shift $shift): Response
     {
@@ -171,9 +169,8 @@ class ShiftController extends Controller
     /**
      * Book a shift admin.
      *
-     * @Route("/{id}/book_admin", name="shift_book_admin")
+     * @Route("/{id}/book_admin", name="shift_book_admin", methods={"GET","POST"})
      * @Security("has_role('ROLE_SHIFT_MANAGER')")
-     * @Method("POST")
      */
     public function bookShiftAdminAction(Request $request, Shift $shift)
     {
@@ -252,8 +249,7 @@ class ShiftController extends Controller
     /**
      * free a shift.
      *
-     * @Route("/{id}/free", name="shift_free")
-     * @Method("POST")
+     * @Route("/{id}/free", name="shift_free", methods={"POST"})
      */
     public function freeShiftAction(Request $request, Shift $shift)
     {
@@ -312,8 +308,7 @@ class ShiftController extends Controller
     /**
      * validate / invalidate a shift.
      *
-     * @Route("/{id}/validate", name="shift_validate")
-     * @Method("POST")
+     * @Route("/{id}/validate", name="shift_validate", methods={"POST"})
      */
     public function validateShiftAction(Request $request, Shift $shift)
     {
@@ -381,8 +376,7 @@ class ShiftController extends Controller
     /**
      * Dismiss a booked shift
      *
-     * @Route("/{id}/dismiss", name="shift_dismiss")
-     * @Method("POST")
+     * @Route("/{id}/dismiss", name="shift_dismiss", methods={"POST"})
      */
     public function dismissShiftAction(Request $request, Shift $shift)
     {
@@ -417,8 +411,7 @@ class ShiftController extends Controller
     /**
      * Undismiss a shift
      *
-     * @Route("/undismiss", name="shift_undismiss")
-     * @Method("POST")
+     * @Route("/undismiss", name="shift_undismiss", methods={"POST"})
      */
     public function undismissShiftAction(Request $request)
     {
@@ -457,8 +450,7 @@ class ShiftController extends Controller
     /**
      * Accept a reserved shift
      *
-     * @Route("/{id}/accept", name="shift_accept_reserved")
-     * @Method("GET")
+     * @Route("/{id}/accept", name="shift_accept_reserved", methods={"GET"})
      */
     public function acceptReservedShiftAction(Request $request, Shift $shift)
     {
@@ -499,8 +491,7 @@ class ShiftController extends Controller
     /**
      * Reject a reserved shift
      *
-     * @Route("/{id}/reject", name="shift_reject_reserved")
-     * @Method("GET")
+     * @Route("/{id}/reject", name="shift_reject_reserved", methods={"GET"})
      */
     public function rejectReservedShiftAction(Request $request, Shift $shift)
     {
@@ -533,9 +524,8 @@ class ShiftController extends Controller
     /**
      * delete a shift.
      *
-     * @Route("/{id}", name="shift_delete")
+     * @Route("/{id}", name="shift_delete", methods={"DELETE"})
      * @Security("has_role('ROLE_SHIFT_MANAGER')")
-     * @Method("DELETE")
      */
     public function removeShiftAction(Request $request, Shift $shift)
     {

--- a/src/AppBundle/Controller/ShiftExemptionController.php
+++ b/src/AppBundle/Controller/ShiftExemptionController.php
@@ -4,8 +4,8 @@ namespace AppBundle\Controller;
 
 use AppBundle\Entity\ShiftExemption;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\HttpFoundation\Request;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Session\Session;
 
@@ -19,9 +19,8 @@ class ShiftExemptionController extends Controller
     /**
      * Lists all shiftExemption entities.
      *
-     * @Route("/", name="admin_shiftexemption_index")
+     * @Route("/", name="admin_shiftexemption_index", methods={"GET"})
      * @Security("has_role('ROLE_ADMIN')")
-     * @Method("GET")
      */
     public function indexAction()
     {
@@ -37,9 +36,8 @@ class ShiftExemptionController extends Controller
     /**
      * Creates a new shiftExemption entity.
      *
-     * @Route("/new", name="admin_shiftexemption_new")
+     * @Route("/new", name="admin_shiftexemption_new", methods={"GET","POST"})
      * @Security("has_role('ROLE_ADMIN')")
-     * @Method({"GET", "POST"})
      */
     public function newAction(Request $request)
     {
@@ -66,9 +64,8 @@ class ShiftExemptionController extends Controller
     /**
      * Displays a form to edit an existing shiftExemption entity.
      *
-     * @Route("/{id}/edit", name="admin_shiftexemption_edit")
+     * @Route("/{id}/edit", name="admin_shiftexemption_edit", methods={"GET","POST"})
      * @Security("has_role('ROLE_ADMIN')")
-     * @Method({"GET", "POST"})
      */
     public function editAction(Request $request, ShiftExemption $shiftExemption)
     {
@@ -94,9 +91,8 @@ class ShiftExemptionController extends Controller
     /**
      * Deletes a shiftExemption entity.
      *
-     * @Route("/{id}", name="admin_shiftexemption_delete")
+     * @Route("/{id}", name="admin_shiftexemption_delete", methods={"DELETE"})
      * @Security("has_role('ROLE_SUPER_ADMIN')")
-     * @Method("DELETE")
      */
     public function deleteAction(Request $request, ShiftExemption $shiftExemption)
     {

--- a/src/AppBundle/Controller/SwipeCardController.php
+++ b/src/AppBundle/Controller/SwipeCardController.php
@@ -16,7 +16,6 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Routing\Annotation\Route;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
@@ -37,8 +36,7 @@ class SwipeCardController extends Controller
      * @param String $code
      * @param Request $request
      * @return Response
-     * @Route("/in/{code}", name="swipe_in")
-     * @Method({"GET"})
+     * @Route("/in/{code}", name="swipe_in", methods={"GET"})
      */
     public function swipeInAction(Request $request, $code){
         $session = new Session();
@@ -70,10 +68,9 @@ class SwipeCardController extends Controller
      * @param Request $request
      * @param Beneficiary $beneficiary
      * @return Response
-     * @Route("/active/", name="active_swipe")
-     * @Route("/active/{id}", name="active_swipe_for_beneficiary")
+     * @Route("/active/", name="active_swipe", methods={"GET","POST"})
+     * @Route("/active/{id}", name="active_swipe_for_beneficiary", methods={"POST"})
      * @Security("has_role('ROLE_USER')")
-     * @Method({"POST"})
      */
     public function activeSwipeCardAction(Request $request,Beneficiary $beneficiary = null)
     {
@@ -136,9 +133,8 @@ class SwipeCardController extends Controller
      * @param Beneficiary $beneficiary
      * @return Response
      * @Route("/enable/", name="enable_swipe")
-     * @Route("/enable/{id}", name="enable_swipe_for_beneficiary")
+     * @Route("/enable/{id}", name="enable_swipe_for_beneficiary", methods={"POST"})
      * @Security("has_role('ROLE_USER')")
-     * @Method({"POST"})
      */
     public function enableSwipeCardAction(Request $request,Beneficiary $beneficiary = null){
         $session = new Session();
@@ -187,9 +183,8 @@ class SwipeCardController extends Controller
      * @param Beneficiary $beneficiary
      * @return Response
      * @Route("/disable/", name="disable_swipe")
-     * @Route("/disable/{id}", name="disable_swipe_for_beneficiary")
+     * @Route("/disable/{id}", name="disable_swipe_for_beneficiary", methods={"POST"})
      * @Security("has_role('ROLE_USER')")
-     * @Method({"POST"})
      */
     public function disableSwipeCardAction(Request $request,Beneficiary $beneficiary = null){
         $session = new Session();
@@ -229,9 +224,8 @@ class SwipeCardController extends Controller
      *
      * @param Request $request
      * @return Response
-     * @Route("/delete/", name="delete_swipe")
+     * @Route("/delete/", name="delete_swipe", methods={"POST"})
      * @Security("has_role('ROLE_ADMIN')")
-     * @Method({"POST"})
      */
     public function deleteAction(Request $request){
         $session = new Session();
@@ -263,9 +257,8 @@ class SwipeCardController extends Controller
      *
      * @param SwipeCard $card
      * @return Response A Response instance
-     * @Route("/{id}/show", name="swipe_show")
+     * @Route("/{id}/show", name="swipe_show", methods={"GET"})
      * @Security("has_role('ROLE_USER_MANAGER')")
-     * @Method({"GET"})
      */
     public function showAction(SwipeCard $card){
         return $this->render('user/swipe_card.html.twig', [
@@ -291,8 +284,7 @@ class SwipeCardController extends Controller
      *
      * @param String $code
      * @return Response A Response instance
-     * @Route("/{code}/qr.png", name="swipe_qr")
-     * @Method({"GET"})
+     * @Route("/{code}/qr.png", name="swipe_qr", methods={"GET"})
      */
     public function qrAction(Request $request, $code){
         $code = urldecode($code);
@@ -320,8 +312,7 @@ class SwipeCardController extends Controller
      *
      * @param String $code
      * @return Response A Response instance
-     * @Route("/{code}/br.png", name="swipe_br")
-     * @Method({"GET"})
+     * @Route("/{code}/br.png", name="swipe_br", methods={"GET"})
      */
     public function brAction(Request $request, $code){
         $code = urldecode($code);

--- a/src/AppBundle/Controller/TaskController.php
+++ b/src/AppBundle/Controller/TaskController.php
@@ -6,8 +6,7 @@ namespace AppBundle\Controller;
 use AppBundle\Entity\Task;
 use AppBundle\Form\TaskType;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Form\Form;
 use Symfony\Component\HttpFoundation\Request;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
@@ -25,8 +24,7 @@ class TaskController extends Controller
     /**
      * Lists all tasks.
      *
-     * @Route("/", name="tasks_list")
-     * @Method("GET")
+     * @Route("/", name="tasks_list", methods={"GET"})
      */
     public function listAction(Request $request)
     {
@@ -43,8 +41,7 @@ class TaskController extends Controller
     /**
      * add new task.
      *
-     * @Route("/new", name="task_new")
-     * @Method({"GET","POST"})
+     * @Route("/new", name="task_new", methods={"GET","POST"})
      */
     public function newAction(Request $request)
     {
@@ -89,8 +86,7 @@ class TaskController extends Controller
     /**
      * add new task.
      *
-     * @Route("/edit/{id}", name="task_edit")
-     * @Method({"GET","POST"})
+     * @Route("/edit/{id}", name="task_edit", methods={"GET","POST"})
      */
     public function editAction(Request $request,Task $task)
     {
@@ -140,8 +136,7 @@ class TaskController extends Controller
     /**
      * task delete
      *
-     * @Route("/{id}", name="task_delete")
-     * @Method({"DELETE"})
+     * @Route("/{id}", name="task_delete", methods={"DELETE"})
      */
     public function removeAction(Request $request,Task $task)
     {

--- a/src/AppBundle/Controller/TimeLogController.php
+++ b/src/AppBundle/Controller/TimeLogController.php
@@ -9,8 +9,7 @@ use AppBundle\Form\TimeLogType;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Request;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
+use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 
 /**
@@ -24,8 +23,7 @@ class TimeLogController extends Controller
     /**
      * Delete time log
      *
-     * @Route("/{id}/timelog_delete/{timelog_id}", name="member_timelog_delete")
-     * @Method({"GET"})
+     * @Route("/{id}/timelog_delete/{timelog_id}", name="member_timelog_delete", methods={"GET"})
      * @Security("has_role('ROLE_SUPER_ADMIN')")
      * @param Membership $member
      * @param $timelog_id
@@ -50,8 +48,7 @@ class TimeLogController extends Controller
     /**
      * Create a new log
      *
-     * @Route("/{id}/new", name="time_log_new")
-     * @Method({"GET", "POST"})
+     * @Route("/{id}/new", name="time_log_new", methods={"GET","POST"})
      * @Security("has_role('ROLE_SHIFT_MANAGER')")
      * @param Membership $member
      */

--- a/src/AppBundle/Controller/UserController.php
+++ b/src/AppBundle/Controller/UserController.php
@@ -28,8 +28,7 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Validator\Constraints\Email as EmailConstraint;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpFoundation\Request;
 use DateTime;
 use Symfony\Component\Validator\Constraints\NotBlank;
@@ -56,8 +55,7 @@ class UserController extends Controller
     /**
      * install admin
      *
-     * @Route("/install_admin", name="user_install_admin")
-     * @Method({"GET","POST"})
+     * @Route("/install_admin", name="user_install_admin", methods={"GET","POST"})
      */
     public function installAdminAction(Request $request)
     {
@@ -107,8 +105,7 @@ class UserController extends Controller
     /**
      * change_password
      *
-     * @Route("/change_password", name="user_change_password")
-     * @Method({"GET", "POST"})
+     * @Route("/change_password", name="user_change_password", methods={"GET","POST"})
      * @param Request $request
      * @return Response
      */
@@ -153,8 +150,7 @@ class UserController extends Controller
     /**
      * Creates a new user entity
      *
-     * @Route("/quick_new", name="user_quick_new")
-     * @Method({"GET", "POST"})
+     * @Route("/quick_new", name="user_quick_new", methods={"GET","POST"})
      * @Security("has_role('ROLE_USER_VIEWER')")
      */
     public function quickNewAction(Request $request, \Swift_Mailer $mailer)
@@ -190,8 +186,7 @@ class UserController extends Controller
     /**
      * remove role of user
      *
-     * @Route("/{id}/removeRole/{role}", name="user_remove_role")
-     * @Method({"GET"})
+     * @Route("/{id}/removeRole/{role}", name="user_remove_role", methods={"GET","POST"})
      * @Security("has_role('ROLE_ADMIN')")
      * @param User $user
      * @param $role
@@ -225,8 +220,7 @@ class UserController extends Controller
     /**
      * add role of user
      *
-     * @Route("/{id}/addRole/{role}", name="user_add_role")
-     * @Method({"GET"})
+     * @Route("/{id}/addRole/{role}", name="user_add_role", methods={"GET"})
      * @Security("has_role('ROLE_ADMIN')")
      * @param User $user
      * @param $role
@@ -260,8 +254,7 @@ class UserController extends Controller
     /**
      * self_register
      *
-     * @Route("/self_register", name="user_self_register")
-     * @Method({"GET"})
+     * @Route("/self_register", name="user_self_register", methods={"GET"})
      * @Security("has_role('ROLE_USER')")
      */
     public function selfRegistrationAction()
@@ -278,8 +271,7 @@ class UserController extends Controller
     /**
      * remove client from user
      *
-     * @Route("/{username}/remove_client/{client_id}", name="user_client_remove")
-     * @Method({"GET", "POST"})
+     * @Route("/{username}/remove_client/{client_id}", name="user_client_remove", methods={"GET","POST"})
      */
     public function removeClientUserAction(User $user, $client_id)
     {
@@ -313,8 +305,7 @@ class UserController extends Controller
     /**
      * Deletes a user entity
      *
-     * @Route("/delete/{id}", name="user_delete")
-     * @Method("DELETE")
+     * @Route("/delete/{id}", name="user_delete", methods={"DELETE"})
      * @Security("has_role('ROLE_SUPER_ADMIN')")
      * @param Request $request
      * @param User $user
@@ -340,8 +331,7 @@ class UserController extends Controller
     /**
      * List all unconfirmed users
      *
-     * @Route("/pre_users", name="pre_user_index")
-     * @Method({"GET"})
+     * @Route("/pre_users", name="pre_user_index", methods={"GET"})
      * @Security("has_role('ROLE_USER_VIEWER')")
      */
     public function preUsersAction()
@@ -360,8 +350,7 @@ class UserController extends Controller
     /**
      * Recall unconfirmed user
      *
-     * @Route("/pre_users/{id}/recall", name="pre_user_recall")
-     * @Method({"GET"})
+     * @Route("/pre_users/{id}/recall", name="pre_user_recall", methods={"GET"})
      * @Security("has_role('ROLE_USER_VIEWER')")
      */
     public function quickNewRecallAction(Request $request, AnonymousBeneficiary $anonymousBeneficiary)
@@ -385,8 +374,7 @@ class UserController extends Controller
     /**
      * Delete unconfirmed user
      * 
-     * @Route("/pre_users/{id}/delete", name="pre_user_delete")
-     * @Method({"GET"})
+     * @Route("/pre_users/{id}/delete", name="pre_user_delete", methods={"GET"})
      * @Security("has_role('ROLE_USER_MANAGER')")
      */
     public function preUsersDeleteAction(AnonymousBeneficiary $anonymousBeneficiary, SessionInterface $session)


### PR DESCRIPTION
Les annotations de routage de **SensioFrameworkExtraBundle** sont obsolètes depuis la version 5.2 car elles sont maintenant une fonctionnalité incluse dans Symfony. Don en vu d'une éventuelle migration vers Symfony 4, il faut, entre autre, enlever tous les utilisations obsolètes de Symfony 3 dont:

```
``User Deprecated: The "Sensio\Bundle\FrameworkExtraBundle\Configuration\Route" annotation is deprecated since version 5.2. Use "Symfony\Component\Routing\Annotation\Route" instead.``
```

donc il faut changer tous les :

```PHP
use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;

class UserController
    {
    /**
     * @Route("/route")
     * @Method("GET")
     */
     [...]
````
par :
```PHP
use Symfony\Component\Routing\Annotation\Route;

class UserController
    {
    /**
     * @Route(path="/users", methods={"GET"})
     */
     [...]
```

Il y a aussi un correction pour https://github.com/elefan-grenoble/gestion-compte/issues/681, puisque j'ai checké toutes les routes :-)


---
[source 1](https://stackoverflow.com/questions/51171934/how-to-fix-symfony-3-4-route-and-method-deprecation)
[source 2](https://symfony.com/bundles/SensioFrameworkExtraBundle/current/annotations/routing.html)