### PR TITLE
Différencier les bucket vérrouillés de complets

### DIFF
--- a/app/Resources/views/booking/_partial/disabled_shift.html.twig
+++ b/app/Resources/views/booking/_partial/disabled_shift.html.twig
@@ -1,20 +1,24 @@
 {% set nbShifts = bucket.shifts | length %}
 {% set nbBookableShifts = shift_service.getBookableShifts(bucket) | length %}
-{% set nbBookedShifts = nbShifts - nbBookableShifts %}
+
 <div class="tooltipped" data-tooltip="{{ bucket.sortedShifts.first.job.name }} - {% if nbBookableShifts == 0 %}complet{% else %}inaccessible pour {{ beneficiary.firstname }}{% endif %}"
         data-offset="{{ (((bucket.start|date('G')-start)*60 + bucket.start|date('i'))/60) }}"
         data-length="{{ (100/(end-start+1)) }}"
-        style="padding: 0 1px;width:{{ (bucket.duration / 60) * (100/(end-start+1)) }}%;position: absolute;
-                left:{{ (((bucket.start|date('G')-start)*60 + bucket.start|date('i'))/60)*(100/(end-start+1)) }}%;
-                top: {{ line*10 }}px;">
+        style="padding: 0 1px;width:{{ (bucket.duration / 60) * (100/(end-start+1)) }}%;position: absolute;left:{{ (((bucket.start|date('G')-start)*60 + bucket.start|date('i'))/60)*(100/(end-start+1)) }}%;top: {{ line*10 }}px;">
     <div class="z-depth-1 grey lighten-3" style="height:40px;position: relative; cursor: not-allowed">
-
         <div class="shift-block grey-text text-lighten-1">
-            <i class="material-icons tiny">lock</i><span class="small hide-on-med-and-up" style="font-size: 10px">
-                    {% if bucket.start|date('i') == '00' %}{{ bucket.start|date('G\\h') }}{% else %}{{ bucket.start|date('G\\hi') }}{% endif %}
+            {% if bucket.first.locked %}
+                <i class="material-icons tiny">lock</i>
+            {% elseif nbBookableShifts == 0 %}
+                <i class="material-icons tiny">check</i>
+            {% endif %}
+            <span class="small hide-on-med-and-up" style="font-size: 10px">
+                {% if bucket.start|date('i') == '00' %}{{ bucket.start|date('G\\h') }}{% else %}{{ bucket.start|date('G\\hi') }}{% endif %}
                 {% if bucket.end|date('i') == '00' %}{{ bucket.end|date('G\\h') }}{% else %}{{ bucket.end|date('G\\hi') }}{% endif %}
-                </span>
-            <span class="hide-on-small-and-down">{{ bucket.start|date('G\\hi') }} - {{ bucket.end|date('G\\hi') }}</span>
+            </span>
+            <span class="hide-on-small-and-down">
+                {{ bucket.start|date('G\\hi') }} - {{ bucket.end|date('G\\hi') }}
+            </span>
         </div>
         <div class="shift-block">
             <div class="hide-on-med-and-down">

--- a/app/Resources/views/booking/_partial/list.html.twig
+++ b/app/Resources/views/booking/_partial/list.html.twig
@@ -54,7 +54,7 @@
                                     {% if shift_service.isBucketBookable(bucket, beneficiary) or not beneficiary %}
                                         {% include "booking/_partial/shift.html.twig" with { beneficiary: beneficiary, user: app.user, bucket: bucket, start: hours|first, end: hours|last, line:l, cycle: current_cycle, display_names: display_names } %}
                                     {% else %}
-                                        {% include "booking/_partial/disabled_shift.html.twig" with { bucket: bucket,start: hours|first, end: hours|last, line:l, display_names: display_names  } %}
+                                        {% include "booking/_partial/disabled_shift.html.twig" with { bucket: bucket,start: hours|first, end: hours|last, line:l, display_names: display_names } %}
                                     {% endif %}
                                 {% endfor %}
                             </div>

