### PR TITLE
ShiftFreeLog : stocker si le créneau libéré était fixe ou pas

### DIFF
--- a/app/DoctrineMigrations/Version20230128132355_shiftfreelog_fixe.php
+++ b/app/DoctrineMigrations/Version20230128132355_shiftfreelog_fixe.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20230128132355 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE shiftfreelog ADD fixe TINYINT(1) DEFAULT \'0\' NOT NULL');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE shiftfreelog DROP fixe');
+    }
+}

--- a/app/Resources/views/admin/shiftfreelog/index.html.twig
+++ b/app/Resources/views/admin/shiftfreelog/index.html.twig
@@ -18,8 +18,11 @@
                 <th>Auteur</th>
                 <th>Créneau</th>
                 <th>Bénéficiaire</th>
+                {% if use_fly_and_fixed %}
+                    <th>Fixe</th>
+                {% endif %}
                 {% if is_granted("ROLE_ADMIN") %}
-                <th>Route</th>
+                    <th>Route</th>
                 {% endif %}
                 <th>Raison</th>
             </tr>
@@ -48,8 +51,11 @@
                         {{ shiftFreeLog.beneficiary }}
                     </a>
                 </td>
+                {% if use_fly_and_fixed %}
+                    <td>{{ shiftFreeLog.fixe }}</td>
+                {% endif %}
                 {% if is_granted("ROLE_ADMIN") %}
-                <td>{{ shiftFreeLog.requestRoute }}</td>
+                    <td>{{ shiftFreeLog.requestRoute }}</td>
                 {% endif %}
                 <td>{{ shiftFreeLog.reason }}</td>
             </tr>

--- a/src/AppBundle/Controller/JobController.php
+++ b/src/AppBundle/Controller/JobController.php
@@ -46,7 +46,6 @@ class JobController extends Controller
         $res["form"]->handleRequest($request);
 
         if ($res["form"]->isSubmitted() && $res["form"]->isValid()) {
-            var_dump($res["form"]->get("enabled")->getData());
             $res["enabled"] = $res["form"]->get("enabled")->getData();
         }
 

--- a/src/AppBundle/Controller/ShiftController.php
+++ b/src/AppBundle/Controller/ShiftController.php
@@ -259,6 +259,7 @@ class ShiftController extends Controller
             } else {
                 // store shift beneficiary & reason
                 $beneficiary = $shift->getShifter();
+                $fixe = $shift->isFixe();
                 $reason = $form->get("reason")->getData();
 
                 // shouldn't happen: in the UI, you need to first invalidate a shift before being able to free it
@@ -278,7 +279,7 @@ class ShiftController extends Controller
                 if ($wasCarriedOut) {
                     $dispatcher->dispatch(ShiftInvalidatedEvent::NAME, new ShiftInvalidatedEvent($shift, $beneficiary));
                 }
-                $dispatcher->dispatch(ShiftFreedEvent::NAME, new ShiftFreedEvent($shift, $beneficiary, $reason));
+                $dispatcher->dispatch(ShiftFreedEvent::NAME, new ShiftFreedEvent($shift, $beneficiary, $fixe, $reason));
 
                 $success = true;
                 $message = "Le créneau a bien été libéré !";
@@ -406,6 +407,7 @@ class ShiftController extends Controller
             }
             // store shift beneficiary & reason
             $beneficiary = $shift->getShifter();
+            $fixe = $shift->isFixe();
             $reason = $form->get("reason")->getData();
 
             // free shift
@@ -416,7 +418,7 @@ class ShiftController extends Controller
             $em->flush();
 
             $dispatcher = $this->get('event_dispatcher');
-            $dispatcher->dispatch(ShiftFreedEvent::NAME, new ShiftFreedEvent($shift, $beneficiary, $reason));
+            $dispatcher->dispatch(ShiftFreedEvent::NAME, new ShiftFreedEvent($shift, $beneficiary, $fixe, $reason));
         } else {
             return $this->redirectToRoute('homepage');
         }

