### PR TITLE
Home : améliorer le wording de la section "Mon bénévolat"

### DIFF
--- a/app/Resources/views/booking/home_booked_shifts.html.twig
+++ b/app/Resources/views/booking/home_booked_shifts.html.twig
@@ -2,18 +2,6 @@
     {% set beneficiary = app.user.beneficiary %}
     {% set member = beneficiary.membership %}
 
-    {% if member.isCurrentlyExemptedFromShifts() %}
-        <div class="card-panel teal white-text">
-            <i class="material-icons left">beach_access</i>
-            <strong>{% if member.beneficiaries | length %}Votre{% else %}Ton{% endif %} compte est exempté de créneau !</strong>
-            <ul class="list-unstyled">
-                {% for currentMembershipShiftExemption in member.getCurrentMembershipShiftExemptions() %}
-                    <li><i>{{ currentMembershipShiftExemption.shiftExemption }}</i> du {{ currentMembershipShiftExemption.start | date_fr_full }} au {{ currentMembershipShiftExemption.end | date_fr_full }}</li>
-                {% endfor %}
-            </ul>
-        </div>
-    {% endif %}
-
     <ul class="collapsible collapsible-expandable">
         {% if use_fly_and_fixed %}
             <li class="active">

--- a/app/Resources/views/booking/home_dashboard.html.twig
+++ b/app/Resources/views/booking/home_dashboard.html.twig
@@ -44,34 +44,34 @@
             <p>
                 <i class="material-icons">warning</i>
                 {% if member.beneficiaries | length > 1 %}
-                    <span>Vous avez du retard sur votre bénévolat. Pensez à réserver vos créneaux.</span>
+                    <span>Vous avez du retard sur votre bénévolat.</span>
                 {% else %}
-                    <span>Tu as du retard sur ton bénévolat. Pense à réserver tes créneaux.</span>
+                    <span>Tu as du retard sur ton bénévolat.</span>
                 {% endif %}
             </p>
+        {% endif %}
+        {% set cycleRemainingToBook = shift_service.remainingToBook(member) %}
+        {% if cycleRemainingToBook > 0 %}
+            <p>
+                <span>{% if member.beneficiaries | length > 1 %}Pensez à réserver vos créneaux.{% else %}Pense à réserver tes créneaux.{% endif %}</span>
+                <br />
+                <span>{% if member.beneficiaries | length > 1 %}Vous avez{% else %}Tu as{% endif %} encore {{ cycleRemainingToBook | duration_from_minutes }} à réserver.</span>
+            </p>
         {% else %}
-            {% set remaining = shift_service.remainingToBook(member) %}
-            {% if remaining > 0 %}
-                <p>
-                    <i class="material-icons">warning</i>
-                    <span>{% if member.beneficiaries | length > 1 %}Pensez à réserver vos créneaux.{% else %}Pense à réserver tes créneaux.{% endif %}</span>
-                    <br />
-                    <span>{% if member.beneficiaries | length > 1 %}Vous avez{% else %}Tu as{% endif %} encore {{ remaining | duration_from_minutes }} à effectuer.</span>
-                </p>
-            {% else %}
-                {% set duration_to_book = (shift_service.shiftTimeByCycle(member) - member.timeCount(end_current_cycle)) %}
-                <p>
-                    Bravo ! {% if member.beneficiaries | length > 1 %}Vos{% else %}Tes{% endif %} {{ due_duration_by_cycle | duration_from_minutes }}
-                    ont été planifiées sur le cycle actuel.
-                </p>
-                {% if beneficiariesWhoCanBook | length > 0 and duration_to_book > 0 and not allow_extra_shifts %}
+            <p>
+                Bravo ! {% if member.beneficiaries | length > 1 %}Vos{% else %}Tes{% endif %} {{ due_duration_by_cycle | duration_from_minutes }}
+                ont été planifiées sur le cycle actuel.
+            </p>
+            {% set cycleRemainingToBookExtra = shift_service.remainingToBookExtra(member) %}
+            {% if cycleRemainingToBookExtra > 0 %}
+                {% if beneficiariesWhoCanBook | length > 0 and not allow_extra_shifts %}
                     <p>
                         {% if beneficiariesWhoCanBook | length > 1 %}
                             {% for b in beneficiariesWhoCanBook %} {{ b.firstname }} {% if loop.index < loop.length %} et {% endif %}{% endfor %}peuvent
                         {% else %}
                             {{ (beneficiariesWhoCanBook | first).firstname }} peut
                         {% endif %} encore
