### PR TITLE
Renommer shift_dismiss en shift_free

### DIFF
--- a/app/Resources/views/booking/_partial/home_shift_card.html.twig
+++ b/app/Resources/views/booking/_partial/home_shift_card.html.twig
@@ -16,27 +16,27 @@
         {% if not shift.fixe or shift.isUpcoming %}
             <div class="card-action">
                 {% if not shift.fixe %}
-                    <a href="#dismiss{{ shift.id }}" class="modal-trigger btn-flat red white-text" title="Annuler">Annuler</a>
+                    <a href="#free{{ shift.id }}" class="modal-trigger btn-flat red white-text" title="Annuler">Annuler</a>
                 {% endif %}
                 {% if shift.isUpcoming %}
                     <a href="#contact{{ shift.id }}" class="modal-trigger btn-flat" title="Contacter les bénévoles du créneau"><i class="material-icons">email</i></a>
                 {% endif %}
             </div>
-            <div id="dismiss{{ shift.id }}" class="modal black-text">
-                {{ form_start(shift_dismiss_forms[shift.id]) }}
+            <div id="free{{ shift.id }}" class="modal black-text">
+                {{ form_start(shift_free_forms[shift.id]) }}
                     <div class="modal-content">
                         <h5>Je ne peux pas faire mon créneau</h5>
                         <div class="input-field">
-                            {{ form_label(shift_dismiss_forms[shift.id].reason) }}
-                            {{ form_errors(shift_dismiss_forms[shift.id].reason) }}
-                            {{ form_widget(shift_dismiss_forms[shift.id].reason) }}
+                            {{ form_label(shift_free_forms[shift.id].reason) }}
+                            {{ form_errors(shift_free_forms[shift.id].reason) }}
+                            {{ form_widget(shift_free_forms[shift.id].reason) }}
                         </div>
                     </div>
                     <div class="modal-footer">
                         <a href="#!" class="modal-action modal-close waves-effect waves-green btn-flat grey-text">Annuler</a>
                         <button type="submit" class="modal-action modal-close waves-effect waves-green btn red">Oui, je me désiste !</button>
                     </div>
-                {{ form_end(shift_dismiss_forms[shift.id]) }}
+                {{ form_end(shift_free_forms[shift.id]) }}
             </div>
         {% endif %}
     {% endif %}

