### PR TITLE
Annulations : filtre basique sur la liste des créneaux annulés

### DIFF
--- a/app/Resources/views/admin/job/list.html.twig
+++ b/app/Resources/views/admin/job/list.html.twig
@@ -21,11 +21,10 @@
                 {{ form_start(filter_form) }}
                 <div class="row">
                     <div class="col s6">
-                        {{ form_errors(filter_form.enabled) }}
-                        <label>
+                        <div class="input-field">
                             {{ form_widget(filter_form.enabled) }}
-                            <span>{{ filter_form.enabled.vars.label }}</span>
-                        </label>
+                            {{ form_label(filter_form.enabled) }}
+                        </div>
                     </div>
                 </div>
                 {{ form_widget(filter_form.filter) }}

--- a/app/Resources/views/admin/shiftfreelog/index.html.twig
+++ b/app/Resources/views/admin/shiftfreelog/index.html.twig
@@ -20,20 +20,42 @@
             <div class="collapsible-body">
                 {{ form_start(filter_form) }}
                 <div class="row">
-                    <div class="col s4">
-                        <div class="input-field">
-                            {{ form_widget(filter_form.beneficiary) }}
-                            {{ form_label(filter_form.beneficiary) }}
-                        </div>
-                    </div>
-                    {% if use_fly_and_fixed %}
-                        <div class="col s4">
-                            <div class="input-field">
-                                {{ form_widget(filter_form.fixe) }}
-                                {{ form_label(filter_form.fixe) }}
+                    <div class="col s12 m4">
+                        <h5>Annulation</h5>
+                        <div class="row">
+                            <div class="col s12">
+                                <div class="input-field">
+                                    {{ form_widget(filter_form.created_at) }}
+                                    {{ form_label(filter_form.created_at) }}
+                                </div>
                             </div>
                         </div>
-                    {% endif %}
+                    </div>
+                    <div class="col s12 m4">
+                        <h5>Créneau</h5>
+                        <div class="row">
+                            <div class="col s12">
+                                <div class="input-field">
+                                    {{ form_widget(filter_form.beneficiary) }}
+                                    {{ form_label(filter_form.beneficiary) }}
+                                </div>
+                            </div>
+                            <div class="col s12">
+                                <div class="input-field">
+                                    {{ form_widget(filter_form.shift_start_date) }}
+                                    {{ form_label(filter_form.shift_start_date) }}
+                                </div>
+                            </div>
+                            {% if use_fly_and_fixed %}
+                                <div class="col s12">
+                                    <div class="input-field">
+                                        {{ form_widget(filter_form.fixe) }}
+                                        {{ form_label(filter_form.fixe) }}
+                                    </div>
+                                </div>
+                            {% endif %}
+                        </div>
+                    </div>
                 </div>
                 {{ form_widget(filter_form.submit) }}
                 {{ form_row(filter_form._token) }}

--- a/app/Resources/views/admin/shiftfreelog/index.html.twig
+++ b/app/Resources/views/admin/shiftfreelog/index.html.twig
@@ -38,8 +38,9 @@
                         </div>
                     </div>
                 {% endif %}
-                {{ form_widget(filter_form.filter) }}
-                {{ form_end(filter_form) }}
+                {{ form_widget(filter_form.submit) }}
+                {{ form_row(filter_form._token) }}
+                {{ form_end(filter_form, {'render_rest': false}) }}
             </div>
         </li>
     </ul>

--- a/app/Resources/views/admin/shiftfreelog/index.html.twig
+++ b/app/Resources/views/admin/shiftfreelog/index.html.twig
@@ -26,18 +26,15 @@
                             {{ form_label(filter_form.beneficiary) }}
                         </div>
                     </div>
-                </div>
-                {% if use_fly_and_fixed %}
-                    <div class="row">
-                        <div class="col s6">
-                            {{ form_errors(filter_form.fixe) }}
-                            <label>
+                    {% if use_fly_and_fixed %}
+                        <div class="col s4">
+                            <div class="input-field">
                                 {{ form_widget(filter_form.fixe) }}
