### PR TITLE
Shift : cleanup du nom des formulaires

### DIFF
--- a/src/AppBundle/Controller/BookingController.php
+++ b/src/AppBundle/Controller/BookingController.php
@@ -689,7 +689,7 @@ class BookingController extends Controller
     {
         return $this->createFormBuilder()
             ->setAction($this->generateUrl('shift_dismiss', array('id' => $shift->getId())))
-            ->add('reason', TextareaType::class, ['label' => 'Justification éventuelle', 'attr' => [ 'class' => 'materialize-textarea']])
+            ->add('reason', TextareaType::class, array('required' => false, 'label' => 'Justification éventuelle', 'attr' => array('class' => 'materialize-textarea')))
             ->setMethod('POST')
             ->getForm();
     }

--- a/src/AppBundle/Controller/BookingController.php
+++ b/src/AppBundle/Controller/BookingController.php
@@ -73,12 +73,7 @@ class BookingController extends Controller
         $shiftDismissForms = [];
         foreach ($shifts_by_cycle as $key => $shifts) {
             foreach ($shifts as $shift) {
-                $shiftDismissForms[$shift->getId()] = $this->createFormBuilder()
-                    ->setAction($this->generateUrl('shift_dismiss', ['id' => $shift->getId()]))
-                    ->setMethod('POST')
-                    ->add('reason', TextareaType::class, ['label' => 'Justification éventuelle', 'attr' => [ 'class' => 'materialize-textarea']])
-                    ->getForm()
-                    ->createView();
+                $shiftDismissForms[$shift->getId()] = $this->createShiftDismissForm($shift)->createView();
             }
         }
 
@@ -399,10 +394,10 @@ class BookingController extends Controller
         $shiftFreeForms = [];
         $shiftValidateInvalidateForms = [];
         foreach ($shifts as $shift) {
-            $shiftBookForms[$shift->getId()] = $this->createBookForm($shift)->createView();
-            $shiftDeleteForms[$shift->getId()] = $this->createDeleteForm($shift)->createView();
-            $shiftFreeForms[$shift->getId()] = $this->createFreeForm($shift)->createView();
-            $shiftValidateInvalidateForms[$shift->getId()] = $this->createValidateInvalidateShiftForm($shift)->createView();
+            $shiftBookForms[$shift->getId()] = $this->createShiftBookForm($shift)->createView();
+            $shiftDeleteForms[$shift->getId()] = $this->createShiftDeleteForm($shift)->createView();
+            $shiftFreeForms[$shift->getId()] = $this->createShiftFreeForm($shift)->createView();
+            $shiftValidateInvalidateForms[$shift->getId()] = $this->createShiftValidateInvalidateForm($shift)->createView();
         }
         $bucketAddForm = $this->get('form.factory')->createNamed(
             'bucket_add_form',
@@ -412,8 +407,8 @@ class BookingController extends Controller
                 'action' => $this->generateUrl('shift_new'),
                 'only_add_formation' => true,
             ));
