### PR TITLE
Shift : permettre à un admin de donner une raison lors de l'annulation

### DIFF
--- a/app/Resources/views/admin/booking/_partial/bucket_modal.html.twig
+++ b/app/Resources/views/admin/booking/_partial/bucket_modal.html.twig
@@ -50,7 +50,8 @@ It use the materialize modal class https://materializecss.com/modals.html
                                 {% endif %}
                             {{ form_end(shift_validate_invalidate_forms[shift.id]) }}
                         {% endif %}
-                        {{ form_start(shift_free_forms[shift.id], {'attr': { 'style':  'display:inline;'}}) }}
+                        {{ form_start(shift_free_forms[shift.id], {'attr': { 'style':  'display:inline;' }}) }}
+                            {% do shift_free_forms[shift.id].reason.setRendered() %} <!-- hidden -->
                             {% if shift.isPast %}
                                 <button type="submit" class="btn red" title="Supprimer la participation">
                                     <i class="material-icons left">delete</i>Supprimer la participation

--- a/app/Resources/views/booking/_partial/home_shift_card.html.twig
+++ b/app/Resources/views/booking/_partial/home_shift_card.html.twig
@@ -33,7 +33,7 @@
                         </div>
                     </div>
                     <div class="modal-footer">
-                        <a href="#!" class="modal-action modal-close waves-effect waves-green btn-flat grey-text">Retour à la raison</a>
+                        <a href="#!" class="modal-action modal-close waves-effect waves-green btn-flat grey-text">Annuler</a>
                         <button type="submit" class="modal-action modal-close waves-effect waves-green btn red">Oui, je me désiste !</button>
                     </div>
                 {{ form_end(shift_dismiss_forms[shift.id]) }}

--- a/app/Resources/views/user/_partial/shift_card.html.twig
+++ b/app/Resources/views/user/_partial/shift_card.html.twig
@@ -37,7 +37,7 @@
     <div id="free{{ shift.id }}" class="modal black-text">
         {{ form_start(shift_free_forms[shift.id]) }}
             <div class="modal-content">
-                <h5>Ce membre ne peux pas faire son créneau</h5>
+                <h5>Ce membre ne peut pas faire son créneau</h5>
                 <div class="input-field">
                     {{ form_label(shift_free_forms[shift.id].reason) }}
                     {{ form_errors(shift_free_forms[shift.id].reason) }}

--- a/app/Resources/views/user/_partial/shift_card.html.twig
+++ b/app/Resources/views/user/_partial/shift_card.html.twig
@@ -19,18 +19,35 @@
                 {% endif %}
             {{ form_end(shift_validate_invalidate_forms[shift.id]) }}
         {% endif %}
-        {% if is_granted('free',shift) %}
-            {{ form_start(shift_free_forms[shift.id]) }}
-                {% if shift.isPast %}
+        {% if is_granted('free', shift) %}
+            {% if shift.isPast %}
+                {{ form_start(shift_free_forms[shift.id]) }}
+                    {% do shift_free_forms[shift.id].reason.setRendered() %} <!-- hidden -->
                     <button type="submit" class="btn red" title="Supprimer la participation">
                         <i class="material-icons left">delete</i>Supprimer la participation
                     </button>
-                {% else %}
-                    <button type="submit" class="btn orange" title="Libérer">
-                        <i class="material-icons left">lock_open</i>Libérer
-                    </button>
-                {% endif %}
-            {{ form_end(shift_free_forms[shift.id]) }}
+                {{ form_end(shift_free_forms[shift.id]) }}
+            {% else %}
+                <a href="#free{{ shift.id }}" class="modal-trigger btn orange" title="Libérer">
+                    <i class="material-icons left">lock_open</i>Libérer
+                </a>
+            {% endif %}
         {% endif %}
+    </div>
+    <div id="free{{ shift.id }}" class="modal black-text">
+        {{ form_start(shift_free_forms[shift.id]) }}
+            <div class="modal-content">
+                <h5>Ce membre ne peux pas faire son créneau</h5>
+                <div class="input-field">
+                    {{ form_label(shift_free_forms[shift.id].reason) }}
+                    {{ form_errors(shift_free_forms[shift.id].reason) }}
+                    {{ form_widget(shift_free_forms[shift.id].reason) }}
+                </div>
+            </div>
+            <div class="modal-footer">
+                <a href="#!" class="modal-action modal-close waves-effect waves-green btn-flat grey-text">Annuler</a>
+                <button type="submit" class="modal-action modal-close waves-effect waves-green btn red">Oui, libérer le créneau !</button>
+            </div>
+        {{ form_end(shift_free_forms[shift.id]) }}
     </div>
 </div>