--- a/app/Resources/views/booking/_partial/shift.html.twig
+++ b/app/Resources/views/booking/_partial/shift.html.twig
@@ -23,13 +23,15 @@
                     {% if bucket.start|date('i') == '00' %}{{ bucket.start|date('G\\h') }}{% else %}{{ bucket.start|date('G\\hi') }}{% endif %}
                     {% if bucket.end|date('i') == '00' %}{{ bucket.end|date('G\\h') }}{% else %}{{ bucket.end|date('G\\hi') }}{% endif %}
                 </span>
-                <span class="hide-on-small-and-down">{{ bucket.start|date('G\\hi') }} - {{ bucket.end|date('G\\hi') }}</span><br>
-                {% if (nbShifter == 0) %}
+                <span class="hide-on-small-and-down">{{ bucket.start|date('G\\hi') }} - {{ bucket.end|date('G\\hi') }}</span>
+                <br>
+                {% if bucket.first.locked %}
+                    <i class="material-icons tiny">lock</i><span class="hide-on-small-and-down">&nbsp;vérouillé</span>
+                {% elseif (nbShifter == 0) %}
                     <span class="red-text"><i class="material-icons tiny">warning</i><span class="hide-on-small-and-down">&nbsp;sous-effectif</span></span>
                 {% elseif (nbShifter < nbShifts/2) %}
                     <span class="orange-text"><i class="material-icons tiny">warning</i><span class="hide-on-small-and-down">&nbsp;sous-effectif</span></span>
-                {% endif %}
-                {% if nbBookableShifts == 0 %}
+                {% elseif nbBookableShifts == 0 %}
                     <span class="green-text"><i class="material-icons tiny">check</i>&nbsp;complet</span>
                 {% endif %}
             </div>

--- a/app/Resources/views/booking/_partial/shift.html.twig
+++ b/app/Resources/views/booking/_partial/shift.html.twig
@@ -3,6 +3,7 @@
 {% set nbBookableShifts = shift_service.getBookableShiftsCount(bucket) %}
 {% set nbBookedShifts = nbShifts - nbBookableShifts %}
 {% set firstBookableShift = shift_service.firstBookable(bucket, beneficiary) %}
+
 <div class="shift-bucket"
      data-offset="{{ (((bucket.start|date('G')-start)*60 + bucket.start|date('i'))/60) }}" data-length="{{ (100/(end-start+1)) }}"
      style="width:{{ (bucket.duration / 60) * (100/(end-start+1)) }}%;left:{{ (((bucket.start|date('G')-start)*60 + bucket.start|date('i'))/60)*(100/(end-start+1)) }}%;top: {{ line*10 }}px;">


### PR DESCRIPTION
### Quoi ?

Différencier les bucket (lot de créneaux) qui sont verrouillés, vs ceux qui sont inaccessibles (car bucket complet, ou requiert une formation, ...)

### Pourquoi ?

Pour clarifier les raisons (multiples) qu'un créneau soit inaccessible.

Il reste d'ailleurs à expliciter la règle : "pas possible de réserver de créneau si l'on en a déjà un dans la même plage horaire"

### Captures d'écran

|Page|Avant|Après|
|---|---|---|
|Booking (1 créneau "vérouillé" et 1 créneau "complet")|![Screenshot from 2023-01-26 23-34-47](https://user-images.githubusercontent.com/7147385/214966307-ae0c5429-5105-40bb-910d-d108682a5b54.png)|![Screenshot from 2023-01-26 23-33-59](https://user-images.githubusercontent.com/7147385/214966385-a292fa11-adff-4344-963e-aacb4d0f94d1.png)|
|Planning (idem) (connecté ou anonyme)|![Screenshot from 2023-01-26 23-46-29](https://user-images.githubusercontent.com/7147385/214967963-d98b66eb-c0c8-4ada-8359-4a47c6db6127.png)|![Screenshot from 2023-01-26 23-46-43](https://user-images.githubusercontent.com/7147385/214967978-01bb9452-d22c-4c9f-b3dc-e3aafc90bf46.png)|