### PR TITLE
Mettre un peu en avant les membres sans adhésions

### DIFF
--- a/app/Resources/views/admin/period/index.html.twig
+++ b/app/Resources/views/admin/period/index.html.twig
@@ -40,30 +40,25 @@
 {% endblock %}
 
 {% block macro %}
-    {# generate a imput form, used for the filters #}
-    {% macro input(input_obj, hidden=false) %}
+    {# generate a form input, used for the filters #}
+    {% macro form_input(input_obj, hidden=false) %}
         <div class="input-field col m3">
             {% if hidden %}
                 {{ form_widget(input_obj, { 'attr': {'class': 'hide'} }) }}
-
             {% else %}
                 {{ form_widget(input_obj) }}
                 {{ form_label(input_obj) }}
             {% endif %}
-
         </div>
     {% endmacro %}
 
-    {# generate one line with the icon and the member
-         # name and id and if needed a warning icon
-         # take a shifter (a benificiary object or null)
-    #}
-    {% macro one_line_shifter(position) %}
+    {# generate one line with the icon and the shifter id+name and if needed a warning icon #}
+    {% macro position_shifter_display(position) %}
         {% set shifter = position.shifter %}
         {% set formation = position.formation??"Sans formation" %}
 
         {% if shifter %}
-            {# sombody is registered to this period #}
+            {# sombody is registered for this periodposition #}
             {% set warning = shifter.hasWarningStatus %}
             <a href="{{ path('member_show', { 'member_number': shifter.membership.memberNumber }) }}"
                class="black-text tooltipped editable-box truncate" data-position="bottom" data-tooltip="{{ shifter.getDisplayNameWithMemberNumberAndStatusIcon() | raw }} &#013;&#010; ({{ formation }})">
@@ -80,21 +75,18 @@
                 <strong><i>libre</i></strong>
             </div>
         {% endif %}
-    {% endmacro one_line_shifter %}
+    {% endmacro position_shifter_display %}
 
     {# generate a card for all positions in a period
      # period: a period object
      # week_filter: a string with the week to keep or null if no filter
     #}
     {% macro period_card(period, week_filter, pb_filter) %}
-        <div class="card {{ period.job? period.job.color : "blue" }} lighten-2 hoverable"
-             style="padding: 15px;">
+        <div class="card {{ period.job? period.job.color : "blue" }} lighten-2 hoverable" style="padding: 15px;">
 
             {# Card header #}
             <a href="{{ path("period_edit",{'id': period.id}) }}" class="black-text">
-
                 <div class="black-text editable-box">
-
                     {% if period.job %}
                         <b>{{ period.job.name }}</b>
                         <br>
@@ -103,7 +95,6 @@
                         {{ period.start | date('H:i') }}-{{ period.end | date('H:i') }}
                         <br>
                     {% endif %}
-
                 </div>
             </a>
             {# if display by job/training #}
@@ -117,21 +108,20 @@
                 {% endfor %}
             </div>
 
-            {# if display by member name  #}
+            {# if display by member name #}
             {% if use_fly_and_fixed %}
                 <div id="shifter" style="margin-top:1em;">
                     {% for week, positions in period.positionsperweekcycle %}
                         {% if (week in week_filter) or not week_filter %}
                             <h6>Semaine {{ week }}</h6>
                             {% for position in positions %}
-                                {{ _self.one_line_shifter(position) }}
+                                {{ _self.position_shifter_display(position) }}
                             {% endfor %}
                         {% endif %}
                     {% endfor %}
                 </div>
             {% endif %}
         </div>
-
     {% endmacro %}
 {% endblock macro %}
 
@@ -160,9 +150,9 @@
                     <div class="collapsible-body">
                         {{ form_start(filter_form) }}
                         <div class="row">
-                            {{ _self.input(filter_form.job) }}
-                            {{ _self.input(filter_form.week) }}
-                            {{ _self.input(filter_form.filling, not use_fly_and_fixed) }}
+                            {{ _self.form_input(filter_form.job) }}
+                            {{ _self.form_input(filter_form.week) }}
+                            {{ _self.form_input(filter_form.filling, not use_fly_and_fixed) }}
                         </div>
                         {{ form_widget(filter_form.filter) }}
                         {{ form_end(filter_form) }}
@@ -213,6 +203,62 @@
                                 </a>
                             </div>
                         {% endif %}
+                    </div>
+                </li>
+                {# Légende ----------------------------------- #}
+                <li>
+                    <div class="collapsible-header">
+                        <i class="material-icons">help_outline</i>Légende
+                    </div>
+                    <div class="collapsible-body">
+                        <table class="responsive-table striped">
+                            <thead>
+                                <tr>
+                                    <th>Texte</th>
+                                    <th>Explication</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <i class="material-icons">person</i>&nbsp;<strong><i>libre</i></strong>
+                                    </td>
+                                    <td>
+                                        Un créneau fixe libre
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <i class="material-icons">person</i>&nbsp;Prénom N
+                                    </td>
+                                    <td>
+                                        Un créneau fixe avec un bénéficiaire d'inscrit
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <i class="red-text material-icons warning-animation">warning</i>&nbsp;Prénom N
+                                    </td>
+                                    <td>
+                                        Un créneau fixe avec un bénéficiaire dans un état "anormal"
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        Etats "anormaux"
+                                    </td>
+                                    <td>
+                                        <ul>
+                                            <li>∅ Membre clôturé</li>
+                                            <li>❄ Membre gelé</li>
+                                            <li>☂ Membre exempté de créneaux</li>
+                                            <li>€ Membre avec une adhésion expirée</li>
+                                            <li>✈ Bénéficiaire avec un statut "volant"</li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
                     </div>
                 </li>
             </ul>

--- a/app/Resources/views/admin/period/index.html.twig
+++ b/app/Resources/views/admin/period/index.html.twig
@@ -64,7 +64,7 @@
 
         {% if shifter %}
             {# sombody is registered to this period #}
-            {% set warning = shifter.isFlying or shifter.getMembership.getFrozen or shifter.getMembership.getWithdrawn %}
+            {% set warning = shifter.hasWarningStatus %}
             <a href="{{ path('member_show', { 'member_number': shifter.membership.memberNumber }) }}"
                class="black-text tooltipped editable-box truncate" data-position="bottom" data-tooltip="{{ shifter.getDisplayNameWithMemberNumberAndStatusIcon() | raw }} &#013;&#010; ({{ formation }})">
                 {% if warning %}

--- a/app/Resources/views/admin/period/index.html.twig
+++ b/app/Resources/views/admin/period/index.html.twig
@@ -252,7 +252,7 @@
                                             <li>∅ Membre clôturé</li>
                                             <li>❄ Membre gelé</li>
                                             <li>☂ Membre exempté de créneaux</li>
-                                            <li>€ Membre avec une adhésion expirée</li>
+                                            <li>$ Membre avec une adhésion expirée</li>
                                             <li>✈ Bénéficiaire avec un statut "volant"</li>
                                         </ul>
                                     </td>

--- a/app/Resources/views/admin/user/list.html.twig
+++ b/app/Resources/views/admin/user/list.html.twig
@@ -228,7 +228,7 @@
                         {% if member.withdrawn %}
                             <i class="material-icons" title="Compte fermé">block</i>
                         {% elseif not member.hasValidRegistration() %}
-                            <i class="material-icons" title="Compte en attente d'adhésion">euro_symbol</i>
+                            <i class="material-icons" title="Compte en attente d'adhésion">attach_money</i>
                         {% endif %}
                         {% if member.frozen %}
                             <i class="material-icons" title="Compte gelé">ac_unit</i>

--- a/app/Resources/views/admin/user/list.html.twig
+++ b/app/Resources/views/admin/user/list.html.twig
@@ -227,6 +227,8 @@
                     <td class="hide-on-med-and-down">
                         {% if member.withdrawn %}
                             <i class="material-icons" title="Compte fermé">block</i>
+                        {% elseif not member.hasValidRegistration() %}
+                            <i class="material-icons" title="Compte en attente d'adhésion">euro_symbol</i>
                         {% endif %}
                         {% if member.frozen %}
                             <i class="material-icons" title="Compte gelé">ac_unit</i>

--- a/app/Resources/views/booking/index.html.twig
+++ b/app/Resources/views/booking/index.html.twig
@@ -39,7 +39,7 @@
             <ul class="collapsible" id="legend">
                 <li>
                     <div class="collapsible-header {% if frontend_cookie is defined and frontend_cookie.booking is defined and frontend_cookie.booking.legend_closed is defined and frontend_cookie.booking.legend_closed %}{% else %}active{% endif %}">
-                        <i class="material-icons">help_outline</i>legende
+                        <i class="material-icons">help_outline</i>Légende
                     </div>
                     <div class="collapsible-body">
                         <ul>

--- a/app/Resources/views/member/show.html.twig
+++ b/app/Resources/views/member/show.html.twig
@@ -20,10 +20,17 @@
         {% if member.mainBeneficiary and not member.mainBeneficiary.user.isEnabled %}
             <i class="material-icons" title="Compte pas encore activé">phonelink_off</i>
         {% endif %}
-        {% if member.isCurrentlyExemptedFromShifts() %}<i class="material-icons" title="Compte exempté">beach_access</i>{% endif %}
-        {% if member.frozen %}<i class="material-icons" title="Compte gelé">ac_unit</i>{% endif %}
-        {% if member.withdrawn %}<i class="material-icons" title="Compte fermé">block</i>{% endif %}
-        {% if not member.hasValidRegistration() and not member.withdrawn %}<i class="material-icons" title="Compte en attente d'adhésion">euro_symbol</i>{% endif %}
+        {% if member.isCurrentlyExemptedFromShifts() %}
+            <i class="material-icons" title="Compte exempté">beach_access</i>
+        {% endif %}
+        {% if member.frozen %}
+            <i class="material-icons" title="Compte gelé">ac_unit</i>
+        {% endif %}
+        {% if member.withdrawn %}
+            <i class="material-icons" title="Compte fermé">block</i>
+        {% elseif not member.hasValidRegistration() %}
+            <i class="material-icons" title="Compte en attente d'adhésion">euro_symbol</i>
+        {% endif %}
     </h4>
 
     {% if member.beneficiaries | length %}

--- a/app/Resources/views/member/show.html.twig
+++ b/app/Resources/views/member/show.html.twig
@@ -29,7 +29,7 @@
         {% if member.withdrawn %}
             <i class="material-icons" title="Compte fermé">block</i>
         {% elseif not member.hasValidRegistration() %}
-            <i class="material-icons" title="Compte en attente d'adhésion">euro_symbol</i>
+            <i class="material-icons" title="Compte en attente d'adhésion">attach_money</i>
         {% endif %}
     </h4>
 

--- a/app/Resources/views/member/show.html.twig
+++ b/app/Resources/views/member/show.html.twig
@@ -23,6 +23,7 @@
         {% if member.isCurrentlyExemptedFromShifts() %}<i class="material-icons" title="Compte exempté">beach_access</i>{% endif %}
         {% if member.frozen %}<i class="material-icons" title="Compte gelé">ac_unit</i>{% endif %}
         {% if member.withdrawn %}<i class="material-icons" title="Compte fermé">block</i>{% endif %}
+        {% if not member.hasValidRegistration() and not member.withdrawn %}<i class="material-icons" title="Compte en attente d'adhésion">euro_symbol</i>{% endif %}
     </h4>
 
     {% if member.beneficiaries | length %}
@@ -421,7 +422,7 @@
         body {
             background-color: {{ member_frozen_background_color }};
         }
-        {% elseif member.isCurrentlyExemptedFromShifts() %}
+        {% elseif member.isCurrentlyExemptedFromShifts() or not member.hasValidRegistration() %}
         body {
             background-color: {{ member_exempted_background_color }};
         }

--- a/src/AppBundle/Controller/ShiftFreeLogController.php
+++ b/src/AppBundle/Controller/ShiftFreeLogController.php
@@ -104,7 +104,6 @@ class ShiftFreeLogController extends Controller
             ->orderBy('sfl.' . $sort, $order);
 
         if ($filter["created_at"]) {
-            var_dump($filter["created_at"]);
             $qb = $qb->andWhere("DATE_FORMAT(sfl.createdAt, '%Y-%m-%d') = :created_at")
                 ->setParameter('created_at', $filter['created_at']->format('Y-m-d'));
         }

--- a/src/AppBundle/Entity/Beneficiary.php
+++ b/src/AppBundle/Entity/Beneficiary.php
@@ -553,14 +553,11 @@ class Beneficiary
      */
     public function hasWarningStatus()
     {
-        if ($this->getMembership()->getWithdrawn() ||
+        return $this->getMembership()->getWithdrawn() ||
             $this->getMembership()->getFrozen() ||
             $this->isFlying() ||
             $this->getMembership()->isCurrentlyExemptedFromShifts() ||
-            !$this->getMembership()->hasValidRegistration()
-        ) {
-            return true;
-        }
+            !$this->getMembership()->hasValidRegistration();
     }
 
     /**

--- a/src/AppBundle/Entity/Beneficiary.php
+++ b/src/AppBundle/Entity/Beneficiary.php
@@ -553,19 +553,12 @@ class Beneficiary
      */
     public function hasWarningStatus()
     {
-        if ($this->getMembership()->getWithdrawn()) {
-            return true;
-        }
-        if ($this->getMembership()->getFrozen()) {
-            return true;
-        }
-        if ($this->isFlying()) {
-            return true;
-        }
-        if ($this->getMembership()->isCurrentlyExemptedFromShifts()) {
-            return true;
-        }
-        if (!$this->getMembership()->hasValidRegistration()) {
+        if ($this->getMembership()->getWithdrawn() ||
+            $this->getMembership()->getFrozen() ||
+            $this->isFlying() ||
+            $this->getMembership()->isCurrentlyExemptedFromShifts() ||
+            !$this->getMembership()->hasValidRegistration()
+        ) {
             return true;
         }
     }
@@ -583,19 +576,19 @@ class Beneficiary
         $symbols = array();
 
         if ($this->getMembership()->getWithdrawn()) {
-            $symbols[]= "&#x2205;"; // ∅
+            $symbols[] = '∅';
         }
         if ($this->getMembership()->getFrozen()) {
-            $symbols[]= "&#x2744;"; // ❄
+            $symbols[] = '❄';
         }
         if ($this->isFlying()) {
-            $symbols[]= "&#9992;"; // ✈
+            $symbols[] = '✈';
         }
         if ($this->getMembership()->isCurrentlyExemptedFromShifts()) {
-            $symbols[]= "&#x2602;"; // ☂
+            $symbols[] = '☂';
         }
         if (!$this->getMembership()->hasValidRegistration()) {
-            $symbols[]= "&#36;"; // $
+            $symbols[] = '$';
         }
 
         if (count($symbols)) {

--- a/src/AppBundle/Entity/Beneficiary.php
+++ b/src/AppBundle/Entity/Beneficiary.php
@@ -546,6 +546,31 @@ class Beneficiary
     }
 
     /**
+     * return true if the beneficiary is in a "warning" status
+     * useful for PeriodPositionController
+     * 
+     * @return bool
+     */
+    public function hasWarningStatus()
+    {
+        if ($this->getMembership()->getWithdrawn()) {
+            return true;
+        }
+        if ($this->getMembership()->getFrozen()) {
+            return true;
+        }
+        if ($this->isFlying()) {
+            return true;
+        }
+        if ($this->getMembership()->isCurrentlyExemptedFromShifts()) {
+            return true;
+        }
+        if (!$this->getMembership()->hasValidRegistration()) {
+            return true;
+        }
+    }
+
+    /**
      * return a string with emoji between brackets depending on the
      * beneficiary status, if she/he is inactive (withdrawn), frozen or flying
      * or an empty string if none of those
@@ -553,31 +578,36 @@ class Beneficiary
      * @param bool $includeLeadingSpace if true add a space at the beginning
      * @return string with ether emoji(s) for the beneficiary's status or empty
      */
-    public function getStatusIcon(bool $includeLeadingSpace = false):string{
-
-
+    public function getStatusIcon(bool $includeLeadingSpace = false):string
+    {
         $symbols = array();
 
-        if($this->getMembership()->getWithdrawn()){
-            $symbols[]= "&#x26A0;";
+        if ($this->getMembership()->getWithdrawn()) {
+            $symbols[]= "&#x26A0;"; // ∅
         }
-        if ($this->getMembership()->getFrozen()){
-            $symbols[]= "&#x2744;";
+        if ($this->getMembership()->getFrozen()) {
+            $symbols[]= "&#x2744;"; // ❄
         }
-        if($this->isFlying()){
-            $symbols[]= "&#9992;";
+        if ($this->isFlying()) {
+            $symbols[]= "&#9992;"; // ✈
+        }
+        if ($this->getMembership()->isCurrentlyExemptedFromShifts()) {
+            $symbols[]= "&#x2602;"; // ☂
+        }
+        if (!$this->getMembership()->hasValidRegistration()) {
+            $symbols[]= "&#8364;"; // €
         }
 
-        if (count($symbols)){
+        if (count($symbols)) {
             $res = '[' . implode("/", $symbols) . ']';
 
-            if($includeLeadingSpace){
+            if ($includeLeadingSpace) {
                 $res = " " . $res;
             }
-        }else{
-            $res =  "";
+        } else {
+            $res = "";
         }
-        // 	for dispensed beneficiary &#127989;
+
         return $res;
 
     }

--- a/src/AppBundle/Entity/Beneficiary.php
+++ b/src/AppBundle/Entity/Beneficiary.php
@@ -583,7 +583,7 @@ class Beneficiary
         $symbols = array();
 
         if ($this->getMembership()->getWithdrawn()) {
-            $symbols[]= "&#x26A0;"; // ∅
+            $symbols[]= "&#x2205;"; // ∅
         }
         if ($this->getMembership()->getFrozen()) {
             $symbols[]= "&#x2744;"; // ❄
@@ -595,7 +595,7 @@ class Beneficiary
             $symbols[]= "&#x2602;"; // ☂
         }
         if (!$this->getMembership()->hasValidRegistration()) {
-            $symbols[]= "&#8364;"; // €
+            $symbols[]= "&#36;"; // $
         }
 
         if (count($symbols)) {

--- a/src/AppBundle/Entity/Membership.php
+++ b/src/AppBundle/Entity/Membership.php
@@ -502,12 +502,27 @@ class Membership
      */
     public function hasValidRegistrationBefore($date)
     {
+        if (!$date) {
+            $date = new \DateTime('now');
+        }
         foreach ($this->getRegistrations() as $registration) {
             if ($registration->getDate() < $date) {
                 return true;
             }
         }
         return false;
+    }
+
+    /**
+     * Return if the member has a valid registration
+     *
+     * @param \DateTime $date
+     * @return bool
+     */
+    public function hasValidRegistration()
+    {
+        $date = new \DateTime('now');
+        return $this->hasValidRegistrationBefore($date);
     }
 
     /**

--- a/src/AppBundle/Service/SearchUserFormHelper.php
+++ b/src/AppBundle/Service/SearchUserFormHelper.php
@@ -48,7 +48,7 @@ class SearchUserFormHelper {
             ]
         ]);
         $formBuilder->add('exempted', ChoiceType::class, [
-            'label' => 'exempté',
+            'label' => '☂ exempté',
             'required' => false,
             'choices' => [
                 'exempté' => 2,


### PR DESCRIPTION
### Quoi ?

Dans la page "Semaine type"
- dans le tooltip des bénéficiaires en "warning", nouvel icon "$" pour indiquer les bénéficiaires dont le compte-membre est en retard d'adhésion
- nouvelle section "légende" (voire capture d'écran)

Dans la page "Liste des membres" et "Membre"
- nouvel icon "$" à coté du numéro de membre si le compte-membre est en retard d'adhésion (+ ajouter le fond utilisé actuellement pour les exemptions)

### Pourquoi ?

Pour indiquer les membres "actifs" mais qui n'ont pas encore (ré-)adhéré. Cela peut poser problème si ils sont inscrits à des créneaux fixes, il y a un risque qu'ils ne viennent pas.

### Captures d'écran

|Page|Capture|
|---|---|
|Liste des membres|![Screenshot from 2023-01-31 19-41-45](https://user-images.githubusercontent.com/7147385/215852993-9e1d112e-8a56-46bb-a610-dc2b2ff4e502.png)|
|Membre en retard d'adhésion|![Screenshot from 2023-01-31 19-36-27](https://user-images.githubusercontent.com/7147385/215851880-07f6e26a-ae6e-44e8-a065-c75c0aa69109.png)|
|Semaine type|![Screenshot from 2023-01-31 19-32-01](https://user-images.githubusercontent.com/7147385/215850890-25d53fe0-2c87-4c7e-a869-2ce61dd84071.png)|

edit : remplacé le € par un $

