### PR TITLE
Exemption : remplacer isValid par isCurrent pour clarifier

### DIFF
--- a/app/Resources/views/admin/membershipshiftexemption/index.html.twig
+++ b/app/Resources/views/admin/membershipshiftexemption/index.html.twig
@@ -70,7 +70,7 @@
             </a>
         </li>
         {% for i in range(1,max_page) %}
-        <li class="{% if(current_page==i) %}active{% else %}waves-effect{% endif %}"><a href="{{ path("admin_membershipshiftexemption_index",{'page':i}) }}">{{ i }}</a></li>
+            <li class="{% if(current_page==i) %}active{% else %}waves-effect{% endif %}"><a href="{{ path("admin_membershipshiftexemption_index",{'page':i}) }}">{{ i }}</a></li>
         {% endfor %}
         <li class="{% if(current_page==max_page) %}disabled{% else %}waves-effect{% endif %}">
             <a href="{% if(current_page==max_page) %}#!{% else %}{{ path("admin_membershipshiftexemption_index",{'page':current_page+1}) }}{% endif %}">

--- a/app/Resources/views/admin/user/list.html.twig
+++ b/app/Resources/views/admin/user/list.html.twig
@@ -215,7 +215,7 @@
         <tbody>
         {% for member in members %}
             {% if member.mainBeneficiary %}
-                <tr data-url="{{ path('member_show', { 'member_number': member.memberNumber }) }}" class="{% if member.withdrawn %}withdrawn{% elseif member.frozen %}frozen{% elseif member.isExemptedFromShifts() %}exempted{% endif %}">
+                <tr data-url="{{ path('member_show', { 'member_number': member.memberNumber }) }}" class="{% if member.withdrawn %}withdrawn{% elseif member.frozen %}frozen{% elseif member.isCurrentlyExemptedFromShifts() %}exempted{% endif %}">
                     <td class="hide-on-med-and-down">
                         {% if member.withdrawn %}
                             <i class="material-icons" title="Compte fermé">block</i>
@@ -223,7 +223,7 @@
                         {% if member.frozen %}
                             <i class="material-icons" title="Compte gelé">ac_unit</i>
                         {% endif %}
-                        {% if member.isExemptedFromShifts() %}
+                        {% if member.isCurrentlyExemptedFromShifts() %}
                             <i class="material-icons" title="Compte exempté">beach_access</i>
                         {% endif %}
                         {% if not member.mainBeneficiary.user.isEnabled %}

--- a/app/Resources/views/ambassador/phone/list.html.twig
+++ b/app/Resources/views/ambassador/phone/list.html.twig
@@ -122,7 +122,7 @@
         </thead>
         <tbody>
         {% for member in members %}
-            <tr class="{% if member.withdrawn %}withdrawn{% elseif member.frozen %}frozen{% elseif member.isExemptedFromShifts() %}exempted{% endif %}">
+            <tr class="{% if member.withdrawn %}withdrawn{% elseif member.frozen %}frozen{% elseif member.isCurrentlyExemptedFromShifts() %}exempted{% endif %}">
                 <td class="hide-on-med-and-down">
                     {% if member.withdrawn %}
                         <i class="material-icons" title="Compte fermé">block</i>
@@ -130,7 +130,7 @@
                     {% if member.frozen %}
                         <i class="material-icons" title="Compte gelé">ac_unit</i>
                     {% endif %}
-                    {% if member.isExemptedFromShifts() %}
+                    {% if member.isCurrentlyExemptedFromShifts() %}
                         <i class="material-icons" title="Compte exempté">beach_access</i>
                     {% endif %}
                     {% if not member.mainBeneficiary.user.isEnabled %}

--- a/app/Resources/views/booking/home_booked_shifts.html.twig
+++ b/app/Resources/views/booking/home_booked_shifts.html.twig
@@ -3,12 +3,14 @@
     {% set member = beneficiary.membership %}
 
     {% if member.isCurrentlyExemptedFromShifts() %}
-        {% set firstCurrentMembershipShiftExemption = member.getCurrentMembershipShiftExemptions().first %}
         <div class="card-panel teal white-text">
-            <i class="material-icons small left">beach_access</i>
+            <i class="material-icons left">beach_access</i>
             <strong>{% if member.beneficiaries | length %}Votre{% else %}Ton{% endif %} compte est exempté de créneau !</strong>
