### PR TITLE
Booking : fix ne pas permettre de réserver des shifts déjà pris

### DIFF
--- a/app/Resources/views/booking/_partial/modal.html.twig
+++ b/app/Resources/views/booking/_partial/modal.html.twig
@@ -1,6 +1,6 @@
 {% set nbShifts = bucket.shifts | length %}
-{% set nbBookableShifts = shift_service.bookableShifts(bucket, beneficiary) | length %}
-{% set availableShifts = shift_service.bookableShifts(bucket, beneficiary) %}
+{% set bookableShifts = shift_service.bookableShifts(bucket, beneficiary) %}
+{% set nbBookableShifts = bookableShifts | length %}
 {% set firstBookable = shift_service.firstBookable(bucket, beneficiary) %}
 <div id="book{{ firstBookable.id }}" class="modal">
     <div class="modal-content">
@@ -8,34 +8,30 @@
         <h6>{{ bucket.start|date_fr_long }} de {{ bucket.start|date('G\\hi') }} à {{ bucket.end|date('G\\hi') }}</h6>
 
         {% if not shift_service.canBookDuration(beneficiary, bucket.getFirst.getDuration, cycle) %}
-          <div class="alert card red lighten-4 red-text text-darken-4">
-            <div class="card-content">
-              {% if not shift_service.canBookDuration(beneficiary, shift_service.getMinimalShiftDuration, cycle) %}
-                <span class="card-title">Attention, tu as déjà fait ton quota d'heures sur ce cycle.</span>
-                <p>Ce créneau ne sera pas comptabilisé dans ton calcul d'heures car seul un maximum de {{ due_duration_by_cycle | duration_from_minutes }} est comptabilisé par cycle.</p>
-              {% else %}
-                <span class="card-title">Attention, avec ce créneau tu dépasseras les {{ due_duration_by_cycle | duration_from_minutes }} de bénévolat sur ton cycle.</span>
-                <p>Ce créneau ne sera qu'en partie comptabilisé dans ton calcul d'heures, car seul un maximum de {{ due_duration_by_cycle | duration_from_minutes }} est comptabilisé par cycle.</p>
-              {% endif %}
+            <div class="alert card red lighten-4 red-text text-darken-4">
+                <div class="card-content">
+                    {% if not shift_service.canBookDuration(beneficiary, shift_service.getMinimalShiftDuration, cycle) %}
+                        <span class="card-title">Attention, tu as déjà fait ton quota d'heures sur ce cycle.</span>
+                        <p>Ce créneau ne sera pas comptabilisé dans ton calcul d'heures car seul un maximum de {{ due_duration_by_cycle | duration_from_minutes }} est comptabilisé par cycle.</p>
+                    {% else %}
+                        <span class="card-title">Attention, avec ce créneau tu dépasseras les {{ due_duration_by_cycle | duration_from_minutes }} de bénévolat sur ton cycle.</span>
+                        <p>Ce créneau ne sera qu'en partie comptabilisé dans ton calcul d'heures, car seul un maximum de {{ due_duration_by_cycle | duration_from_minutes }} est comptabilisé par cycle.</p>
+                    {% endif %}
+                </div>
             </div>
-          </div>
         {% endif %}
 
-        {% if availableShifts | length == 1 %}
+        {% if bookableShifts | length == 1 %}
             {% if not firstBookable.formation and beneficiary.formations | length %}
-                <div class="row">
-                    <div class="col s12">
-                        <div class="card-panel teal warning">
-                            <span class="white-text">
-                                <i class="material-icons">warning</i>
-                                Ce créneau n'est <b>pas</b> qualifié.
-                                <br>
-                                {{ beneficiary.firstname }} a {% if beneficiary.formations | length == 1 %}une formation{% else %}des formations{% endif %} ({{ beneficiary.formations | join(', ')}}).
-                                <br>
-                                Tes compétences sont précieuses, pense si possible à les valoriser sur <b>un créneau qualifié</b>.
-                            </span>
-                        </div>
-                    </div>
+                <div class="card-panel teal warning">
+                    <span class="white-text">
+                        <i class="material-icons">warning</i>
+                        Ce créneau n'est <b>pas</b> qualifié.
+                        <br>
+                        {{ beneficiary.firstname }} a {% if beneficiary.formations | length == 1 %}une formation{% else %}des formations{% endif %} ({{ beneficiary.formations | join(', ')}}).
+                        <br>
+                        Tes compétences sont précieuses, pense si possible à les valoriser sur <b>un créneau qualifié</b>.
+                    </span>
                 </div>
             {% endif %}
         {% endif %}
@@ -61,12 +57,13 @@
                 {% endif %}
             {% endif %}
             <p>Nombre de places restantes : {{ nbBookableShifts }}/{{ nbShifts }}</p>
-            {% for availableShift in availableShifts %}
+            {% for bookableShift in bookableShifts %}
                 <div>
