### PR TITLE
Shift : enlever le champ 'reason' inutilisé

### DIFF
--- a/app/DoctrineMigrations/Version20230126114831_shift_reason_remove.php
+++ b/app/DoctrineMigrations/Version20230126114831_shift_reason_remove.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20230126114831 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE shift DROP reason');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE shift ADD reason VARCHAR(255) CHARACTER SET utf8mb4 DEFAULT NULL COLLATE `utf8mb4_unicode_ci`');
+    }
+}

--- a/src/AppBundle/Entity/Shift.php
+++ b/src/AppBundle/Entity/Shift.php
@@ -44,11 +44,6 @@ class Shift
     private $bookedTime;
 
     /**
-     * @var string
-     */
-    private $reason;
-
-    /**
      * @var bool
      *
      * @ORM\Column(name="was_carried_out", type="boolean", options={"default" : 0})
@@ -224,30 +219,6 @@ class Shift
     public function getBookedTime()
     {
         return $this->bookedTime;
-    }
-
-    /**
-     * Set reason
-     *
-     * @param string $reason
-     *
-     * @return BookedShift
-     */
-    public function setreason($reason)
-    {
-        $this->reason = $reason;
-
-        return $this;
-    }
-
-    /**
-     * Get reason
-     *
-     * @return string
-     */
-    public function getreason()
-    {
-        return $this->reason;
     }
 
     /**


### PR DESCRIPTION
Le champ `Shift.reason` ne semble pas utiliser.
Enlever pour éviter de s'emmêler avec `ShiftFreeLog.reason`