-            <br />
-            ({{ firstCurrentMembershipShiftExemption.shiftExemption }}) jusqu'au {{ firstCurrentMembershipShiftExemption.end | date_fr_full }}
+            <ul class="list-unstyled">
+                {% for currentMembershipShiftExemption in member.getCurrentMembershipShiftExemptions() %}
+                    <li><i>{{ currentMembershipShiftExemption.shiftExemption }}</i> du {{ currentMembershipShiftExemption.start | date_fr_full }} au {{ currentMembershipShiftExemption.end | date_fr_full }}</li>
+                {% endfor %}
+            </ul>
         </div>
     {% endif %}
 

--- a/app/Resources/views/booking/home_booked_shifts.html.twig
+++ b/app/Resources/views/booking/home_booked_shifts.html.twig
@@ -2,13 +2,13 @@
     {% set beneficiary = app.user.beneficiary %}
     {% set member = beneficiary.membership %}
 
-    {% if member.isExemptedFromShifts() %}
-        {% set firstValidMembershipShiftExemption = member.getValidMembershipShiftExemptions().first %}
+    {% if member.isCurrentlyExemptedFromShifts() %}
+        {% set firstCurrentMembershipShiftExemption = member.getCurrentMembershipShiftExemptions().first %}
         <div class="card-panel teal white-text">
             <i class="material-icons small left">beach_access</i>
             <strong>{% if member.beneficiaries | length %}Votre{% else %}Ton{% endif %} compte est exempté de créneau !</strong>
             <br />
-            ({{ firstValidMembershipShiftExemption.shiftExemption }}) jusqu'au {{ firstValidMembershipShiftExemption.end | date_fr_full }}
+            ({{ firstCurrentMembershipShiftExemption.shiftExemption }}) jusqu'au {{ firstCurrentMembershipShiftExemption.end | date_fr_full }}
         </div>
     {% endif %}
 

--- a/app/Resources/views/member/_partial/shifts.html.twig
+++ b/app/Resources/views/member/_partial/shifts.html.twig
@@ -1,13 +1,13 @@
 {% set firstShiftDate = member.firstShiftDate %}
 
-{% if member.isExemptedFromShifts() %}
+{% if member.isCurrentlyExemptedFromShifts() %}
     <div class="row">
-        {% set firstValidMembershipShiftExemption = member.getValidMembershipShiftExemptions().first %}
+        {% set firstCurrentMembershipShiftExemption = member.getCurrentMembershipShiftExemptions().first %}
         <div class="card-panel teal white-text">
             <i class="material-icons small left">beach_access</i>
             <strong>Compte exempté de créneau !</strong>
             <br />
-            ({{ firstValidMembershipShiftExemption.shiftExemption }}) jusqu'au {{ firstValidMembershipShiftExemption.end | date_fr_full }}
+            ({{ firstCurrentMembershipShiftExemption.shiftExemption }}) jusqu'au {{ firstCurrentMembershipShiftExemption.end | date_fr_full }}
         </div>
     </div>
 {% endif %}

--- a/app/Resources/views/member/_partial/shifts.html.twig
+++ b/app/Resources/views/member/_partial/shifts.html.twig
@@ -2,12 +2,14 @@
 
 {% if member.isCurrentlyExemptedFromShifts() %}
     <div class="row">
-        {% set firstCurrentMembershipShiftExemption = member.getCurrentMembershipShiftExemptions().first %}
         <div class="card-panel teal white-text">
-            <i class="material-icons small left">beach_access</i>
+            <i class="material-icons left">beach_access</i>
             <strong>Compte exempté de créneau !</strong>
-            <br />
-            ({{ firstCurrentMembershipShiftExemption.shiftExemption }}) jusqu'au {{ firstCurrentMembershipShiftExemption.end | date_fr_full }}
+            <ul class="list-unstyled">
+                {% for currentMembershipShiftExemption in member.getCurrentMembershipShiftExemptions() %}
+                    <li><i>{{ currentMembershipShiftExemption.shiftExemption }}</i> du {{ currentMembershipShiftExemption.start | date_fr_full }} au {{ currentMembershipShiftExemption.end | date_fr_full }}</li>
+                {% endfor %}
+            </ul>
         </div>
     </div>
 {% endif %}