-                                <span>{{ filter_form.fixe.vars.label }}</span>
-                            </label>
+                                {{ form_label(filter_form.fixe) }}
+                            </div>
                         </div>
-                    </div>
-                {% endif %}
+                    {% endif %}
+                </div>
                 {{ form_widget(filter_form.submit) }}
                 {{ form_row(filter_form._token) }}
                 {{ form_end(filter_form, {'render_rest': false}) }}
@@ -65,8 +62,8 @@
         <tbody>
         {% for shiftFreeLog in shiftFreeLogs %}
             <tr>
-                <td>
-                    {{ shiftFreeLog.createdAt|date('d/m/Y H:i:s') }}
+                <td title="{{ shiftFreeLog.createdAt | date_fr_with_time }}">
+                    {{ shiftFreeLog.createdAt | date('d/m/Y') }}
                 </td>
                 <td>
                     <a href="{{ path("member_show",{'member_number': shiftFreeLog.beneficiary.membership.memberNumber}) }}">

--- a/app/Resources/views/admin/shiftfreelog/index.html.twig
+++ b/app/Resources/views/admin/shiftfreelog/index.html.twig
@@ -9,18 +9,40 @@
 {% endblock %}
 
 {% block content %}
-    <h4>Historique des annulations de créneaux</h4>
+    <h4>Historique des annulations de créneaux ({{ shiftFreeLogs | length }})</h4>
+
+    {# Filter form  --------- #}
+    <ul class="collapsible">
+        <li>
+            <div class="collapsible-header">
+                <i class="material-icons">tune</i>Filtres
+            </div>
+            <div class="collapsible-body">
+                {{ form_start(filter_form) }}
+                <div class="row">
+                    <div class="col s4">
+                        <div class="input-field">
+                            {{ form_widget(filter_form.beneficiary) }}
+                            {{ form_label(filter_form.beneficiary) }}
+                        </div>
+                    </div>
+                </div>
+                {{ form_widget(filter_form.filter) }}
+                {{ form_end(filter_form) }}
+            </div>
+        </li>
+    </ul>
 
     <table class="responsive-table">
         <thead>
             <tr>
                 <th>Date</th>
-                <th>Auteur</th>
-                <th>Créneau</th>
                 <th>Bénéficiaire</th>
+                <th>Créneau</th>
                 {% if use_fly_and_fixed %}
                     <th>Fixe</th>
                 {% endif %}
+                <th>Auteur</th>
                 {% if is_granted("ROLE_ADMIN") %}
                     <th>Route</th>
                 {% endif %}
@@ -35,6 +57,17 @@
                     {{ shiftFreeLog.createdAt|date('d/m/Y H:i:s') }}
                 </td>
                 <td>
+                    <a href="{{ path("member_show",{'member_number': shiftFreeLog.beneficiary.membership.memberNumber}) }}">
+                        {{ shiftFreeLog.beneficiary }}
+                    </a>
+                </td>
+                <td>
+                    {{ shiftFreeLog.shift.job }} - {{ shiftFreeLog.shift.start | date('d/m/Y') }} de {{ shiftFreeLog.shift.start | date('H:i') }} à {{ shiftFreeLog.shift.end | date('H:i') }}
+                </td>
+                {% if use_fly_and_fixed %}
+                    <td>{{ shiftFreeLog.fixe }}</td>
+                {% endif %}
+                <td>
                     {% if shiftFreeLog.createdBy and shiftFreeLog.createdBy.beneficiary %}
                         <a href="{{ path("member_show",{'member_number': shiftFreeLog.createdBy.beneficiary.membership.memberNumber}) }}">
                             {{ shiftFreeLog.createdBy.beneficiary }}
@@ -43,17 +76,6 @@
                         {{ shiftFreeLog.createdBy }}
                     {% endif %}
                 </td>
-                <td>
-                    {{ shiftFreeLog.shift.job }} - {{ shiftFreeLog.shift.start | date('d/m/Y \\d\\e H:i')}} à {{ shiftFreeLog.shift.end | date('H:i')}}
-                </td>
-                <td>
-                    <a href="{{ path("member_show",{'member_number': shiftFreeLog.beneficiary.membership.memberNumber}) }}">
-                        {{ shiftFreeLog.beneficiary }}
-                    </a>
-                </td>
-                {% if use_fly_and_fixed %}
-                    <td>{{ shiftFreeLog.fixe }}</td>
-                {% endif %}
                 {% if is_granted("ROLE_ADMIN") %}
                     <td>{{ shiftFreeLog.requestRoute }}</td>
                 {% endif %}

--- a/app/Resources/views/admin/shiftfreelog/index.html.twig
+++ b/app/Resources/views/admin/shiftfreelog/index.html.twig
@@ -27,6 +27,17 @@
                         </div>
                     </div>
                 </div>
+                {% if use_fly_and_fixed %}
+                    <div class="row">
+                        <div class="col s6">
+                            {{ form_errors(filter_form.fixe) }}
+                            <label>
+                                {{ form_widget(filter_form.fixe) }}
+                                <span>{{ filter_form.fixe.vars.label }}</span>
+                            </label>
+                        </div>
+                    </div>
+                {% endif %}
                 {{ form_widget(filter_form.filter) }}
                 {{ form_end(filter_form) }}
             </div>

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -124,6 +124,7 @@ doctrine:
     auto_mapping: true
     dql:
       string_functions:
+        DATE_FORMAT: DoctrineExtensions\Query\Mysql\DateFormat
         MONTH: DoctrineExtensions\Query\Mysql\Month
         YEAR: DoctrineExtensions\Query\Mysql\Year
         WEEK: DoctrineExtensions\Query\Mysql\Week

--- a/src/AppBundle/Controller/JobController.php
+++ b/src/AppBundle/Controller/JobController.php
@@ -10,7 +10,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Validator\Constraints\DateTime;
-use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 
 /**
@@ -33,9 +33,13 @@ class JobController extends Controller
         // filter creation ----------------------
         $res["form"] = $this->createFormBuilder()
             ->setAction($this->generateUrl('job_list'))
-            ->add('enabled', CheckboxType::class, array(
-                'label' => 'Afficher seulement les postes actifs',
+            ->add('enabled', ChoiceType::class, array(
+                'label' => 'Poste activé ?',
                 'required' => false,
+                'choices' => [
+                    'activé' => 2,
+                    'désactivé' => 1,
+                ]
             ))
             ->add('filter', SubmitType::class, array(
                 'label' => 'Filtrer',
@@ -63,8 +67,8 @@ class JobController extends Controller
         $filter = $this->filterFormFactory($request);
         $findByFilter = array();
 
-        if($filter["enabled"]) {
-            $findByFilter["enabled"] = $filter["enabled"];
+        if($filter["enabled"] > 0) {
+            $findByFilter["enabled"] = $filter["enabled"]-1;
         }
 
         $em = $this->getDoctrine()->getManager();

--- a/src/AppBundle/Controller/JobController.php
+++ b/src/AppBundle/Controller/JobController.php
@@ -34,7 +34,7 @@ class JobController extends Controller
         $res["form"] = $this->createFormBuilder()
             ->setAction($this->generateUrl('job_list'))
             ->add('enabled', CheckboxType::class, array(
-                'label' => 'Cacher les postes inactifs',
+                'label' => 'Afficher seulement les postes actifs',
                 'required' => false,
             ))
             ->add('filter', SubmitType::class, array(

--- a/src/AppBundle/Controller/ShiftFreeLogController.php
+++ b/src/AppBundle/Controller/ShiftFreeLogController.php
@@ -103,23 +103,23 @@ class ShiftFreeLogController extends Controller
             ->leftJoin("sfl.shift", "s")
             ->orderBy('sfl.' . $sort, $order);
 
-        if($filter["created_at"]) {
+        if ($filter["created_at"]) {
             $qb = $qb->andWhere('sfl.createdAt >= :created_at_start')
                 ->andWhere('sfl.createdAt <= :created_at_end')
                 ->setParameter('created_at_start', $filter['created_at']->format('Y-m-d 00:00:00'))
                 ->setParameter('created_at_end', $filter['created_at']->format('Y-m-d 23:59:59'));
         }
-        if($filter["shift_start_date"]) {
+        if ($filter["shift_start_date"]) {
             $qb = $qb->andWhere('s.start >= :shift_start_date_start')
                 ->andWhere('s.start <= :shift_start_date_end')
                 ->setParameter('shift_start_date_start', $filter['shift_start_date']->format('Y-m-d 00:00:00'))
                 ->setParameter('shift_start_date_end', $filter['shift_start_date']->format('Y-m-d 23:59:59'));
         }
-        if($filter["beneficiary"]) {
+        if ($filter["beneficiary"]) {
             $qb = $qb->andWhere('sfl.beneficiary = :beneficiary')
                 ->setParameter('beneficiary', $filter['beneficiary']);
         }
-        if($filter["fixe"] > 0) {
+        if ($filter["fixe"] > 0) {
             $qb = $qb->andWhere('sfl.fixe = :fixe')
                 ->setParameter('fixe', $filter['fixe']-1);
         }

--- a/src/AppBundle/Controller/ShiftFreeLogController.php
+++ b/src/AppBundle/Controller/ShiftFreeLogController.php
@@ -104,16 +104,13 @@ class ShiftFreeLogController extends Controller
             ->orderBy('sfl.' . $sort, $order);
 
         if ($filter["created_at"]) {
-            $qb = $qb->andWhere('sfl.createdAt >= :created_at_start')
-                ->andWhere('sfl.createdAt <= :created_at_end')
-                ->setParameter('created_at_start', $filter['created_at']->format('Y-m-d 00:00:00'))
-                ->setParameter('created_at_end', $filter['created_at']->format('Y-m-d 23:59:59'));
+            var_dump($filter["created_at"]);
+            $qb = $qb->andWhere("DATE_FORMAT(sfl.createdAt, '%Y-%m-%d') = :created_at")
+                ->setParameter('created_at', $filter['created_at']->format('Y-m-d'));
         }
         if ($filter["shift_start_date"]) {
-            $qb = $qb->andWhere('s.start >= :shift_start_date_start')
-                ->andWhere('s.start <= :shift_start_date_end')
-                ->setParameter('shift_start_date_start', $filter['shift_start_date']->format('Y-m-d 00:00:00'))
-                ->setParameter('shift_start_date_end', $filter['shift_start_date']->format('Y-m-d 23:59:59'));
+            $qb = $qb->andWhere("DATE_FORMAT(s.start, '%Y-%m-%d') = :shift_start_date")
+                ->setParameter('shift_start_date', $filter['shift_start_date']->format('Y-m-d'));
         }
         if ($filter["beneficiary"]) {
             $qb = $qb->andWhere('sfl.beneficiary = :beneficiary')

--- a/src/AppBundle/Controller/ShiftFreeLogController.php
+++ b/src/AppBundle/Controller/ShiftFreeLogController.php
@@ -10,6 +10,7 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Doctrine\ORM\Tools\Pagination\Paginator;
 
@@ -27,13 +28,21 @@ class ShiftFreeLogController extends Controller
     {
         // default values
         $res = [
-            "beneficiary" => null,
+            'beneficiary' => null,
+            'fixe' => 0
         ];
 
         // filter creation ----------------------
         $res["form"] = $this->createFormBuilder()
             ->setAction($this->generateUrl('admin_shiftfreelog_index'))
-            ->add('beneficiary', AutocompleteBeneficiaryType::class, array('label' => 'Bénéficiaire'))
+            ->add('beneficiary', AutocompleteBeneficiaryType::class, array(
+                'label' => 'Bénéficiaire',
+                'required' => false,
+            ))
+            ->add('fixe', CheckboxType::class, array(
+                'label' => 'Afficher seulement les annulations de créneaux fixes',
+                'required' => false,
+            ))
             ->add('filter', SubmitType::class, array(
                 'label' => 'Filtrer',
                 'attr' => array('class' => 'btn', 'value' => 'filtrer')
@@ -44,6 +53,7 @@ class ShiftFreeLogController extends Controller
 
         if ($res['form']->isSubmitted() && $res['form']->isValid()) {
             $res["beneficiary"] = $res["form"]->get("beneficiary")->getData();
+            $res["fixe"] = $res["form"]->get("fixe")->getData();
         }
 
         return $res;
@@ -68,6 +78,10 @@ class ShiftFreeLogController extends Controller
         if($filter["beneficiary"]) {
             $qb = $qb->andWhere('s.beneficiary = :beneficiary')
                 ->setParameter('beneficiary', $filter['beneficiary']);
+        }
+        if($filter["fixe"]) {
+            $qb = $qb->andWhere('s.fixe = :fixe')
+                ->setParameter('fixe', $filter['fixe']);
         }
 
         $limitPerPage = 25;

--- a/src/AppBundle/Controller/ShiftFreeLogController.php
+++ b/src/AppBundle/Controller/ShiftFreeLogController.php
@@ -10,7 +10,7 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
-use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Doctrine\ORM\Tools\Pagination\Paginator;
 
@@ -39,9 +39,13 @@ class ShiftFreeLogController extends Controller
                 'label' => 'Bénéficiaire',
                 'required' => false,
             ))
-            ->add('fixe', CheckboxType::class, array(
-                'label' => 'Afficher seulement les annulations de créneaux fixes',
+            ->add('fixe', ChoiceType::class, array(
+                'label' => 'Type de créneau',
                 'required' => false,
+                'choices' => [
+                    'fixe' => 2,
+                    'volant' => 1,
+                ]
             ))
             ->add('submit', SubmitType::class, array(
                 'label' => 'Filtrer',
@@ -79,9 +83,9 @@ class ShiftFreeLogController extends Controller
             $qb = $qb->andWhere('s.beneficiary = :beneficiary')
                 ->setParameter('beneficiary', $filter['beneficiary']);
         }
-        if($filter["fixe"]) {
+        if($filter["fixe"] > 0) {
             $qb = $qb->andWhere('s.fixe = :fixe')
-                ->setParameter('fixe', $filter['fixe']);
+                ->setParameter('fixe', $filter['fixe']-1);
         }
 
         $limitPerPage = 25;

--- a/src/AppBundle/Controller/ShiftFreeLogController.php
+++ b/src/AppBundle/Controller/ShiftFreeLogController.php
@@ -43,7 +43,7 @@ class ShiftFreeLogController extends Controller
                 'label' => 'Afficher seulement les annulations de créneaux fixes',
                 'required' => false,
             ))
-            ->add('filter', SubmitType::class, array(
+            ->add('submit', SubmitType::class, array(
                 'label' => 'Filtrer',
                 'attr' => array('class' => 'btn', 'value' => 'filtrer')
             ))

--- a/src/AppBundle/Twig/Extension/AppExtension.php
+++ b/src/AppBundle/Twig/Extension/AppExtension.php
@@ -146,8 +146,10 @@ class AppExtension extends AbstractExtension
 
     /**
      * exemple output: "mercredi 29 juin 2022 à 11:31"
+     *
+     * @param: \DateTime|\DateTimeImmutable $date
      */
-    public function date_fr_with_time(\DateTime $date)
+    public function date_fr_with_time($date)
     {
         setlocale(LC_TIME, 'fr_FR.UTF8');
         return strftime("%A %e %B %Y à %H:%M", $date->getTimestamp());


### PR DESCRIPTION
### Quoi ?

- pouvoir filtrer la liste des créneaux annulés : par "date de l'annulation", "bénéficiaire", "date du créneau" et "fixe ou volant"
- ajouter le count de la liste
- réordonner un peu les colonnes (se rapprocher de la liste des exemptions)

### Capture d'écran

![Screenshot from 2023-01-31 18-28-56](https://user-images.githubusercontent.com/7147385/215837363-8c1b0041-874f-4239-be09-569d20464e00.png)
