### PR TITLE
TimeLog : ne pas toujours supprimer lors de onShiftInvalidated

### DIFF
--- a/src/AppBundle/Command/FixTimeLogCommand.php
+++ b/src/AppBundle/Command/FixTimeLogCommand.php
@@ -38,7 +38,7 @@ class FixTimeLogCommand extends ContainerAwareCommand
                     });
                     // Insert log if it doesn't exist fot this shift
                     if ($logs->count() == 0) {
-                        $log = $this->getContainer()->get('time_log_service')->initShiftTimeLog($shift, $shift->getStart(), "Créneau réalisé");
+                        $log = $this->getContainer()->get('time_log_service')->initShiftValidatedTimeLog($shift, $shift->getStart(), "Créneau réalisé");
                         $em->persist($log);
                         $countShiftLogs++;
                     }

--- a/src/AppBundle/Command/InitTimeLogCommand.php
+++ b/src/AppBundle/Command/InitTimeLogCommand.php
@@ -41,7 +41,7 @@ class InitTimeLogCommand extends ContainerAwareCommand
                 $current_cycle_end = $this->getContainer()->get('membership_service')->getEndOfCycle($member, 0);
                 $shifts = $em->getRepository('AppBundle:Shift')->findShiftsForMembership($member, $previous_cycle_start, $current_cycle_end);
                 foreach ($shifts as $shift) {
-                    $log = $this->getContainer()->get('time_log_service')->initShiftTimeLog($shift, $shift->getStart());
+                    $log = $this->getContainer()->get('time_log_service')->initShiftValidatedTimeLog($shift, $shift->getStart());
                     $em->persist($log);
                     $countShiftLogs++;
                 }

--- a/src/AppBundle/Controller/ShiftController.php
+++ b/src/AppBundle/Controller/ShiftController.php
@@ -264,7 +264,7 @@ class ShiftController extends Controller
                 $session->getFlashBag()->add("error", "Impossible de libérer le créneau car il n'est actuellement pas réservé.");
                 return $this->redirectToRoute("homepage");
             }
-            // store shift beneficiary & reason
+            // store shift beneficiary & reason (before shift free())
             $beneficiary = $shift->getShifter();
             $fixe = $shift->isFixe();
             $reason = $form->get("reason")->getData();
@@ -304,7 +304,7 @@ class ShiftController extends Controller
                 $success = false;
                 $message = "Impossible de libérer le créneau car il n'est actuellement pas réservé.";
             } else {
-                // store shift beneficiary & reason
+                // store shift beneficiary & reason (before shift free())
                 $beneficiary = $shift->getShifter();
                 $fixe = $shift->isFixe();
                 $reason = $form->get("reason")->getData();

--- a/src/AppBundle/Entity/Shift.php
+++ b/src/AppBundle/Entity/Shift.php
@@ -424,6 +424,16 @@ class Shift
     }
 
     /**
+     * Return true if the shift is in the future
+     *
+     * @return boolean
+     */
+    public function getIsFuture()
+    {
+        return !$this->getIsPastOrCurrent();
+    }
+
+    /**
      * Return true if the shift is not in the past, not current, and close enough
      *
      * @return boolean
@@ -444,7 +454,7 @@ class Shift
     {
         $futureDate = new \DateTime($duration);
         $futureDate->setTime(23, 59, 59);
-        return !$this->getIsPast() && !$this->getIsCurrent() && ($futureDate > $this->start);
+        return $this->getIsFuture() && ($this->start < $futureDate);
     }
 
     /**

--- a/src/AppBundle/Entity/TimeLog.php
+++ b/src/AppBundle/Entity/TimeLog.php
@@ -283,6 +283,13 @@ class TimeLog
                 } else {
                     return "Créneau (non renseigné)";
                 }
+            case self::TYPE_SHIFT_INVALIDATED:
+                if ($this->shift) {
+                    setlocale(LC_TIME, 'fr_FR.UTF8');
+                    return "Créneau *invalidé* " . $this->shift->getJob()->getName() . strftime(" du %d/%m/%y de %R", $this->shift->getStart()->getTimestamp()) . ' à ' . strftime("%R", $this->shift->getEnd()->getTimestamp()) . ' [' . $this->shift->getShifter() . ']';
+                } else {
+                    return "Créneau *invalidé* (non renseigné)";
+                }
             case self::TYPE_CYCLE_END:
                 return "Début de cycle";
             case self::TYPE_CYCLE_END_FROZEN:

--- a/src/AppBundle/Entity/TimeLog.php
+++ b/src/AppBundle/Entity/TimeLog.php
@@ -15,7 +15,8 @@ class TimeLog
 {
     const TYPE_CUSTOM = 0;
 
-    const TYPE_SHIFT = 1;
+    const TYPE_SHIFT_VALIDATED = 1;
+    const TYPE_SHIFT_INVALIDATED = 10;
 
     const TYPE_CYCLE_END = 2;
     const TYPE_CYCLE_END_FROZEN = 3;
@@ -275,7 +276,7 @@ class TimeLog
         switch ($this->type) {
             case self::TYPE_CUSTOM:
                 return $this->description;
-            case self::TYPE_SHIFT:
+            case self::TYPE_SHIFT_VALIDATED:
                 if ($this->shift) {
                     setlocale(LC_TIME, 'fr_FR.UTF8');
                     return "Créneau " . $this->shift->getJob()->getName() . strftime(" du %d/%m/%y de %R", $this->shift->getStart()->getTimestamp()) . ' à ' . strftime("%R", $this->shift->getEnd()->getTimestamp()) . ' [' . $this->shift->getShifter() . ']';

--- a/src/AppBundle/EventListener/TimeLogEventListener.php
+++ b/src/AppBundle/EventListener/TimeLogEventListener.php
@@ -113,7 +113,7 @@ class TimeLogEventListener
         if ($this->use_card_reader_to_validate_shifts) {
             // check that a TimeLog::TYPE_SHIFT_VALIDATED already exists
             // if true, create an inverse timelog
-            $shiftValidatedTimeLog = $shift->getTimeLogs()->filter(function (TimeLog $log) {
+            $shiftValidatedTimeLog = $shift->getTimeLogs()->filter(function (TimeLog $log) use ($member) {
                 return (($log->type == TimeLog::TYPE_SHIFT_VALIDATED) && ($log->getMembership() == $member));
             });
             if ($shiftValidatedTimeLog->count() > 0) {

--- a/src/AppBundle/EventListener/TimeLogEventListener.php
+++ b/src/AppBundle/EventListener/TimeLogEventListener.php
@@ -93,7 +93,12 @@ class TimeLogEventListener
     public function onShiftFreed(ShiftFreedEvent $event)
     {
         $this->logger->info("Time Log Listener: onShiftFreed");
-        $this->deleteShiftLogs($event->getShift(), $event->getMember());
+        if ($this->use_card_reader_to_validate_shifts) {
+            // do nothing!
+            // TimeLogs are created in onShiftValidated & onShiftInvalidated (should already be managed there)
+        } else {
+            $this->deleteShiftLogs($event->getShift(), $event->getMember());
+        }
     }
 
     /**

--- a/src/AppBundle/Service/TimeLogService.php
+++ b/src/AppBundle/Service/TimeLogService.php
@@ -26,6 +26,13 @@ class TimeLogService
         $this->due_duration_by_cycle = $due_duration_by_cycle;
     }
 
+    /**
+     * Initialize a log with the member data
+     * 
+     * @param Membership $member
+     * @param \DateTime $date
+     * @return TimeLog
+     */
     public function initTimeLog(Membership $member, \DateTime $date = null, $description = null)
     {
         $current_user = $this->tokenStorage->getToken() ? $this->tokenStorage->getToken()->getUser() : null;
@@ -46,11 +53,13 @@ class TimeLogService
     }
 
     /**
-     * Initialize a log with the shift data
+     * Initialize a "shift validation" log with the shift data
+     * 
      * @param Shift $shift
+     * @param \DateTime $date
      * @return TimeLog
      */