--- a/app/Resources/views/member/show.html.twig
+++ b/app/Resources/views/member/show.html.twig
@@ -20,7 +20,7 @@
         {% if member.mainBeneficiary and not member.mainBeneficiary.user.isEnabled %}
             <i class="material-icons" title="Compte pas encore activé">phonelink_off</i>
         {% endif %}
-        {% if member.isExemptedFromShifts() %}<i class="material-icons" title="Compte exempté">beach_access</i>{% endif %}
+        {% if member.isCurrentlyExemptedFromShifts() %}<i class="material-icons" title="Compte exempté">beach_access</i>{% endif %}
         {% if member.frozen %}<i class="material-icons" title="Compte gelé">ac_unit</i>{% endif %}
         {% if member.withdrawn %}<i class="material-icons" title="Compte fermé">block</i>{% endif %}
     </h4>
@@ -421,7 +421,7 @@
         body {
             background-color: {{ member_frozen_background_color }};
         }
-        {% elseif member.isExemptedFromShifts() %}
+        {% elseif member.isCurrentlyExemptedFromShifts() %}
         body {
             background-color: {{ member_exempted_background_color }};
         }

--- a/src/AppBundle/Command/ShiftGenerateCommand.php
+++ b/src/AppBundle/Command/ShiftGenerateCommand.php
@@ -98,7 +98,7 @@ class ShiftGenerateCommand extends ContainerAwareCommand
                         $current_shift->setPosition($position);
                         // si c'est un créneau fixe
                         if ($use_fly_and_fixed && $position->getShifter() != null &&
-                            !$position->getShifter()->getMembership()->isExemptedFromShifts($current_shift->getStart())) {
+                            !$position->getShifter()->getMembership()->isCurrentlyExemptedFromShifts($current_shift->getStart())) {
                             $current_shift->setFixe(True);
                             $current_shift->setShifter($position->getShifter());
                             $current_shift->setBookedTime(new \DateTime('now'));

--- a/src/AppBundle/Controller/MembershipShiftExemptionController.php
+++ b/src/AppBundle/Controller/MembershipShiftExemptionController.php
@@ -168,7 +168,7 @@ class MembershipShiftExemptionController extends Controller
         $em = $this->getDoctrine()->getManager();
         $shifts = $em->getRepository('AppBundle:Shift')->findInProgressAndUpcomingShiftsForMembership($membershipShiftExemption->getMembership());
         return $shifts->exists(function($key, $value) use ($membershipShiftExemption) {
-            return $membershipShiftExemption->isValid($value->getStart());
+            return $membershipShiftExemption->isCurrent($value->getStart());
         });
     }
 }