-                        effectuer {{ duration_to_book | duration_from_minutes }}.
+                        effectuer {{ cycleRemainingToBookExtra | duration_from_minutes }}.
                     </p>
                 {% elseif (allow_extra_shifts) %}
                     <p>
@@ -81,11 +81,6 @@
                             Tu peux
                         {% endif %}
                         encore effectuer des créneaux.
-                    </p>
-                {% else %}
-                    <p>
-                        <i class="material-icons">stars</i> Bravo !
-                        Tous {% if member.beneficiaries | length > 1 %}vos{% else %}tes{% endif %} créneaux ont été planifiés sur le cycle actuel !
                     </p>
                 {% endif %}
             {% endif %}
@@ -100,5 +95,5 @@
         Réserver
     </a>
 
-    <p>{% if member.beneficiaries | length > 1 %}Votre{% else %}Mon{% endif %} cycle actuel se termine le {{ end_current_cycle | date_fr_long }}</p>
+    <p>{% if member.beneficiaries | length > 1 %}Votre{% else %}Mon{% endif %} cycle actuel se termine le {{ end_current_cycle | date_fr_long }}.</p>
 {% endif %}

--- a/app/Resources/views/default/index.html.twig
+++ b/app/Resources/views/default/index.html.twig
@@ -184,14 +184,15 @@
                 {% endif %}
             </div>
         </div>