--- a/src/AppBundle/Controller/BookingController.php
+++ b/src/AppBundle/Controller/BookingController.php
@@ -653,7 +653,7 @@ class BookingController extends Controller
     private function createShiftFreeForm(Shift $shift)
     {
         return $this->get('form.factory')->createNamedBuilder('shift_free_forms_' . $shift->getId())
-            ->setAction($this->generateUrl('shift_free', array('id' => $shift->getId())))
+            ->setAction($this->generateUrl('shift_free_admin', array('id' => $shift->getId())))
             ->add('reason', TextareaType::class, array('required' => false, 'label' => 'Justification éventuelle', 'attr' => array('class' => 'materialize-textarea')))
             ->setMethod('POST')
             ->getForm();

--- a/src/AppBundle/Controller/BookingController.php
+++ b/src/AppBundle/Controller/BookingController.php
@@ -394,7 +394,7 @@ class BookingController extends Controller
         $shiftFreeForms = [];
         $shiftValidateInvalidateForms = [];
         foreach ($shifts as $shift) {
-            $shiftBookForms[$shift->getId()] = $this->createShiftBookForm($shift)->createView();
+            $shiftBookForms[$shift->getId()] = $this->createShiftBookAdminForm($shift)->createView();
             $shiftDeleteForms[$shift->getId()] = $this->createShiftDeleteForm($shift)->createView();
             $shiftFreeForms[$shift->getId()] = $this->createShiftFreeAdminForm($shift)->createView();
             $shiftValidateInvalidateForms[$shift->getId()] = $this->createShiftValidateInvalidateForm($shift)->createView();
@@ -597,13 +597,13 @@ class BookingController extends Controller
 
     /**
      * Creates a form to book a shift entity.
-     * // TODO: how to avoid having same createShiftBookForm in ShiftController ?
+     * // TODO: how to avoid having same createShiftBookAdminForm in ShiftController ?
      *
      * @param Shift $shift The shift entity
      *
      * @return \Symfony\Component\Form\Form The form
      */
-    private function createShiftBookForm(Shift $shift)
+    private function createShiftBookAdminForm(Shift $shift)
     {
         $form = $this->get('form.factory')->createNamedBuilder('shift_book_forms_' . $shift->getId())
             ->setAction($this->generateUrl('shift_book_admin', array('id' => $shift->getId())))

--- a/src/AppBundle/Controller/BookingController.php
+++ b/src/AppBundle/Controller/BookingController.php
@@ -70,15 +70,15 @@ class BookingController extends Controller
         $shifts_by_cycle = $em->getRepository('AppBundle:Shift')->findShiftsByCycles($membership, $preceding_previous_cycle_start, $next_cycle_end);
         $period_positions = $em->getRepository('AppBundle:PeriodPosition')->findByBeneficiaries($beneficiaries);
 
-        $shiftDismissForms = [];
+        $shiftFreeForms = [];
         foreach ($shifts_by_cycle as $key => $shifts) {
             foreach ($shifts as $shift) {
-                $shiftDismissForms[$shift->getId()] = $this->createShiftDismissForm($shift)->createView();
+                $shiftFreeForms[$shift->getId()] = $this->createShiftFreeForm($shift)->createView();
             }
         }
 
         return $this->render('booking/home_booked_shifts.html.twig', array(
-            'shift_dismiss_forms' => $shiftDismissForms,
+            'shift_free_forms' => $shiftFreeForms,
             'period_positions' => $period_positions,
             'shiftsByCycle' => $shifts_by_cycle,
         ));
@@ -396,7 +396,7 @@ class BookingController extends Controller
         foreach ($shifts as $shift) {
             $shiftBookForms[$shift->getId()] = $this->createShiftBookForm($shift)->createView();
             $shiftDeleteForms[$shift->getId()] = $this->createShiftDeleteForm($shift)->createView();
-            $shiftFreeForms[$shift->getId()] = $this->createShiftFreeForm($shift)->createView();
+            $shiftFreeForms[$shift->getId()] = $this->createShiftFreeAdminForm($shift)->createView();
             $shiftValidateInvalidateForms[$shift->getId()] = $this->createShiftValidateInvalidateForm($shift)->createView();
         }
         $bucketAddForm = $this->get('form.factory')->createNamed(
@@ -644,13 +644,30 @@ class BookingController extends Controller
 
     /**
      * Creates a form to free a shift entity.
-     * // TODO: how to avoid having same createShiftFreeForm in ShiftController ?
+     * // TODO: how to avoid having similar createShiftFreeForm in ShiftController ?
      *
      * @param Shift $shift The shift entity
      *
      * @return \Symfony\Component\Form\Form The form
      */
     private function createShiftFreeForm(Shift $shift)
+    {
+        return $this->createFormBuilder()
+            ->setAction($this->generateUrl('shift_free', array('id' => $shift->getId())))
+            ->add('reason', TextareaType::class, array('required' => false, 'label' => 'Justification éventuelle', 'attr' => array('class' => 'materialize-textarea')))
+            ->setMethod('POST')
+            ->getForm();
+    }
+
+    /**
+     * Creates a form to free a shift entity (admin side).
+     * // TODO: how to avoid having same createShiftFreeAdminForm in ShiftController ?
+     *
+     * @param Shift $shift The shift entity
+     *
+     * @return \Symfony\Component\Form\Form The form
+     */
+    private function createShiftFreeAdminForm(Shift $shift)
     {
         return $this->get('form.factory')->createNamedBuilder('shift_free_forms_' . $shift->getId())
             ->setAction($this->generateUrl('shift_free_admin', array('id' => $shift->getId())))
@@ -674,23 +691,6 @@ class BookingController extends Controller
             ->add('validate', HiddenType::class, [
                 'data' => ($shift->getWasCarriedOut() ? 0 : 1),
             ])
-            ->setMethod('POST')
-            ->getForm();
-    }
-
-    /**
-     * Creates a form to dismiss a shift entity.
-     * // TODO: how to avoid having similar createShiftDismissForm in ShiftController ?
-     *
-     * @param Shift $shift The shift entity
-     *
-     * @return \Symfony\Component\Form\Form The form
-     */
-    private function createShiftDismissForm(Shift $shift)
-    {
-        return $this->createFormBuilder()
-            ->setAction($this->generateUrl('shift_dismiss', array('id' => $shift->getId())))
-            ->add('reason', TextareaType::class, array('required' => false, 'label' => 'Justification éventuelle', 'attr' => array('class' => 'materialize-textarea')))
             ->setMethod('POST')
             ->getForm();
     }

--- a/src/AppBundle/Controller/MembershipController.php
+++ b/src/AppBundle/Controller/MembershipController.php
@@ -170,7 +170,7 @@ class MembershipController extends Controller
         $shiftValidateInvalidateForms = [];
         foreach ($shifts_by_cycle as $shifts) {
             foreach ($shifts as $shift) {
-                $shiftFreeForms[$shift->getId()] = $this->createShiftFreeForm($shift)->createView();
+                $shiftFreeForms[$shift->getId()] = $this->createShiftFreeAdminForm($shift)->createView();
                 $shiftValidateInvalidateForms[$shift->getId()] = $this->createShiftValidateInvalidateForm($shift)->createView();
             }
         }
@@ -1180,14 +1180,14 @@ class MembershipController extends Controller
     }
 
     /**
-     * Creates a form to free a shift entity.
-     * // TODO: how to avoid having same createShiftFreeForm in ShiftController ?
+     * Creates a form to free a shift entity (admin side).
+     * // TODO: how to avoid having same createShiftFreeAdminForm in ShiftController ?
      *
      * @param Shift $shift The shift entity
      *
      * @return \Symfony\Component\Form\Form The form
      */
-    private function createShiftFreeForm(Shift $shift)
+    private function createShiftFreeAdminForm(Shift $shift)
     {
         return $this->get('form.factory')->createNamedBuilder('shift_free_forms_' . $shift->getId())
             ->setAction($this->generateUrl('shift_free_admin', array('id' => $shift->getId())))

--- a/src/AppBundle/Controller/MembershipController.php
+++ b/src/AppBundle/Controller/MembershipController.php
@@ -1190,7 +1190,7 @@ class MembershipController extends Controller
     private function createShiftFreeForm(Shift $shift)
     {
         return $this->get('form.factory')->createNamedBuilder('shift_free_forms_' . $shift->getId())
-            ->setAction($this->generateUrl('shift_free', array('id' => $shift->getId())))
+            ->setAction($this->generateUrl('shift_free_admin', array('id' => $shift->getId())))
             ->add('reason', TextareaType::class, array('required' => false, 'label' => 'Justification éventuelle', 'attr' => array('class' => 'materialize-textarea')))
             ->setMethod('POST')
             ->getForm();

--- a/src/AppBundle/Controller/ShiftController.php
+++ b/src/AppBundle/Controller/ShiftController.php
@@ -164,7 +164,7 @@ class ShiftController extends Controller
     }
 
     /**
-     * Book a shift admin.
+     * Book a shift (admin side).
      *
      * @Route("/{id}/book_admin", name="shift_book_admin", methods={"GET","POST"})
      * @Security("has_role('ROLE_SHIFT_MANAGER')")
@@ -241,11 +241,12 @@ class ShiftController extends Controller
     }
 
     /**
-     * free a shift.
+     * free a shift (admin side).
      *
-     * @Route("/{id}/free", name="shift_free", methods={"POST"})
+     * @Route("/{id}/free_admin", name="shift_free_admin", methods={"POST"})
+     * @Security("has_role('ROLE_SHIFT_MANAGER')")
      */
-    public function freeShiftAction(Request $request, Shift $shift)
+    public function freeShiftAdminAction(Request $request, Shift $shift)
     {
         $this->denyAccessUnlessGranted(ShiftVoter::FREE, $shift);
 
@@ -608,7 +609,7 @@ class ShiftController extends Controller
     private function createShiftFreeForm(Shift $shift)
     {
         $form = $this->get('form.factory')->createNamedBuilder('shift_free_forms_' . $shift->getId())
-            ->setAction($this->generateUrl('shift_free', array('id' => $shift->getId())))
+            ->setAction($this->generateUrl('shift_free_admin', array('id' => $shift->getId())))
             ->add('reason', TextareaType::class, array('required' => false, 'label' => 'Justification éventuelle', 'attr' => array('class' => 'materialize-textarea')))
             ->setMethod('POST');
 

--- a/src/AppBundle/Controller/ShiftController.php
+++ b/src/AppBundle/Controller/ShiftController.php
@@ -171,7 +171,7 @@ class ShiftController extends Controller
      */
     public function bookShiftAdminAction(Request $request, Shift $shift)
     {
-        $form = $this->createShiftBookForm($shift);
+        $form = $this->createShiftBookAdminForm($shift);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
@@ -266,6 +266,7 @@ class ShiftController extends Controller
             }
             // store shift beneficiary & reason
             $beneficiary = $shift->getShifter();
+            $fixe = $shift->isFixe();
             $reason = $form->get("reason")->getData();
 
             // free shift
@@ -276,7 +277,7 @@ class ShiftController extends Controller
             $em->flush();
 
             $dispatcher = $this->get('event_dispatcher');
-            $dispatcher->dispatch(ShiftFreedEvent::NAME, new ShiftFreedEvent($shift, $beneficiary, $reason));
+            $dispatcher->dispatch(ShiftFreedEvent::NAME, new ShiftFreedEvent($shift, $beneficiary, $fixe, $reason));
         } else {
             return $this->redirectToRoute('homepage');
         }
@@ -559,7 +560,7 @@ class ShiftController extends Controller
      *
      * @return \Symfony\Component\Form\Form The form
      */
-    private function createShiftBookForm(Shift $shift)
+    private function createShiftBookAdminForm(Shift $shift)
     {
         $form = $this->get('form.factory')->createNamedBuilder('shift_book_forms_' . $shift->getId())
             ->setAction($this->generateUrl('shift_book_admin', array('id' => $shift->getId())))

--- a/tests/AppBundle/Service/ShiftServiceTest.php
+++ b/tests/AppBundle/Service/ShiftServiceTest.php
@@ -108,7 +108,7 @@ class ShiftServiceTest extends TestCase
         $shiftService = $this
             ->getMockBuilder(ShiftService::class)
             ->setMethods(['isShiftEmpty', 'canBookDuration', 'isBeginner'])
-            ->setConstructorArgs([$this->em, $this->due_duration_by_cycle, $this->min_shift_duration, $this->new_users_start_as_beginner, $this->allow_extra_shifts, $this->max_time_in_advance_to_book_extra_shifts, $this->forbid_shift_overlap_time, $beneficiaryService, $membershipService])
+            ->setConstructorArgs([$this->em, $beneficiaryService, $membershipService, $this->due_duration_by_cycle, $this->min_shift_duration, $this->new_users_start_as_beginner, $this->allow_extra_shifts, $this->max_time_in_advance_to_book_extra_shifts, $this->forbid_shift_overlap_time])
             ->getMock();
         $shiftService->expects($this->any())
             ->method('isShiftEmpty')
@@ -153,7 +153,7 @@ class ShiftServiceTest extends TestCase
         $shiftService = $this
             ->getMockBuilder(ShiftService::class)
             ->setMethods(['hasPreviousValidShifts'])
-            ->setConstructorArgs([$this->em, $this->due_duration_by_cycle, $this->min_shift_duration, $newUserStartAsBeginner, $this->allow_extra_shifts, $this->max_time_in_advance_to_book_extra_shifts, $this->forbid_shift_overlap_time, $beneficiaryService, $membershipService])
+            ->setConstructorArgs([$this->em, $beneficiaryService, $membershipService, $this->due_duration_by_cycle, $this->min_shift_duration, $newUserStartAsBeginner, $this->allow_extra_shifts, $this->max_time_in_advance_to_book_extra_shifts, $this->forbid_shift_overlap_time])
             ->getMock()
         ;
 
@@ -182,7 +182,7 @@ class ShiftServiceTest extends TestCase
     {
         $date = new \DateTime();
         $date->add(new \DateInterval('P10D'));
-        $this->assertFalse($this->doTestHasPreviousValidShifts($date, true));
+        $this->assertFalse($this->doTestHasPreviousValidShifts($date));
     }
 
     public function testHasPreviousValidShiftsWithoutShift()
@@ -190,14 +190,13 @@ class ShiftServiceTest extends TestCase
         $this->assertFalse($this->doTestHasPreviousValidShifts(null));
     }
 
-    public function doTestHasPreviousValidShifts($shiftDate, $dismissed = false)
+    public function doTestHasPreviousValidShifts($shiftDate)
     {
         $shifts = new ArrayCollection();
 
         if ($shiftDate)
         {
             $shift = new Shift();
-            $shift->setIsDismissed($dismissed);
             $shift->setStart($shiftDate);
             $shifts->add($shift);
         }


### PR DESCRIPTION
### Quoi ?

Pour la libération de créneau, remplacer l'utilisation de "dismiss" par "free" (calquer le code avec `shift_book` / `shift_book_admin`)

### Pourquoi ?

- éviter d'utiliser 2 mots pour la même action
- permettra aussi dans `ShiftFreeLog.requestRoute` d'avoir "admin" qui apparaisse

### Recap des modifications

|Avant|Après|
|---|---|
|`@Route("/{id}/dismiss", name="shift_dismiss" ...)`|`@Route("/{id}/free", name="shift_free" ...)`|
|`@Route("/{id}/free", name="shift_free", methods={"POST"})`|`@Route("/{id}/free_admin", name="shift_free_admin", methods={"POST"})`|
|`createShiftDismissForm`|`createShiftFreeForm`|
|`createShiftFreeForm`|`createShiftFreeAdminForm`|
|`createShiftBookForm`|`createShiftBookAdminForm`|