--- a/src/AppBundle/Controller/ShiftController.php
+++ b/src/AppBundle/Controller/ShiftController.php
@@ -184,7 +184,7 @@ class ShiftController extends Controller
             } elseif ($shift->getFormation() && !$beneficiary->getFormations()->contains($shift->getFormation())) {
                 $message = "Désolé, ce bénévole n'a pas la qualification necessaire (" . $shift->getFormation()->getName() . ")";
                 $success = false;
-            } elseif ($beneficiary->getMembership()->isExemptedFromShifts($shift->getStart())) {
+            } elseif ($beneficiary->getMembership()->isCurrentlyExemptedFromShifts($shift->getStart())) {
                 $message = "Désolé, ce bénévole est exempté de créneau sur cette période";
                 $success = false;
             } else {

--- a/src/AppBundle/Entity/Membership.php
+++ b/src/AppBundle/Entity/Membership.php
@@ -692,13 +692,13 @@ class Membership
      *
      * @return \Doctrine\Common\Collections\Collection
      */
-    public function getValidMembershipShiftExemptions(\DateTime $date = null)
+    public function getCurrentMembershipShiftExemptions(\DateTime $date = null)
     {
         if (!$date) {
             $date = new \DateTime('now');
         }
         return $this->membershipShiftExemptions->filter(function($membershipShiftExemption) use ($date) {
-            return $membershipShiftExemption->isValid($date);
+            return $membershipShiftExemption->isCurrent($date);
         });
     }
 
@@ -708,13 +708,13 @@ class Membership
      * @param \DateTime $date
      * @return boolean
      */
-    public function isExemptedFromShifts(\DateTime $date = null)
+    public function isCurrentlyExemptedFromShifts(\DateTime $date = null)
     {
         if (!$date) {
             $date = new \DateTime('now');
         }
-        return $this->membershipShiftExemptions->exists(function($key, $value) use ($date) {
-            return $value->isValid($date);
+        return $this->membershipShiftExemptions->exists(function($key, $membershipShiftExemption) use ($date) {
+            return $membershipShiftExemption->isCurrent($date);
         });
     }
 

--- a/src/AppBundle/Entity/MembershipShiftExemption.php
+++ b/src/AppBundle/Entity/MembershipShiftExemption.php
@@ -255,13 +255,16 @@ class MembershipShiftExemption
     }
 
     /**
-     * Return if the membershipShiftExemption is valid for a given date
+     * Return if the membershipShiftExemption is current (ongoing) for a given date
      *
      * @param \DateTime $date
      * @return \DateTime
      */
-    public function isValid(\Datetime $date)
+    public function isCurrent(\Datetime $date = null)
     {
+        if (!$date) {
+            $date = new \DateTime('now');
+        }
         return ($date >= $this->start) && ($date <= $this->end);
     }
 }

--- a/src/AppBundle/Entity/TimeLog.php
+++ b/src/AppBundle/Entity/TimeLog.php
@@ -271,8 +271,8 @@ class TimeLog
             case self::TYPE_CYCLE_END_REGULATE_OPTIONAL_SHIFTS:
                 return "Régulation du bénévolat facultatif";
             case self::TYPE_CYCLE_END_EXEMPTED:
-                return "Début de cycle (compte exempté de créneau - exemption n°" . join(",", $this->membership->getMembershipShiftExemptions()->filter(function($element) {
-                    return $element->isValid($this->createdAt);
+                return "Début de cycle (compte exempté de créneau - exemption n°" . join(",", $this->membership->getMembershipShiftExemptions()->filter(function($membershipShiftExemption) {
+                    return $membershipShiftExemption->isCurrent($this->createdAt);
                 })->map(function($element) {
                     return $element->getId();
                 })->toArray()) . ")";

--- a/src/AppBundle/EventListener/TimeLogEventListener.php
+++ b/src/AppBundle/EventListener/TimeLogEventListener.php
@@ -121,7 +121,7 @@ class TimeLogEventListener
             $this->createRegistrationExpiredLog($member);
         } else if ($member->getFrozen()) {
             $this->createFrozenLog($member);
-        } else if ($member->isExemptedFromShifts($date)) {
+        } else if ($member->isCurrentlyExemptedFromShifts($date)) {
             $this->createExemptedLog($member);
         } else {
             $this->createCycleBeginningLog($member, $date);

--- a/src/AppBundle/Resources/public/css/custom.css
+++ b/src/AppBundle/Resources/public/css/custom.css
@@ -478,3 +478,8 @@ strong {
 .hover-toggle-text-icon a:hover span {
   display: none;
 }
+ul.list-unstyled {
+  list-style: none;
+	margin-left: 0;
+	padding-left: 0;
+}

--- a/src/AppBundle/Resources/public/css/custom.less
+++ b/src/AppBundle/Resources/public/css/custom.less
@@ -501,3 +501,9 @@ strong {
     }
   }
 }
+
+ul.list-unstyled {
+  list-style: none;
+	margin-left: 0;
+	padding-left: 0;
+}

--- a/src/AppBundle/Service/ShiftService.php
+++ b/src/AppBundle/Service/ShiftService.php
@@ -211,7 +211,7 @@ class ShiftService
         }
 
         $member = $beneficiary->getMembership();
-        if ($member->isExemptedFromShifts($shift->getStart()))
+        if ($member->isCurrentlyExemptedFromShifts($shift->getStart()))
             return false;
 
         if ($member->isWithdrawn())


### PR DESCRIPTION
### Quoi ?

|Avant|Après|
|---|---|
|`$membershipShiftExemption->isValid($date)`|`$membershipShiftExemption->isCurrent($date)`|
|`member.isExemptedFromShifts()`|`member.isCurrentlyExemptedFromShifts()`|
|~firstValidMembershipShiftExemption~|afficher toutes les exceptions en cours dans la fiche du membre|

### Pourquoi ?

- pour clarifier !
- une exemption de créneau pourrait être "valide" sans pour autant être "current" (valide au sens de "respecte les règles de start / end / reason)
- `isValid` est une terminologie utilisée dans les formulaires
- alors que `isCurrent` est déjà utilisé pour savoir si un créneau est en cours
- permet de faire la PR suivante qui définit les différents états d'une exemption