-    {% endif %}
-    {% if app.user.beneficiary and member | uptodate %}
-        <div id="home-shifts" class="row">
-            <div class="col s12">
-                {# why render instead of include? because of forms init #}
-                {{ render(controller("AppBundle:Booking:homepageShifts")) }}
+
+        {% if member | uptodate %}
+            <div id="home-shifts" class="row">
+                <div class="col s12">
+                    {# why render instead of include? because of forms init #}
+                    {{ render(controller("AppBundle:Booking:homepageShifts")) }}
+                </div>
             </div>
-        </div>
+        {% endif %}
     {% endif %}
 {% else %}
     <br>

--- a/app/Resources/views/default/index.html.twig
+++ b/app/Resources/views/default/index.html.twig
@@ -40,15 +40,16 @@
             </div>
         {% endif %}
         {% if app.user.beneficiary %}
+            {% set member = app.user.beneficiary.membership %}
             <div class="col s12">
                 <p>
                     Bienvenue sur ton espace personnel à {{ project_name }}
-                    {% if app.user.beneficiary.membership.beneficiaries | length > 1 %}
+                    {% if member.beneficiaries | length > 1 %}
                         <br />
-                        Tu partages ton compte avec {% for beneficiary in app.user.beneficiary.membership.beneficiaries %}{% if beneficiary != app.user.beneficiary %}<strong>{{ beneficiary.firstname }}</strong>{% endif %}{% endfor %}
+                        Tu partages ton compte avec {% for beneficiary in member.beneficiaries %}{% if beneficiary != app.user.beneficiary %}<strong>{{ beneficiary.firstname }}</strong>{% endif %}{% endfor %}
                     {% endif %}
                 </p>
-                {% if app.user.beneficiary.membership | uptodate and app.user.beneficiary.membership | can_register %}
+                {% if member | uptodate and member | can_register %}
                     <a href="{{ path("user_self_register") }}" class="waves-effect waves-light light-green btn"><i class="material-icons left">card_membership</i>Je ré-adhère en ligne</a>
                     <br />
                     <br />
@@ -58,11 +59,27 @@
     </div>
 
     {% if app.user.beneficiary %}
+        {% set member = app.user.beneficiary.membership %}
+
+        {% if member.isCurrentlyExemptedFromShifts() %}
+            <div class="row">
+                <div class="card-panel teal white-text">
+                    <i class="material-icons left">beach_access</i>
+                    <strong>{% if member.beneficiaries | length > 1 %}Votre{% else %}Ton{% endif %} compte est exempté de créneau !</strong>
+                    <ul class="list-unstyled">
+                        {% for currentMembershipShiftExemption in member.getCurrentMembershipShiftExemptions() %}
+                            <li><i>{{ currentMembershipShiftExemption.shiftExemption }}</i> du {{ currentMembershipShiftExemption.start | date_fr_full }} au {{ currentMembershipShiftExemption.end | date_fr_full }}</li>
+                        {% endfor %}
+                    </ul>
+                </div>
+            </div>
+        {% endif %}
+
         <div id="home-actions" class="row center">
-            {% if app.user.beneficiary.membership | uptodate %}
+            {% if member | uptodate %}
                 <div class="col s12 l6">
                     <div class="homebox">
-                        <h5><span class="white">{% if app.user.beneficiary.membership.beneficiaries | length %}Votre{% else %}Mon{% endif %} Bénévolat</span></h5>
+                        <h5><span class="white">{% if member.beneficiaries | length %}Votre{% else %}Mon{% endif %} Bénévolat</span></h5>
                         {% include "booking/home_dashboard.html.twig" %}{# with { beneficiary: app.user.beneficiary } #}
                     </div>
                 </div>
@@ -73,15 +90,15 @@
                 <div class="homebox">
                     <h5><span class="white">Mon compte</span></h5>
                     <div>
-                        {% if (app.user.beneficiary.membership.registrations | length) and not app.user.beneficiary.membership | uptodate %}
+                        {% if (member.registrations | length) and not member | uptodate %}
                             <p>
                                 <i class="material-icons">warning</i>
-                                {% if app.user.beneficiary.membership.beneficiaries | length %}Votre{% else %}Ton{% endif %} adhésion a expirée le {{ "now" | date_modify((app.user.beneficiary.membership | remainder | date("%R%a"))~" days")| date_fr_long }}
+                                {% if member.beneficiaries | length %}Votre{% else %}Ton{% endif %} adhésion a expirée le {{ "now" | date_modify((member | remainder | date("%R%a"))~" days")| date_fr_long }}
                             </p>
                             <a href="{{ path("user_self_register") }}" class="waves-effect waves-light light-green btn">
                                 <i class="material-icons left">card_membership</i>Ré-adhèrer en ligne
                             </a>
-                        {% elseif not app.user.beneficiary.membership | uptodate %}
+                        {% elseif not member | uptodate %}
                             <p>
                                 <i class="material-icons">warning</i>
                                 Il est temps d'adhérer.
@@ -157,7 +174,7 @@
                         {% endfor %}
                     </div>
                 {% endif %}
-                {% if app.user.beneficiary and (app.user.beneficiary.membership | uptodate) and display_keys_shop %}
+                {% if app.user.beneficiary and (member | uptodate) and display_keys_shop %}
                     <div class="homebox">
                         <h5><span class="white"><i class="material-icons">build</i>&nbsp;Outils</span></h5>
                         {% if display_keys_shop %}
@@ -168,7 +185,7 @@
             </div>
         </div>
     {% endif %}
-    {% if app.user.beneficiary and app.user.beneficiary.membership | uptodate %}
+    {% if app.user.beneficiary and member | uptodate %}
         <div id="home-shifts" class="row">
             <div class="col s12">
                 {# why render instead of include? because of forms init #}

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -190,6 +190,7 @@ services:
                 - "%allow_extra_shifts%"
                 - "%max_time_in_advance_to_book_extra_shifts%"
                 - "%forbid_shift_overlap_time%"
+                - "%use_card_reader_to_validate_shifts%"
     shift_free_log_service:
             class: AppBundle\Service\ShiftFreeLogService
             public: true

--- a/src/AppBundle/Entity/Membership.php
+++ b/src/AppBundle/Entity/Membership.php
@@ -671,12 +671,14 @@ class Membership
             $carry += $log->getTime();
             return $carry;
         };
+
         if ($before)
-            $logs = $this->getTimeLogs()->filter(function ($log) use ($before){
+            $logs = $this->getTimeLogs()->filter(function ($log) use ($before) {
                 return ($log->getCreatedAt() < $before);
             });
         else
             $logs = $this->getTimeLogs();
+
         return array_reduce($logs->toArray(), $sum, 0);
     }
 


### PR DESCRIPTION
### Quoi ?

Pour les épiceries qui ont `use_card_reader_to_validate_shifts=true`
Actuellement la section "Mon bénévolat" ne prend pas en compte les créneaux réservés à l'avance.

Modifié `ShiftService.remainingToBook(member)` pour prendre en compte les créneaux à venir du cycle.

|Situation|Avant|Après|
|---|---|---|
|Début de cycle, membre avec créneau fixe|:warning: Pensez à réserver vos créneaux. Vous avez encore 3h00 à effectuer.|Bravo ! Vos 3h00 ont été planifiées sur le cycle actuel.|
|Cours de cycle, membre volant ayant planifié son / ses créneaux|:warning: Pensez à réserver vos créneaux. Vous avez encore 3h00 à effectuer.|Bravo ! Vos 3h00 ont été planifiées sur le cycle actuel.|

J'ai aussi remonté le message "exemption" pour qu'il apparaisse avant la section "Mon bénévolat"

### Pourquoi ?

Clarifier les messages, en particulier pour les membres "fixe" qui ont déjà leur créneaux de générés à chaque début de cycle