### PR TITLE
Fix : pouvoir supprimer le dernier créneau d'un bucket

### DIFF
--- a/app/Resources/views/admin/booking/_partial/bucket_modal.html.twig
+++ b/app/Resources/views/admin/booking/_partial/bucket_modal.html.twig
@@ -109,7 +109,7 @@ It use the materialize modal class https://materializecss.com/modals.html
                     {{ form_end(shift_book_forms[shift.id]) }}
                     {% if not shift.lastShifter %}
                         {{ form_start(shift_delete_forms[shift.id]) }}
-                        <button type="submit" title="Supprimer le poste" class="btn red">
+                        <button type="submit" title="Supprimer le poste" class="btn red" {% if nbShifts == 1 %}disabled{% endif %}>
                             <i class="material-icons left">delete</i>Supprimer
                         </button>
                         {{ form_end(shift_delete_forms[shift.id]) }}

--- a/app/Resources/views/admin/booking/_partial/bucket_modal.html.twig
+++ b/app/Resources/views/admin/booking/_partial/bucket_modal.html.twig
@@ -109,7 +109,7 @@ It use the materialize modal class https://materializecss.com/modals.html
                     {{ form_end(shift_book_forms[shift.id]) }}
                     {% if not shift.lastShifter %}
                         {{ form_start(shift_delete_forms[shift.id]) }}
-                        <button type="submit" title="Supprimer le poste" class="btn red" {% if nbShifts == 1 %}disabled{% endif %}>
+                        <button type="submit" title="Supprimer le poste" class="btn red">
                             <i class="material-icons left">delete</i>Supprimer
                         </button>
                         {{ form_end(shift_delete_forms[shift.id]) }}
@@ -178,7 +178,7 @@ It use the materialize modal class https://materializecss.com/modals.html
                 method: 'POST',
                 success: function (data) {
                     M.toast({ text: data.message, displayLength: 2500, classes: 'green' });
-                    if (this.data.includes("bucket_delete_form")) {
+                    if (this.data.includes("bucket_delete_form") || data.card === null) {
                         $('#main-bucket-{{ bucket.id }}').remove();
                         M.Modal.getInstance($('#modal-bucket')).close();
                     } else if (data.modal) {

--- a/app/Resources/views/admin/booking/index.html.twig
+++ b/app/Resources/views/admin/booking/index.html.twig
@@ -101,7 +101,7 @@
             } else if (jqXHR.status == 404) {
                 msg = 'Oups, le créneau n\'existe plus. Quelqu\'un d\'autre l\'a supprimé entre temps ?';
             } else if (jqXHR.status == 500) {
-                msg = 'Erreur interne, il faut mettre les informatiens sur le coup !';
+                msg = 'Erreur interne, il faut mettre les informaticiens sur le coup !';
             } else if (exception === 'parsererror') {
                 msg = 'Réponse du serveur incompréhensible (JSON parse failed).';
             } else if (exception === 'timeout') {

--- a/app/Resources/views/admin/helloasso/payments.html.twig
+++ b/app/Resources/views/admin/helloasso/payments.html.twig
@@ -88,7 +88,7 @@
             } else if (jqXHR.status == 404) {
                 msg = 'Oups, le paiement n\'existe plus. Quelqu\'un d\'autre l\'a supprimé entre temps ?';
             } else if (jqXHR.status == 500) {
-                msg = 'Erreur interne, il faut mettre les informatiens sur le coup !';
+                msg = 'Erreur interne, il faut mettre les informaticiens sur le coup !';
             } else if (exception === 'parsererror') {
                 msg = 'Réponse du serveur incompréhensible (JSON parse failed).';
             } else if (exception === 'timeout') {

--- a/app/Resources/views/admin/shift/edit.html.twig
+++ b/app/Resources/views/admin/shift/edit.html.twig
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block content %}
-    <h4> Editer créneau / <span class="{{ shift.job.color }}-text">{{ shift.job.name }}</span></h4>
+    <h4> Editer créneaux / <span class="{{ shift.job.color }}-text">{{ shift.job.name }}</span></h4>
     <h5>{{ shift.start|date_fr_long }} de {{ shift.start|date('G\\hi') }} à {{ shift.end|date('G\\hi') }}</h5>
     {{ form_start(form) }}
     <div class="row">

--- a/src/AppBundle/Controller/BookingController.php
+++ b/src/AppBundle/Controller/BookingController.php
@@ -553,7 +553,7 @@ class BookingController extends Controller
             }
             $em->flush();
             $success = true;
-            $message = $count . " créneaux ont été supprimés !";
+            $message = $count . (($count > 1) ? " créneaux ont été supprimés" : " créneau a été supprimé") . " !";
         } else {
             $success = false;
             $message = "Une erreur s'est produite... Impossible de supprimer le créneau. " . (string) $form->getErrors(true, false);

--- a/src/AppBundle/Controller/ShiftController.php
+++ b/src/AppBundle/Controller/ShiftController.php
@@ -548,15 +548,20 @@ class ShiftController extends Controller
         if ($request->isXmlHttpRequest()) {
             if ($success) {
                 $bucket = $this->get('shift_service')->getShiftBucketFromShift($shift);
-                $card =  $this->get('twig')->render('admin/booking/_partial/bucket_card.html.twig', array(
-                    'bucket' => $bucket,
-                    'start' => 6,
-                    'end' => 22,
-                    'line' => 0,
-                ));
-                $modal = $this->forward('AppBundle\Controller\BookingController::showBucketAction', [
-                    'bucket' => $bucket->getShiftWithMinId()
-                ])->getContent();
+                if (count($bucket->getShifts()) > 0) {
+                    $card =  $this->get('twig')->render('admin/booking/_partial/bucket_card.html.twig', array(
+                        'bucket' => $bucket,
+                        'start' => 6,
+                        'end' => 22,
+                        'line' => 0,
+                    ));
+                    $modal = $this->forward('AppBundle\Controller\BookingController::showBucketAction', [
+                        'bucket' => $bucket->getShiftWithMinId()
+                    ])->getContent();
+                } else {
+                    $card = null;
+                    $modal = null;
+                }
                 return new JsonResponse(array('message'=>$message, 'card' => $card, 'modal' => $modal), 200);
             } else {
                 return new JsonResponse(array('message'=>$message), 400);


### PR DESCRIPTION
### Quoi ?

Actuellement, lorsqu'on affiche un "bucket" (groupe de créneaux à une même date/heure donnée), on peut effectuer des actions en AJAX sans rafraichir la page (grâce à #674)
Mais lorsqu'il reste qu'1 seul créneau, le supprimer revient à supprimer le bucket. Mais cela ne se produit pas, et il y a un bug. Pour l'éviter, j'ai disable le bouton supprimer du seul créneau libre, pour pousser à la suppression du bucket directement.

### Captures d'écran

Après
![Screenshot from 2023-01-17 18-57-45](https://user-images.githubusercontent.com/7147385/212975908-7c83ceaa-0c67-4a6b-8585-2920f7462590.png)