-        $bucketDeleteform = $this->createDeleteBucketForm($bucket);
-        $bucketLockUnlockForm = $this->createLockUnlockBucketForm($bucket);
+        $bucketDeleteform = $this->createBucketDeleteForm($bucket);
+        $bucketLockUnlockForm = $this->createBucketLockUnlockForm($bucket);
 
         return $this->render('admin/booking/_partial/bucket_modal.html.twig', [
             'shifts' => $shifts,
@@ -478,7 +473,7 @@ class BookingController extends Controller
     {
         $this->denyAccessUnlessGranted(ShiftVoter::LOCK, $shift);
 
-        $form = $this->createLockUnlockBucketForm($shift);
+        $form = $this->createBucketLockUnlockForm($shift);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
@@ -534,7 +529,7 @@ class BookingController extends Controller
     public function deleteBucketAction(Request $request, Shift $bucket)
     {
         $session = new Session();
-        $form = $this->createDeleteBucketForm($bucket);
+        $form = $this->createBucketDeleteForm($bucket);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
@@ -574,7 +569,7 @@ class BookingController extends Controller
      *
      * @return \Symfony\Component\Form\Form The form
      */
-    private function createLockUnlockBucketForm(Shift $bucket)
+    private function createBucketLockUnlockForm(Shift $bucket)
     {
         return $this->get('form.factory')->createNamedBuilder('bucket_lock_unlock_form')
             ->setAction($this->generateUrl('bucket_lock_unlock', array('id' => $bucket->getId())))
@@ -592,7 +587,7 @@ class BookingController extends Controller
      *
      * @return \Symfony\Component\Form\Form The form
      */
-    private function createDeleteBucketForm(Shift $bucket)
+    private function createBucketDeleteForm(Shift $bucket)
     {
         return $this->get('form.factory')->createNamedBuilder('bucket_delete_form')
             ->setAction($this->generateUrl('bucket_delete', array('id' => $bucket->getId())))
@@ -602,13 +597,13 @@ class BookingController extends Controller
 
     /**
      * Creates a form to book a shift entity.
-     * // TODO: how to avoid having same createBookForm in ShiftController ?
+     * // TODO: how to avoid having same createShiftBookForm in ShiftController ?
      *
      * @param Shift $shift The shift entity
      *
      * @return \Symfony\Component\Form\Form The form
      */
-    private function createBookForm(Shift $shift)
+    private function createShiftBookForm(Shift $shift)
     {
         $form = $this->get('form.factory')->createNamedBuilder('shift_book_forms_' . $shift->getId())
             ->setAction($this->generateUrl('shift_book_admin', array('id' => $shift->getId())))
@@ -633,52 +628,69 @@ class BookingController extends Controller
 
     /**
      * Creates a form to delete a shift entity.
-     * // TODO: how to avoid having same createDeleteForm in ShiftController ?
+     * // TODO: how to avoid having same createShiftDeleteForm in ShiftController ?
      *
      * @param Shift $shift The shift entity
      *
      * @return \Symfony\Component\Form\Form The form
      */
-    private function createDeleteForm(Shift $shift)
+    private function createShiftDeleteForm(Shift $shift)
     {
         return $this->get('form.factory')->createNamedBuilder('shift_delete_forms_' . $shift->getId())
-                                         ->setAction($this->generateUrl('shift_delete', array('id' => $shift->getId())))
-                                         ->setMethod('DELETE')
-                                         ->getForm();
+            ->setAction($this->generateUrl('shift_delete', array('id' => $shift->getId())))
+            ->setMethod('DELETE')
+            ->getForm();
     }
 
     /**
      * Creates a form to free a shift entity.
-     * // TODO: how to avoid having same createFreeForm in ShiftController ?
+     * // TODO: how to avoid having same createShiftFreeForm in ShiftController ?
      *
      * @param Shift $shift The shift entity
      *
      * @return \Symfony\Component\Form\Form The form
      */
-    private function createFreeForm(Shift $shift)
+    private function createShiftFreeForm(Shift $shift)
     {
         return $this->get('form.factory')->createNamedBuilder('shift_free_forms_' . $shift->getId())
-                                         ->setAction($this->generateUrl('shift_free', array('id' => $shift->getId())))
-                                         ->setMethod('POST')
-                                         ->getForm();
+            ->setAction($this->generateUrl('shift_free', array('id' => $shift->getId())))
+            ->setMethod('POST')
+            ->getForm();
     }
 
     /**
      * Creates a form to validate / invalidate a shift entity.
-     * // TODO: how to avoid having same createValidateInvalidateShiftForm in ShiftController ?
+     * // TODO: how to avoid having same createShiftValidateInvalidateForm in ShiftController ?
      *
      * @param Shift $shift The shift entity
      *
      * @return \Symfony\Component\Form\Form The form
      */
-    private function createValidateInvalidateShiftForm(Shift $shift)
+    private function createShiftValidateInvalidateForm(Shift $shift)
     {
         return $this->get('form.factory')->createNamedBuilder('shift_validate_invalidate_forms_' . $shift->getId())
-                                         ->setAction($this->generateUrl('shift_validate', array('id' => $shift->getId())))
-                                         ->add('validate', HiddenType::class, [
-                                             'data'  => ($shift->getWasCarriedOut() ? 0 : 1),
-                                         ])
-                                         ->setMethod('POST')
-                                         ->getForm();
+            ->setAction($this->generateUrl('shift_validate', array('id' => $shift->getId())))
+            ->add('validate', HiddenType::class, [
+                'data' => ($shift->getWasCarriedOut() ? 0 : 1),
+            ])
+            ->setMethod('POST')
+            ->getForm();
+    }
+
+    /**
+     * Creates a form to dismiss a shift entity.
+     * // TODO: how to avoid having similar createShiftDismissForm in ShiftController ?
+     *
+     * @param Shift $shift The shift entity
+     *
+     * @return \Symfony\Component\Form\Form The form
+     */
+    private function createShiftDismissForm(Shift $shift)
+    {
+        return $this->createFormBuilder()
+            ->setAction($this->generateUrl('shift_dismiss', array('id' => $shift->getId())))
+            ->add('reason', TextareaType::class, ['label' => 'Justification éventuelle', 'attr' => [ 'class' => 'materialize-textarea']])
+            ->setMethod('POST')
+            ->getForm();
     }
 }

--- a/src/AppBundle/Controller/MembershipController.php
+++ b/src/AppBundle/Controller/MembershipController.php
@@ -169,8 +169,8 @@ class MembershipController extends Controller
         $shiftValidateInvalidateForms = [];
         foreach ($shifts_by_cycle as $shifts) {
             foreach ($shifts as $shift) {
-                $shiftFreeForms[$shift->getId()] = $this->createFreeForm($shift)->createView();
-                $shiftValidateInvalidateForms[$shift->getId()] = $this->createValidateInvalidateShiftForm($shift)->createView();
+                $shiftFreeForms[$shift->getId()] = $this->createShiftFreeForm($shift)->createView();
+                $shiftValidateInvalidateForms[$shift->getId()] = $this->createShiftValidateInvalidateForm($shift)->createView();
             }
         }
 
@@ -1180,36 +1180,36 @@ class MembershipController extends Controller
 
     /**
      * Creates a form to free a shift entity.
-     * // TODO: how to avoid having same createFreeForm in ShiftController ?
+     * // TODO: how to avoid having same createShiftFreeForm in ShiftController ?
      *
      * @param Shift $shift The shift entity
      *
      * @return \Symfony\Component\Form\Form The form
      */
-    private function createFreeForm(Shift $shift)
+    private function createShiftFreeForm(Shift $shift)
     {
         return $this->get('form.factory')->createNamedBuilder('shift_free_forms_' . $shift->getId())
-                                         ->setAction($this->generateUrl('shift_free', array('id' => $shift->getId())))
-                                         ->setMethod('POST')
-                                         ->getForm();
+            ->setAction($this->generateUrl('shift_free', array('id' => $shift->getId())))
+            ->setMethod('POST')
+            ->getForm();
     }
 
     /**
      * Creates a form to validate / invalidate a shift entity.
-     * // TODO: how to avoid having same createValidateInvalidateShiftForm in ShiftController ?
+     * // TODO: how to avoid having same createShiftValidateInvalidateForm in ShiftController ?
      *
      * @param Shift $shift The shift entity
      *
      * @return \Symfony\Component\Form\Form The form
      */
-    private function createValidateInvalidateShiftForm(Shift $shift)
+    private function createShiftValidateInvalidateForm(Shift $shift)
     {
         return $this->get('form.factory')->createNamedBuilder('shift_validate_invalidate_forms_' . $shift->getId())
-                                         ->setAction($this->generateUrl('shift_validate', array('id' => $shift->getId())))
-                                         ->add('validate', HiddenType::class, [
-                                             'data'  => ($shift->getWasCarriedOut() ? 0 : 1),
-                                         ])
-                                         ->setMethod('POST')
-                                         ->getForm();
+            ->setAction($this->generateUrl('shift_validate', array('id' => $shift->getId())))
+            ->add('validate', HiddenType::class, [
+                'data' => ($shift->getWasCarriedOut() ? 0 : 1),
+            ])
+            ->setMethod('POST')
+            ->getForm();
     }
 }

--- a/src/AppBundle/Controller/PeriodController.php
+++ b/src/AppBundle/Controller/PeriodController.php
@@ -225,7 +225,7 @@ class PeriodController extends Controller
         $positionsBookForms = [];
         foreach ($period->getPositions() as $position) {
             if (!$position->getShifter()) {
-                $positionsBookForms[$position->getId()] = $this->createBookForm($period, $position)->createView();
+                $positionsBookForms[$position->getId()] = $this->createBookPeriodPositionForm($period, $position)->createView();
             }
         }
 
@@ -305,7 +305,7 @@ class PeriodController extends Controller
     {
         $session = new Session();
 
-        $form = $this->createBookForm($period, $position);
+        $form = $this->createBookPeriodPositionForm($period, $position);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
@@ -487,7 +487,7 @@ class PeriodController extends Controller
      *
      * @return \Symfony\Component\Form\Form The form
      */
-    private function createBookForm(Period $period, PeriodPosition $position)
+    private function createBookPeriodPositionForm(Period $period, PeriodPosition $position)
     {
         return $this->get('form.factory')->createNamedBuilder('positions_book_forms_' . $position->getId())
             ->setAction($this->generateUrl('book_position_from_period', array('id' => $period->getId(), 'position' => $position->getId())))

--- a/src/AppBundle/Controller/ShiftController.php
+++ b/src/AppBundle/Controller/ShiftController.php
@@ -386,8 +386,8 @@ class ShiftController extends Controller
         $session = new Session();
 
         if (!$this->isGranted('dismiss', $shift)) {
-            $session->getFlashBag()->add("error", "Impossible d'annuler ce créneau");
-            return $this->redirectToRoute("booking");
+            $session->getFlashBag()->add("error", "Impossible d'annuler ce créneau !");
+            return $this->redirectToRoute("homepage");
         }
 
         $form = $this->createShiftDismissForm($shift);
@@ -396,7 +396,7 @@ class ShiftController extends Controller
 
         if ($form->isSubmitted() && $form->isValid()) {
             if($shift->isFixe()) {
-                $session->getFlashBag()->add("error", "Impossible d'annuler un créneau fixe");
+                $session->getFlashBag()->add("error", "Impossible d'annuler un créneau fixe !");
                 return $this->redirectToRoute("homepage");
             }
             if (!$shift->getShifter()) {
@@ -418,8 +418,7 @@ class ShiftController extends Controller
             return $this->redirectToRoute('homepage');
         }
 
-
-        $session->getFlashBag()->add('success', "Le créneau a été annulé");
+        $session->getFlashBag()->add('success', "Le créneau a été annulé !");
         return $this->redirectToRoute('homepage');
     }
 
@@ -640,7 +639,7 @@ class ShiftController extends Controller
     {
         $form = $this->createFormBuilder()
             ->setAction($this->generateUrl('shift_dismiss', array('id' => $shift->getId())))
-            ->add('reason', TextareaType::class)
+            ->add('reason', TextareaType::class, array('required' => false))
             ->setMethod('POST');
 
         return $form->getForm();

--- a/src/AppBundle/Controller/ShiftController.php
+++ b/src/AppBundle/Controller/ShiftController.php
@@ -171,7 +171,7 @@ class ShiftController extends Controller
      */
     public function bookShiftAdminAction(Request $request, Shift $shift)
     {
-        $form = $this->createBookForm($shift);
+        $form = $this->createShiftBookForm($shift);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
@@ -249,7 +249,7 @@ class ShiftController extends Controller
     {
         $this->denyAccessUnlessGranted(ShiftVoter::FREE, $shift);
 
-        $form = $this->createFreeForm($shift);
+        $form = $this->createShiftFreeForm($shift);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
@@ -317,7 +317,7 @@ class ShiftController extends Controller
     {
         $this->denyAccessUnlessGranted(ShiftVoter::VALIDATE, $shift);
 
-        $form = $this->createValidateInvalidateShiftForm($shift);
+        $form = $this->createShiftValidateInvalidateForm($shift);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
@@ -390,11 +390,7 @@ class ShiftController extends Controller
             return $this->redirectToRoute("booking");
         }
 
-        $form = $this->createFormBuilder()
-            ->setAction($this->generateUrl('shift_dismiss', ['id' => $shift->getId()]))
-            ->setMethod('POST')
-            ->add('reason', TextareaType::class)
-            ->getForm();
+        $form = $this->createShiftDismissForm($shift);
 
         $form->handleRequest($request);
 
@@ -509,7 +505,7 @@ class ShiftController extends Controller
      */
     public function removeShiftAction(Request $request, Shift $shift)
     {
-        $form = $this->createDeleteForm($shift);
+        $form = $this->createShiftDeleteForm($shift);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
@@ -559,7 +555,7 @@ class ShiftController extends Controller
      *
      * @return \Symfony\Component\Form\Form The form
      */
-    private function createBookForm(Shift $shift)
+    private function createShiftBookForm(Shift $shift)
     {
         $form = $this->get('form.factory')->createNamedBuilder('shift_book_forms_' . $shift->getId())
             ->setAction($this->generateUrl('shift_book_admin', array('id' => $shift->getId())))
@@ -589,7 +585,7 @@ class ShiftController extends Controller
      *
      * @return \Symfony\Component\Form\Form The form
      */
-    private function createDeleteForm(Shift $shift)
+    private function createShiftDeleteForm(Shift $shift)
     {
         $form = $this->get('form.factory')->createNamedBuilder('shift_delete_forms_' . $shift->getId())
             ->setAction($this->generateUrl('shift_delete', array('id' => $shift->getId())))
@@ -605,7 +601,7 @@ class ShiftController extends Controller
      *
      * @return \Symfony\Component\Form\Form The form
      */
-    private function createFreeForm(Shift $shift)
+    private function createShiftFreeForm(Shift $shift)
     {
         $form = $this->get('form.factory')->createNamedBuilder('shift_free_forms_' . $shift->getId())
             ->setAction($this->generateUrl('shift_free', array('id' => $shift->getId())))
@@ -621,13 +617,30 @@ class ShiftController extends Controller
      *
      * @return \Symfony\Component\Form\Form The form
      */
-    private function createValidateInvalidateShiftForm(Shift $shift)
+    private function createShiftValidateInvalidateForm(Shift $shift)
     {
         $form = $this->get('form.factory')->createNamedBuilder('shift_validate_invalidate_forms_' . $shift->getId())
             ->setAction($this->generateUrl('shift_validate', array('id' => $shift->getId())))
             ->add('validate', HiddenType::class, [
                 'data'  => ($shift->getWasCarriedOut() ? 0 : 1),
             ])
+            ->setMethod('POST');
+
+        return $form->getForm();
+    }
+
+    /**
+     * Creates a form to dismiss a shift entity.
+     *
+     * @param Shift $shift The shift entity
+     *
+     * @return \Symfony\Component\Form\Form The form
+     */
+    private function createShiftDismissForm(Shift $shift)
+    {
+        $form = $this->createFormBuilder()
+            ->setAction($this->generateUrl('shift_dismiss', array('id' => $shift->getId())))
+            ->add('reason', TextareaType::class)
             ->setMethod('POST');
 
         return $form->getForm();


### PR DESCRIPTION
dans BookingController & ShiftController
- créer des fonction `create` pour les formulaires qui n'en avaient pas
- homogénéiser (et expliciter) le nommage des formulaires