-                    <label for="{{ availableShift.id }}" style="color: #5f5a5a; font-weight: 600;">
-                        <input type="radio" id="{{ availableShift.id }}" class="checkedFormation" name="formation" value="{{ availableShift.id }}" />
-                        {% if availableShift.formation %}
-                            <span>{{ availableShift.formation.name }}</span>
+                    {{ bookableShift.getShifter() }}
+                    <label for="{{ bookableShift.id }}" style="color: #5f5a5a; font-weight: 600;">
+                        <input type="radio" id="{{ bookableShift.id }}" class="checkedFormation" name="formation" value="{{ bookableShift.id }}" />
+                        {% if bookableShift.formation %}
+                            <span>{{ bookableShift.formation.name }}</span>
                         {% else %}
                             <span>sans formation particulière</span>
                         {% endif %}

--- a/app/Resources/views/booking/_partial/shift.html.twig
+++ b/app/Resources/views/booking/_partial/shift.html.twig
@@ -7,7 +7,7 @@
      data-offset="{{ (((bucket.start|date('G')-start)*60 + bucket.start|date('i'))/60) }}" data-length="{{ (100/(end-start+1)) }}"
      style="width:{{ (bucket.duration / 60) * (100/(end-start+1)) }}%;left:{{ (((bucket.start|date('G')-start)*60 + bucket.start|date('i'))/60)*(100/(end-start+1)) }}%;top: {{ line*10 }}px;">
     <div style="height:2px; width: 100%;position: absolute;top:-2px;">
-        {% if nbBookedShifts %}
+        {% if nbBookedShifts > 0 %}
             {% for shift in 1..nbBookedShifts %}
                 <div class="green lighten-3 left" style="height:100%; width: {{ 100/(nbShifts) }}%"></div>
             {% endfor %}

--- a/app/Resources/views/booking/_partial/shift.html.twig
+++ b/app/Resources/views/booking/_partial/shift.html.twig
@@ -1,17 +1,14 @@
-<div
-        {% set nbShifter = bucket.shifterCount() %}
-        {% set nbShifts = bucket.shifts | length %}
-        {% set nbBookableShifts = shift_service.getBookableShiftsCount(bucket) %}
-        {% set nbBookedShifts = nbShifts - nbBookableShifts %}
-        {% set firstBookableShift = shift_service.firstBookable(bucket, beneficiary) %}
-        data-offset="{{ (((bucket.start|date('G')-start)*60 + bucket.start|date('i'))/60) }}"
-        data-length="{{ (100/(end-start+1)) }}"
-        style="width:{{ (bucket.duration / 60) * (100/(end-start+1)) }}%;
-                left:{{ (((bucket.start|date('G')-start)*60 + bucket.start|date('i'))/60)*(100/(end-start+1)) }}%;
-                top: {{ line*10 }}px;" class="shift-bucket">
+{% set nbShifter = bucket.shifterCount() %}
+{% set nbShifts = bucket.shifts | length %}
+{% set nbBookableShifts = shift_service.getBookableShiftsCount(bucket) %}
+{% set nbBookedShifts = nbShifts - nbBookableShifts %}
+{% set firstBookableShift = shift_service.firstBookable(bucket, beneficiary) %}
+<div class="shift-bucket"
+     data-offset="{{ (((bucket.start|date('G')-start)*60 + bucket.start|date('i'))/60) }}" data-length="{{ (100/(end-start+1)) }}"
+     style="width:{{ (bucket.duration / 60) * (100/(end-start+1)) }}%;left:{{ (((bucket.start|date('G')-start)*60 + bucket.start|date('i'))/60)*(100/(end-start+1)) }}%;top: {{ line*10 }}px;">
     <div style="height:2px; width: 100%;position: absolute;top:-2px;">
-        {% if nbBookableShifts < nbShifts %}
-            {% for shifter in 1..(nbShifts - nbBookableShifts) %}
+        {% if nbBookedShifts %}
+            {% for shift in 1..nbBookedShifts %}
                 <div class="green lighten-3 left" style="height:100%; width: {{ 100/(nbShifts) }}%"></div>
             {% endfor %}
         {% endif %}

--- a/src/AppBundle/Entity/ShiftBucket.php
+++ b/src/AppBundle/Entity/ShiftBucket.php
@@ -165,9 +165,13 @@ class ShiftBucket
         return $this->shifts->first()->getDuration();
     }
 
-    public function canBookInterval(Beneficiary $beneficiary) // check if none of the shifts belong to the beneficiary ?
+    /**
+     * - check that none of the shifts belong to the beneficiary
+     * - check that the beneficiary doesn't already have a shift in the same interval
+     */
+    public function canBookInterval(Beneficiary $beneficiary)
     {
-        $alreadyBooked =  $beneficiary->getShifts()->exists(function ($key, Shift $shift) {
+        $alreadyBooked = $beneficiary->getShifts()->exists(function ($key, Shift $shift) {
             return $shift->getStart() == $this->getStart() && $shift->getEnd() == $this->getEnd();
         });
         $alreadyReserved = $beneficiary->getReservedShifts()->exists(function ($key, Shift $shift) {


### PR DESCRIPTION
### Quoi ?

Dans la fonction `ShiftService.isShiftBookable()` il n'y avait pas le cas où le `shift` avait déjà un "shifter", et donc n'est pas bookable.

En local j'avais des incohérences dû à cela

J'ai aussi fait quelques modifs de "cleanup" dans les templates
- renommé `availableShifts` en `bookableShifts`
- alignement

