### PR TITLE
Exemptions : filtre basique sur la liste des membres exemptés

### DIFF
--- a/app/DoctrineMigrations/Version20230130112101_shiftexemption_created_at.php
+++ b/app/DoctrineMigrations/Version20230130112101_shiftexemption_created_at.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20230130112101 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE shift_exemption ADD created_at DATETIME NOT NULL');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE shift_exemption DROP created_at');
+    }
+}

--- a/app/Resources/views/admin/job/list.html.twig
+++ b/app/Resources/views/admin/job/list.html.twig
@@ -29,10 +29,10 @@
                     </div>
                 </div>
                 {{ form_widget(filter_form.filter) }}
+                {{ form_end(filter_form) }}
             </div>
         </li>
     </ul>
-    {{ form_end(filter_form) }}
 
     <table class="responsive-table">
         <thead>

--- a/app/Resources/views/admin/membershipshiftexemption/index.html.twig
+++ b/app/Resources/views/admin/membershipshiftexemption/index.html.twig
@@ -40,35 +40,39 @@
                         <i class="material-icons" title="À venir">schedule</i>
                     {% endif %}
                 </td>
-                <td>{{ membershipShiftExemption.membership.beneficiaries | map(b => "<a href=\'#{path('member_show',{'member_number': b.membership.memberNumber})}\'>#{b}</a>") | join('<br/>') | raw }}</td>
+                <td>
+                    <a href="{{ path("member_show", { 'member_number': membershipShiftExemption.membership.memberNumber }) }}">
+                        {{ membershipShiftExemption.membership.beneficiaries | join('<br/>') | raw }}
+                    </a>
+                </td>
                 <td>{{ membershipShiftExemption.shiftExemption }}</td>
                 <td>{{ membershipShiftExemption.description }}</td>
                 <td>
                     {% if membershipShiftExemption.start %}
-                        {{ membershipShiftExemption.start|date('Y-m-d') }}
+                        {{ membershipShiftExemption.start | date('Y-m-d') }}
                     {% endif %}
                 </td>
                 <td>
                     {% if membershipShiftExemption.end %}
-                        {{ membershipShiftExemption.end|date('Y-m-d') }}
+                        {{ membershipShiftExemption.end | date('Y-m-d') }}
                     {% endif %}
                 </td>
                 <td>
                     {% if membershipShiftExemption.createdBy and membershipShiftExemption.createdBy.beneficiary %}
-                        <a href="{{ path("member_show",{'member_number': membershipShiftExemption.createdBy.beneficiary.membership.memberNumber}) }}">
+                        <a href="{{ path("member_show", { 'member_number': membershipShiftExemption.createdBy.beneficiary.membership.memberNumber }) }}">
                             {{ membershipShiftExemption.createdBy.beneficiary }}
                         </a>
                     {% else %}
-                        {{membershipShiftExemption.createdBy}}
+                        {{ membershipShiftExemption.createdBy }}
                     {% endif %}
                 </td>
-                <td>
-                    {% if membershipShiftExemption.createdAt %}
-                        {{ membershipShiftExemption.createdAt|date('Y-m-d H:i:s') }}
-                    {% endif %}
+                <td title="{{ membershipShiftExemption.createdAt | date('Y-m-d H:i:s') }}">
+                    {{ membershipShiftExemption.createdAt | date('Y-m-d') }}
                 </td>
                 <td>
-                    <a href="{{ path('admin_membershipshiftexemption_edit', { 'id': membershipShiftExemption.id }) }}"><i class="material-icons">edit</i>editer</a>
+                    <a href="{{ path('admin_membershipshiftexemption_edit', { 'id': membershipShiftExemption.id }) }}">
+                        <i class="material-icons">edit</i>Editer
+                    </a>
                 </td>
             </tr>
         {% endfor %}
@@ -93,7 +97,9 @@
 
     <ul>
         <li>
-            <a href="{{ path('admin_membershipshiftexemption_new') }}" class="btn"><i class="material-icons left">add</i>Ajouter une exemption</a>
+            <a href="{{ path('admin_membershipshiftexemption_new') }}" class="btn">
+                <i class="material-icons left">add</i>Ajouter une exemption
+            </a>
         </li>
     </ul>
 {% endblock %}

--- a/app/Resources/views/admin/membershipshiftexemption/index.html.twig
+++ b/app/Resources/views/admin/membershipshiftexemption/index.html.twig
@@ -27,7 +27,7 @@
                         </div>
                     </div>
                 </div>
-                {{ form_widget(filter_form.filter) }}
+                {{ form_widget(filter_form.submit) }}
                 {{ form_end(filter_form) }}
             </div>
         </li>

--- a/app/Resources/views/admin/membershipshiftexemption/index.html.twig
+++ b/app/Resources/views/admin/membershipshiftexemption/index.html.twig
@@ -71,12 +71,12 @@
                 <td>{{ membershipShiftExemption.description }}</td>
                 <td>
                     {% if membershipShiftExemption.start %}