--- a/src/AppBundle/Controller/BookingController.php
+++ b/src/AppBundle/Controller/BookingController.php
@@ -654,6 +654,7 @@ class BookingController extends Controller
     {
         return $this->get('form.factory')->createNamedBuilder('shift_free_forms_' . $shift->getId())
             ->setAction($this->generateUrl('shift_free', array('id' => $shift->getId())))
+            ->add('reason', TextareaType::class, array('required' => false, 'label' => 'Justification éventuelle', 'attr' => array('class' => 'materialize-textarea')))
             ->setMethod('POST')
             ->getForm();
     }

--- a/src/AppBundle/Controller/MembershipController.php
+++ b/src/AppBundle/Controller/MembershipController.php
@@ -35,6 +35,7 @@ use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Form;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
@@ -1190,6 +1191,7 @@ class MembershipController extends Controller
     {
         return $this->get('form.factory')->createNamedBuilder('shift_free_forms_' . $shift->getId())
             ->setAction($this->generateUrl('shift_free', array('id' => $shift->getId())))
+            ->add('reason', TextareaType::class, array('required' => false, 'label' => 'Justification éventuelle', 'attr' => array('class' => 'materialize-textarea')))
             ->setMethod('POST')
             ->getForm();
     }

--- a/src/AppBundle/Controller/ShiftController.php
+++ b/src/AppBundle/Controller/ShiftController.php
@@ -12,7 +12,6 @@ use AppBundle\Event\ShiftInvalidatedEvent;
 use AppBundle\Form\AutocompleteBeneficiaryType;
 use AppBundle\Form\RadioChoiceType;
 use AppBundle\Form\ShiftType;
-use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use AppBundle\Security\MembershipVoter;
 use AppBundle\Security\ShiftVoter;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
@@ -23,6 +22,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Form\Extension\Core\Type\RadioType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
@@ -264,7 +264,8 @@ class ShiftController extends Controller
                 if ($wasCarriedOut) {
                     $shift->invalidateShiftParticipation();
                 }
-                $shift->free();
+                $reason = $form->get("reason")->getData();
+                $shift->free($reason);
 
                 $em = $this->getDoctrine()->getManager();
                 $em->persist($shift);
@@ -405,11 +406,8 @@ class ShiftController extends Controller
             }
             // Store beneficiary entity before removing it
             $beneficiary = $shift->getShifter();
-            $shift->setShifter(null);
-            $shift->setBooker(null);
-            $shift->setFixe(false);
             $reason = $form->get("reason")->getData();
-            $shift->setReason($reason);
+            $shift->free($reason);
 
             $em = $this->getDoctrine()->getManager();
             $em->persist($shift);
@@ -604,6 +602,7 @@ class ShiftController extends Controller
     {
         $form = $this->get('form.factory')->createNamedBuilder('shift_free_forms_' . $shift->getId())
             ->setAction($this->generateUrl('shift_free', array('id' => $shift->getId())))
+            ->add('reason', TextareaType::class, array('required' => false, 'label' => 'Justification éventuelle', 'attr' => array('class' => 'materialize-textarea')))
             ->setMethod('POST');
 
         return $form->getForm();

--- a/src/AppBundle/Entity/Shift.php
+++ b/src/AppBundle/Entity/Shift.php
@@ -411,12 +411,15 @@ class Shift
      *
      * @return \AppBundle\Entity\Shift
      */
-    public function free()
+    public function free($reason = null)
     {
         $this->setBooker(null);
         $this->setBookedTime(null);
         $this->setShifter(null);
         $this->setFixe(false);
+        if ($reason) {
+            $this->setReason($reason);
+        }
         return $this;
     }
 


### PR DESCRIPTION
### Quoi ?

Coté Admin, lors de la "libération" d'un créneau à venir, afficher une modale de confirmation / justification éventuelle. (modale similaire à celle existante coté profil)

Quid de la libération de créneau dans la page "Gérer les créneaux" ? pas possible actuellement / facilement, car les créneaux s'affichent déjà dans une modale, je n'ai pas trouvé comment afficher une 2ème modale par dessus.

### Pourquoi ?

Cette justification s'affichera dans "ShiftFreeLog"

### Capture d'écran

![Screenshot from 2023-01-24 16-00-54](https://user-images.githubusercontent.com/7147385/214329503-a498664a-0f15-482c-8733-84f20eb2682b.png)
