### PR TITLE
Créneaux : afficher les X derniers cycles

### DIFF
--- a/app/Resources/views/booking/home_booked_shifts.html.twig
+++ b/app/Resources/views/booking/home_booked_shifts.html.twig
@@ -65,33 +65,29 @@
                 </li>
             {% endif %}
         {% endfor %}
-        {% if (shift_service.hasCycle(member, -1) or shift_service.hasCycle(member, -2)) %}
-            <li>
-                <div class="collapsible-header">
-                    <i class="material-icons">event_available</i>{% if member.beneficiaries | length > 1 %}Vos{% else %}Mes{% endif %} créneaux passés
-                </div>
-                <div class="collapsible-body">
-                    {# Shift history #}
-                    <div class="row">
-                        {% for cycle in -1..-2 %}
-                            {% if shift_service.hasCycle(member, cycle) %}
-                                <div class="col s12 m6 l4">
-                                    {% set previousShifts = shiftsByCycle[cycle] %}
-                                    <h6>Cycle précédent (du {{ membership_service.startOfCycle(member,cycle) | date('d/m/y') }} au {{ membership_service.endOfCycle(member,cycle) | date('d/m/y') }})</h6>
-                                    {% if previousShifts|length == 0 %}
-                                        Pas de créneau
-                                    {% endif %}
-                                    {% for shift in previousShifts %}
-                                        <div class="col s12 m12">
-                                            {% include "user/_partial/mini_shift_card.html.twig" with { shift: shift } %}
-                                        </div>
-                                    {% endfor %}
-                                </div>
+        <li>
+            <div class="collapsible-header">
+                <i class="material-icons">event_available</i>{% if member.beneficiaries | length > 1 %}Vos{% else %}Mes{% endif %} créneaux passés
+            </div>
+            <div class="collapsible-body">
+                {# Shift history #}
+                <div class="row">
+                    {% for cycle in -1..-3 %}
+                        <div class="col s12 m6 l4">
+                            {% set previousShifts = shiftsByCycle[cycle] %}
+                            <h6>Cycle précédent (du {{ membership_service.startOfCycle(member,cycle) | date('d/m/y') }} au {{ membership_service.endOfCycle(member,cycle) | date('d/m/y') }})</h6>
+                            {% if previousShifts|length == 0 %}
+                                Pas de créneau
                             {% endif %}
-                        {% endfor %}
-                    </div>
+                            {% for shift in previousShifts %}
+                                <div class="col s12 m12">
+                                    {% include "user/_partial/mini_shift_card.html.twig" with { shift: shift } %}
+                                </div>
+                            {% endfor %}
+                        </div>
+                    {% endfor %}
                 </div>
-            </li>
-        {% endif %}
+            </div>
+        </li>
     </ul>
 {% endif %}

--- a/app/Resources/views/member/_partial/shifts.html.twig
+++ b/app/Resources/views/member/_partial/shifts.html.twig
@@ -32,7 +32,7 @@
 {% for cycle, shifts in shifts_by_cycle %}
     <div class="row">
         <h6>
-            {% if cycle == -1 %}
+            {% if cycle <= -1 %}
                 Cycle précédent
             {% elseif cycle == 0 %}
                 Cycle en cours

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -65,6 +65,7 @@ twig:
     use_fly_and_fixed: '%use_fly_and_fixed%'
     max_event_proxy_per_member: '%max_event_proxy_per_member%'
     display_gauge: '%display_gauge%'
+    max_nb_of_past_cycles_to_display: '%max_nb_of_past_cycles_to_display%'
     profile_display_task_list: '%profile_display_task_list%'
     profile_display_time_log: '%profile_display_time_log%'
     # member

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -105,6 +105,7 @@ parameters:
     display_name_shifters: false
     use_card_reader_to_validate_shifts: false
     max_time_at_end_of_shift: 0
+    max_nb_of_past_cycles_to_display: 3
 
     # Events
     max_event_proxy_per_member: 1

--- a/src/AppBundle/Controller/BookingController.php
+++ b/src/AppBundle/Controller/BookingController.php
@@ -65,7 +65,7 @@ class BookingController extends Controller
         $beneficiaries = $membership->getBeneficiaries();
 
         $em = $this->getDoctrine()->getManager();
-        $preceding_previous_cycle_start = $this->get('membership_service')->getStartOfCycle($membership, -3);
+        $preceding_previous_cycle_start = $this->get('membership_service')->getStartOfCycle($membership, -1 * $this->getParameter('max_nb_of_past_cycles_to_display'));
         $next_cycle_end = $this->get('membership_service')->getEndOfCycle($membership, 1);
         $shifts_by_cycle = $em->getRepository('AppBundle:Shift')->findShiftsByCycles($membership, $preceding_previous_cycle_start, $next_cycle_end);
         $period_positions = $em->getRepository('AppBundle:PeriodPosition')->findByBeneficiaries($beneficiaries);

--- a/src/AppBundle/Controller/BookingController.php
+++ b/src/AppBundle/Controller/BookingController.php
@@ -65,7 +65,7 @@ class BookingController extends Controller
         $beneficiaries = $membership->getBeneficiaries();
 
         $em = $this->getDoctrine()->getManager();
-        $preceding_previous_cycle_start = $this->get('membership_service')->getStartOfCycle($membership, -2);
+        $preceding_previous_cycle_start = $this->get('membership_service')->getStartOfCycle($membership, -3);
         $next_cycle_end = $this->get('membership_service')->getEndOfCycle($membership, 1);
         $shifts_by_cycle = $em->getRepository('AppBundle:Shift')->findShiftsByCycles($membership, $preceding_previous_cycle_start, $next_cycle_end);
         $period_positions = $em->getRepository('AppBundle:PeriodPosition')->findByBeneficiaries($beneficiaries);

--- a/src/AppBundle/Controller/MembershipController.php
+++ b/src/AppBundle/Controller/MembershipController.php
@@ -161,9 +161,10 @@ class MembershipController extends Controller
 
         $em = $this->getDoctrine()->getManager();
         $period_positions = $em->getRepository('AppBundle:PeriodPosition')->findByBeneficiaries($member->getBeneficiaries());
-        $previous_cycle_start = $this->get('membership_service')->getStartOfCycle($member, -1);
+        $previous_cycle_start = $this->get('membership_service')->getStartOfCycle($member, -3);
         $next_cycle_end = $this->get('membership_service')->getEndOfCycle($member, 1);
         $shifts_by_cycle = $em->getRepository('AppBundle:Shift')->findShiftsByCycles($member, $previous_cycle_start, $next_cycle_end);
+        $shifts_by_cycle = array_reverse($shifts_by_cycle, true);  // from latest to oldest
         $shiftFreeForms = [];
         $shiftValidateInvalidateForms = [];
         foreach ($shifts_by_cycle as $shifts) {

--- a/src/AppBundle/Controller/MembershipController.php
+++ b/src/AppBundle/Controller/MembershipController.php
@@ -161,7 +161,7 @@ class MembershipController extends Controller
 
         $em = $this->getDoctrine()->getManager();
         $period_positions = $em->getRepository('AppBundle:PeriodPosition')->findByBeneficiaries($member->getBeneficiaries());
-        $previous_cycle_start = $this->get('membership_service')->getStartOfCycle($member, -3);
+        $previous_cycle_start = $this->get('membership_service')->getStartOfCycle($member, -1 * $this->getParameter('max_nb_of_past_cycles_to_display'));
         $next_cycle_end = $this->get('membership_service')->getEndOfCycle($member, 1);
         $shifts_by_cycle = $em->getRepository('AppBundle:Shift')->findShiftsByCycles($member, $previous_cycle_start, $next_cycle_end);
         $shifts_by_cycle = array_reverse($shifts_by_cycle, true);  // from latest to oldest


### PR DESCRIPTION
### Quoi ?

- sur la home, et dans l'admin, homogénéiser le nombre de cycle passé à afficher au membre
- mettre ce nombre dans un paramètre `max_nb_of_past_cycles_to_display`
- répare l'affichage de "créneaux passés" lors d'une nouvelle adhésion