### PR TITLE
Renommer les urls admin de ShiftFreeLog & ShiftExemption

### DIFF
--- a/src/AppBundle/Controller/ShiftExemptionController.php
+++ b/src/AppBundle/Controller/ShiftExemptionController.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation\Session\Session;
 /**
  * Shiftexemption controller.
  *
- * @Route("admin/shiftexemption")
+ * @Route("admin/shifts/exemptions")
  */
 class ShiftExemptionController extends Controller
 {

--- a/src/AppBundle/Controller/ShiftFreeLogController.php
+++ b/src/AppBundle/Controller/ShiftFreeLogController.php
@@ -14,16 +14,15 @@ use Doctrine\ORM\Tools\Pagination\Paginator;
 /**
  * ShiftFreeLog controller.
  *
- * @Route("admin/shifts/logs")
+ * @Route("admin/shifts/freelogs")
  */
 class ShiftFreeLogController extends Controller
 {
     /**
      * Lists all ShiftFreeLog entities.
      *
-     * @Route("/", name="admin_shiftfreelog_index")
+     * @Route("/", name="admin_shiftfreelog_index", methods={"GET"})
      * @Security("has_role('ROLE_SHIFT_MANAGER')")
-     * @Method("GET")
      */
     public function indexAction(Request $request)
     {


### PR DESCRIPTION
### Quoi ?

|Avant|Après|
|---|---|
|`admin/shifts/logs`|`admin/shifts/freelogs`|
|`admin/shiftexemption`|`admin/shifts/exemptions`|

### Pourquoi ?

- avoir la même "racine" `shifts`
- clarifier la lecture des urls
- mettre tout au pluriel