-                        {{ membershipShiftExemption.start | date('Y-m-d') }}
+                        {{ membershipShiftExemption.start | date('d/m/Y') }}
                     {% endif %}
                 </td>
                 <td>
                     {% if membershipShiftExemption.end %}
-                        {{ membershipShiftExemption.end | date('Y-m-d') }}
+                        {{ membershipShiftExemption.end | date('d/m/Y') }}
                     {% endif %}
                 </td>
                 <td>
@@ -88,8 +88,8 @@
                         {{ membershipShiftExemption.createdBy }}
                     {% endif %}
                 </td>
-                <td title="{{ membershipShiftExemption.createdAt | date('Y-m-d H:i:s') }}">
-                    {{ membershipShiftExemption.createdAt | date('Y-m-d') }}
+                <td title="{{ membershipShiftExemption.createdAt | date('d/m/Y H:i') }}">
+                    {{ membershipShiftExemption.createdAt | date('d/m/Y') }}
                 </td>
                 <td>
                     <a href="{{ path('admin_membershipshiftexemption_edit', { 'id': membershipShiftExemption.id }) }}">

--- a/app/Resources/views/admin/membershipshiftexemption/index.html.twig
+++ b/app/Resources/views/admin/membershipshiftexemption/index.html.twig
@@ -11,12 +11,34 @@
 {% block content %}
     <h4>Liste des membres exempté.e.s de bénévolat ({{ membershipShiftExemptions | length }})</h4>
 
+    {# Filter form  --------- #}
+    <ul class="collapsible">
+        <li>
+            <div class="collapsible-header">
+                <i class="material-icons">tune</i>Filtres
+            </div>
+            <div class="collapsible-body">
+                {{ form_start(filter_form) }}
+                <div class="row">
+                    <div class="col s4">
+                        <div class="input-field">
+                            {{ form_widget(filter_form.shiftExemption) }}
+                            {{ form_label(filter_form.shiftExemption) }}
+                        </div>
+                    </div>
+                </div>
+                {{ form_widget(filter_form.filter) }}
+                {{ form_end(filter_form) }}
+            </div>
+        </li>
+    </ul>
+
     <table class="responsive-table">
         <thead>
             <tr>
                 <th>Etat</th>
                 <th>Membre</th>
-                <th>Raison</th>
+                <th>Motif</th>
                 <th>Description</th>
                 <th>Début</th>
                 <th>Fin</th>

--- a/app/Resources/views/admin/shiftexemption/index.html.twig
+++ b/app/Resources/views/admin/shiftexemption/index.html.twig
@@ -5,16 +5,17 @@
 {% block breadcrumbs %}
 <a href="{{ path('homepage') }}"><i class="material-icons">home</i></a><i class="material-icons">chevron_right</i>
 <a href="{{ path('admin') }}"><i class="material-icons">build</i>&nbsp;Administration</a><i class="material-icons">chevron_right</i>
-<i class="material-icons">list</i>&nbsp;Liste des exemptions de bénévolat
+<i class="material-icons">list</i>&nbsp;Liste des motifs d'exemptions de bénévolat
 {% endblock %}
 
 {% block content %}
-    <h4>Liste des exemptions de bénévolat ({{ shiftExemptions | length }})</h4>
+    <h4>Liste des motifs d'exemptions de bénévolat ({{ shiftExemptions | length }})</h4>
 
     <table class="responsive-table">
         <thead>
             <tr>
                 <th>Exemption</th>
+                <th>Nombre d'exemptions</th>
                 <th>Actions</th>
             </tr>
         </thead>
@@ -23,6 +24,7 @@
         {% for shiftExemption in shiftExemptions %}
             <tr>
                 <td>{{ shiftExemption.name }}</td>
+                <td>{{ shiftExemption.membershipShiftExemptions | length }}</td>
                 <td>
                     <a href="{{ path('admin_shiftexemption_edit', { 'id': shiftExemption.id }) }}"><i class="material-icons">edit</i>editer</a>
                 </td>

--- a/src/AppBundle/Controller/MembershipShiftExemptionController.php
+++ b/src/AppBundle/Controller/MembershipShiftExemptionController.php
@@ -41,7 +41,7 @@ class MembershipShiftExemptionController extends Controller
                 'multiple' => false,
                 'required' => false,
             ))