-    public function initShiftTimeLog(Shift $shift, \DateTime $date = null, $description = null)
+    public function initShiftValidatedTimeLog(Shift $shift, \DateTime $date = null, $description = null)
     {
         $log = $this->initTimeLog($shift->getShifter()->getMembership(), $date, $description);
         $log->setType(TimeLog::TYPE_SHIFT_VALIDATED);
@@ -61,7 +70,25 @@ class TimeLogService
     }
 
     /**
-     * Initialize a log with the member data
+     * Initialize an "shift invalidation" log with the shift data
+     * 
+     * @param Shift $shift
+     * @param \DateTime $date
+     * @return TimeLog
+     */
+    public function initShiftInvalidatedTimeLog(Shift $shift, \DateTime $date = null, $description = null)
+    {
+        $log = $this->initTimeLog($shift->getShifter()->getMembership(), $date, $description);
+        $log->setType(TimeLog::TYPE_SHIFT_INVALIDATED);
+        $log->setShift($shift);
+        $log->setTime(-1 * $shift->getDuration());
+
+        return $log;
+    }
+
+    /**
+     * Initialize a "cycle beginning" log with the member data
+     * 
      * @param Membership $member
      * @param \DateTime $date
      * @return TimeLog
@@ -76,7 +103,8 @@ class TimeLogService
     }
 
     /**
-     * Initialize a log with the member data
+     * Initialize a "current cycle beginning" log with the member data
+     * 
      * @param Membership $member
      * @return TimeLog
      */
@@ -89,7 +117,8 @@ class TimeLogService
     }
 
     /**
-     * Initialize a custom log with the member data
+     * Initialize a "custom" log with the member data
+     * 
      * @param Membership $member
      * @return TimeLog
      */

--- a/src/AppBundle/Service/TimeLogService.php
+++ b/src/AppBundle/Service/TimeLogService.php
@@ -53,7 +53,7 @@ class TimeLogService
     public function initShiftTimeLog(Shift $shift, \DateTime $date = null, $description = null)
     {
         $log = $this->initTimeLog($shift->getShifter()->getMembership(), $date, $description);
-        $log->setType(TimeLog::TYPE_SHIFT);
+        $log->setType(TimeLog::TYPE_SHIFT_VALIDATED);
         $log->setShift($shift);
         $log->setTime($shift->getDuration());
 


### PR DESCRIPTION
### Quoi ?

Dans certains cas, on souhaite garder une trâce de l'invalidation d'un créneau dans le passé, et ne pas supprimer complètement le log associé

Modifications apportées : 
- renommé `TimeLog::TYPE_SHIFT` en `TimeLog::TYPE_SHIFT_VALIDATED`
- nouveau `TimeLog::TYPE_SHIFT_INVALIDATED`
- nouvelle fonction `Shift.getIsFuture()`
- modifications de `TimeLogEventListener.onShiftInvalidated()` pour gérer différents cas