### PR TITLE
Booking : cacher l'option "fixe" aux membres

### DIFF
--- a/app/Resources/views/booking/_partial/modal.html.twig
+++ b/app/Resources/views/booking/_partial/modal.html.twig
@@ -81,16 +81,10 @@
                         <span>volant (une seule fois)</span>
                     </label>
                 </div>
-                <div>
-                    <label for="fixe{{ firstBookable.id }}" style="color: #5f5a5a; font-weight: 600;">
-                        <input type="radio" id="fixe{{ firstBookable.id }}" class="checkedTypeService" name="typeService" value=1 />
-                        <span>fixe (reporté à chaque cycle)</span>
-                    </label>
-                </div>
             {% else %}
                 <input type="hidden" name="typeService" value=0 />
             {% endif %}
-            <div class="" style="position: fixed;top:0;width: 100%;left: 0;">
+            <div style="position: fixed;top:0;width: 100%;left: 0;">
                 {% if nbBookableShifts < nbShifts %}
                     {% for shifter in 1..(nbShifts - nbBookableShifts) %}
                         <div class="green lighten-2 left" style="height:10px; width: {{ 100/(nbShifts) }}%"></div>
@@ -105,8 +99,7 @@
         {% endif %}
     </div>
     <div class="modal-footer">
-        <a href="#!"
-           class="modal-action modal-close waves-effect waves-green btn-flat red-text" onclick="cancelAll()">Annuler</a>
+        <a href="#!" class="modal-action modal-close waves-effect waves-green btn-flat red-text" onclick="cancelAll()">Annuler</a>
         {% if beneficiary.membership.beneficiaries | length >= 1 %}
             <button id="confirmButton" onclick="postSelectedId({{ beneficiary.id }})" class="waves-effect waves-green btn teal">Confirmer</button>
         {% endif %}

--- a/app/Resources/views/booking/index.html.twig
+++ b/app/Resources/views/booking/index.html.twig
@@ -55,8 +55,7 @@
                             <li class="row">
                                 {% for job in jobs %}
                                     <div class="col s12 m4 {% if job.description is not empty %}legend_job {% endif %}" data-description="{{ job.description | markdown | raw }}">
-                                        <div style="padding: 3px;margin:5px"
-                                        class="{{ job.color }} z-depth-1 lighten-5 valign-wrapper">
+                                        <div class="{{ job.color }} z-depth-1 lighten-5 valign-wrapper" style="padding: 3px;margin:5px">
                                             <p>{{ job.name }}</p>
                                         </div>
                                     </div>
@@ -64,22 +63,19 @@
                             </li>
                             <li class="row">
                                 <div class="col s12 m4">
-                                    <div style="padding: 3px;margin:5px"
-                                         class="z-depth-1 lighten-5 valign-wrapper">
+                                    <div class="z-depth-1 lighten-5 valign-wrapper" style="padding: 3px;margin:5px">
                                         <p>Aucun bénévole inscrit</p>
                                         <span class="red-text"><i class="material-icons tiny">warning</i>&nbsp;sous-effectif</span>
                                     </div>
                                 </div>
                                 <div class="col s12 m4">
-                                    <div style="padding: 3px;margin:5px"
-                                         class="z-depth-1 lighten-5 valign-wrapper">
+                                    <div class="z-depth-1 lighten-5 valign-wrapper" style="padding: 3px;margin:5px">
                                         <p>Pas assez de bénévoles inscrits pour ouvrir</p>
                                         <span class="orange-text"><i class="material-icons tiny">warning</i>&nbsp;sous-effectif</span>
                                     </div>
                                 </div>
                                 <div class="col s12 m4">
-                                    <div style="padding: 3px;margin:5px;cursor: not-allowed"
-                                         class="z-depth-1 grey lighten-3 valign-wrapper grey-text text-lighten-1">
+                                    <div class="z-depth-1 grey lighten-3 valign-wrapper grey-text text-lighten-1" style="padding: 3px;margin:5px;cursor: not-allowed">
                                         <i class="material-icons tiny">lock</i>
                                         <p class="black-text">Créneau complet ou inaccessible pour {{ beneficiary.firstname }} <small>(quota d'heures dépassé ou formation insuffisante)</small></p>
                                     </div>


### PR DESCRIPTION
### Quoi ?

Pour les épiceries qui ont `use_fly_and_fixed=true`
Enlever l'option "fixe" lors de la réservation de créneau (seulement côté membre)

### Pourquoi ?

- ca induit en erreur le membre (penser que ce créneau sera ensuite reconduit à chaque cycle)
- ca induit en erreur nos stats (le créneau sera indiqué comme "fixe" alors qu'il a été réservé en "volant")

Note : à l'éléfàn on a commenté ce bout de code en prod, donc on n'a pas vraiment ce soucis

### Captures d'écran

|Avant|Après|
|---|---|
|![Screenshot from 2023-01-26 11-13-37](https://user-images.githubusercontent.com/7147385/214810762-04904800-7e39-4653-9fda-0995b2364845.png)|![Screenshot from 2023-01-26 11-14-13](https://user-images.githubusercontent.com/7147385/214810868-4aad7b45-3d90-4c43-ba07-9792c4ef28d8.png)|