--- a/src/AppBundle/Entity/ShiftFreeLog.php
+++ b/src/AppBundle/Entity/ShiftFreeLog.php
@@ -49,6 +49,13 @@ class ShiftFreeLog
     private $beneficiary;
 
     /**
+     * @var bool
+     *
+     * @ORM\Column(name="fixe", type="boolean", options={"default" : 0}, nullable=false)
+     */
+    private $fixe = false;
+
+    /**
      * @var string
      *
      * @ORM\Column(type="string", length=255, nullable=true)
@@ -114,6 +121,20 @@ class ShiftFreeLog
         $this->beneficiary = $beneficiary;
 
         return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isFixe(): ?bool {
+        return $this->fixe;
+    }
+
+    /**
+     * @param bool $fixe
+     */
+    public function setFixe(?bool $fixe): void {
+        $this->fixe = $fixe;
     }
 
     public function getReason(): ?string

--- a/src/AppBundle/Event/ShiftFreedEvent.php
+++ b/src/AppBundle/Event/ShiftFreedEvent.php
@@ -14,12 +14,14 @@ class ShiftFreedEvent extends Event
 
     private $shift;
     private $beneficiary;
+    private $fixe;
     private $reason;
 
-    public function __construct(Shift $shift, Beneficiary $beneficiary, $reason = null)
+    public function __construct(Shift $shift, Beneficiary $beneficiary, $fixe = false, $reason = null)
     {
         $this->shift = $shift;
         $this->beneficiary = $beneficiary;
+        $this->fixe = $fixe;
         $this->reason = $reason;
     }
 
@@ -48,7 +50,15 @@ class ShiftFreedEvent extends Event
     }
 
     /**
-     * @return
+     * @return boolean
+     */
+    public function getFixe()
+    {
+        return $this->fixe;
+    }
+
+    /**
+     * @return string|null
      */
     public function getReason()
     {

--- a/src/AppBundle/EventListener/ShiftFreeLogEventListener.php
+++ b/src/AppBundle/EventListener/ShiftFreeLogEventListener.php
@@ -30,7 +30,7 @@ class ShiftFreeLogEventListener
     public function onShiftFreed(ShiftFreedEvent $event)
     {
         $this->logger->info("Shift Free Log Listener: onShiftFreed");
-        $log = $this->container->get('shift_free_log_service')->initShiftFreeLog($event->getShift(), $event->getBeneficiary(), $event->getReason());
+        $log = $this->container->get('shift_free_log_service')->initShiftFreeLog($event->getShift(), $event->getBeneficiary(), $event->getFixe(), $event->getReason());
         $this->em->persist($log);
         $this->em->flush();
     }

--- a/src/AppBundle/Service/ShiftFreeLogService.php
+++ b/src/AppBundle/Service/ShiftFreeLogService.php
@@ -23,7 +23,7 @@ class ShiftFreeLogService
         $this->tokenStorage = $tokenStorage;
     }
 
-    public function initShiftFreeLog(Shift $shift, Beneficiary $beneficiary, $reason = null)
+    public function initShiftFreeLog(Shift $shift, Beneficiary $beneficiary, $fixe = false, $reason = null)
     {
         $current_user = $this->tokenStorage->getToken() ? $this->tokenStorage->getToken()->getUser() : null;
         $request = $this->requestStack->getCurrentRequest();
@@ -31,6 +31,7 @@ class ShiftFreeLogService
         $log = new ShiftFreeLog;
         $log->setShift($shift);
         $log->setBeneficiary($beneficiary);
+        $log->setFixe($fixe);
         if ($reason) {
             $log->setReason($reason);
         }


### PR DESCRIPTION
### Quoi ?

Cela concerne les épiceries qui ont `use_fly_and_fixed=true`

- nouveau champ `ShiftFreeLog.fixe`
- mise à jour de `ShiftFreedEvent`

### Pourquoi ?

Savoir si le créneau annulé était un créneau fixe du membre ou pas.