-            ->add('filter', SubmitType::class, array(
+            ->add('submit', SubmitType::class, array(
                 'label' => 'Filtrer',
                 'attr' => array('class' => 'btn', 'value' => 'filtrer')
             ))

--- a/src/AppBundle/Controller/MembershipShiftExemptionController.php
+++ b/src/AppBundle/Controller/MembershipShiftExemptionController.php
@@ -67,14 +67,15 @@ class MembershipShiftExemptionController extends Controller
         $em = $this->getDoctrine()->getManager();
         $filter = $this->filterFormFactory($request);
         $findByFilter = array();
+        $sort = 'createdAt';
+        $order = 'DESC';
 
-        if($filter["shiftExemption"]) {
+        if ($filter["shiftExemption"]) {
             $findByFilter["shiftExemption"] = $filter["shiftExemption"];
         }
 
         $page = $request->get('page', 1);
         $limit = 50;
-        $order = array('createdAt' => 'DESC');
 
         $nb_exemptions = $em->getRepository('AppBundle:MembershipShiftExemption')->count([]);
         if ($nb_exemptions == 0) {
@@ -84,7 +85,7 @@ class MembershipShiftExemptionController extends Controller
         }
 
         $membershipShiftExemptions = $em->getRepository('AppBundle:MembershipShiftExemption')
-            ->findBy($findByFilter, $order, $limit, ($page - 1) * $limit);
+            ->findBy($findByFilter, array($sort => $order), $limit, ($page - 1) * $limit);
 
         return $this->render('admin/membershipshiftexemption/index.html.twig', array(
             'membershipShiftExemptions' => $membershipShiftExemptions,

--- a/src/AppBundle/Controller/PeriodController.php
+++ b/src/AppBundle/Controller/PeriodController.php
@@ -120,6 +120,8 @@ class PeriodController extends Controller
     {
         $filter = $this->filterFormFactory($request);
         $periodsByDay = array();
+        $order = array('start' => 'ASC');
+
         for($i=0;$i<7;$i++){
             $findByFilter = array('dayOfWeek'=>$i);
 
@@ -128,9 +130,10 @@ class PeriodController extends Controller
             }
 
             $periodsByDay[$i] = $em->getRepository('AppBundle:Period')
-                ->findBy($findByFilter,array('start'=>'ASC'));
+                ->findBy($findByFilter, $order);
         }
-        return $this->render('admin/period/index.html.twig',array(
+
+        return $this->render('admin/period/index.html.twig', array(
             "periods_by_day" => $periodsByDay,
             "filter_form" => $filter['form']->createView(),
             "week_filter" => $filter['week'],

--- a/src/AppBundle/Entity/MembershipShiftExemption.php
+++ b/src/AppBundle/Entity/MembershipShiftExemption.php
@@ -44,7 +44,7 @@ class MembershipShiftExemption
     private $createdBy;
 
     /**
-     * @ORM\ManyToOne(targetEntity="ShiftExemption")
+     * @ORM\ManyToOne(targetEntity="ShiftExemption", inversedBy="membershipShiftExemptions")
      * @ORM\JoinColumn(name="shift_exemption_id", referencedColumnName="id")
      */
     private $shiftExemption;

--- a/src/AppBundle/Entity/ShiftExemption.php
+++ b/src/AppBundle/Entity/ShiftExemption.php
@@ -8,6 +8,7 @@ use Doctrine\ORM\Mapping as ORM;
  * ShiftExemption
  *
  * @ORM\Table(name="shift_exemption")
+ * @ORM\HasLifecycleCallbacks()
  * @ORM\Entity(repositoryClass="AppBundle\Repository\ShiftExemptionRepository")
  */
 class ShiftExemption
@@ -29,12 +30,33 @@ class ShiftExemption
     private $name;
 
     /**
+     * @ORM\OneToMany(targetEntity="MembershipShiftExemption", mappedBy="shiftExemption", cascade={"persist"})
+     */
+    private $membershipShiftExemptions;
+
+    /**
+     * @var \DateTime
+     *
+     * @ORM\Column(name="created_at", type="datetime")
+     */
+    private $createdAt;
+
+    /**
      * Define toString.
      *
      * @return string
      */
-    public function __toString() {
+    public function __toString()
+    {
         return $this->name;
+    }
+
+    /**
+     * @ORM\PrePersist
+     */
+    public function setCreatedAtValue()
+    {
+        $this->createdAt = new \DateTime();
     }
 
     /**
@@ -69,5 +91,25 @@ class ShiftExemption
     public function getName()
     {
         return $this->name;
+    }
+
+    /**
+     * Get membershipShiftExemptions
+     *
+     * @return \Doctrine\Common\Collections\Collection
+     */
+    public function getMembershipShiftExemptions()
+    {
+        return $this->membershipShiftExemptions;
+    }
+
+    /**
+     * Get createdAt
+     *
+     * @return \DateTime
+     */
+    public function getCreatedAt()
+    {
+        return $this->createdAt;
     }
 }


### PR DESCRIPTION
### Quoi ?

Modèle `MembershipShiftExemption` : 
- template : nouveau filtre en haut : par motif
- template : renommer "raison" en "motif"
- modèle : ajout du `inversedBy`

Modèle `ShiftExemption` : 
- template : nouvelle colonne "Nombre d'exemptions"
- modèle : ajout du `OneToMany` (inverse du `ManyToOne` du modèle MembershipShiftExemption)
- modèle : ajout de `createdAt`

### Capture d'écran

|Page|Image|
|---|---|
|MembershipShiftExemption|![Screenshot from 2023-01-30 13-32-18](https://user-images.githubusercontent.com/7147385/215477897-6f5629eb-a9ff-4798-b9eb-96d5b9fb56be.png)|
|ShiftExemption|![Screenshot from 2023-01-31 17-39-13](https://user-images.githubusercontent.com/7147385/215823878-c78afecb-3aa3-4596-8ffb-03d964549d85.png)|

