### PR TITLE
TimeLog : nouveau champ requestRoute

### DIFF
--- a/app/DoctrineMigrations/Version20230131091820_timelog_requestroute.php
+++ b/app/DoctrineMigrations/Version20230131091820_timelog_requestroute.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20230131091820 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE time_log ADD request_route VARCHAR(255) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE time_log DROP request_route');
+    }
+}

--- a/app/Resources/views/member/_partial/time_logs.html.twig
+++ b/app/Resources/views/member/_partial/time_logs.html.twig
@@ -38,7 +38,12 @@
             <th>Auteur</th>
             <th>Temps</th>
             <th>Motif</th>
-            <th></th>
+            {% if from_admin and is_granted("ROLE_ADMIN") %}
+                <th>Route</th>
+            {% endif %}
+            {% if from_admin is defined and is_granted("ROLE_SUPER_ADMIN") %}
+                <th>Actions</th>
+            {% endif %}
         </tr>
     </thead>
     <tbody>
@@ -48,11 +53,14 @@
                 <td>{{ timeLog.createdBy }}</td>
                 <td>{{ timeLog.time | duration_from_minutes }}</td>
                 <td>{{ timeLog.computedDescription }}</td>
-                <td>
-                    {% if from_admin is defined and is_granted("ROLE_SUPER_ADMIN") %}
-                        <a href="{{ path('member_timelog_delete',{ "id":member.id, "timelog_id": timeLog.id }) }}" class="red-text">X</a>
-                    {% endif %}
-                </td>
+                {% if from_admin and is_granted("ROLE_ADMIN") %}
+                    <td>{{ timeLog.requestRoute }}</td>
+                {% endif %}
+                {% if from_admin is defined and is_granted("ROLE_SUPER_ADMIN") %}
+                    <td title="Supprimer">
+                        <a href="{{ path('member_timelog_delete', { "id": member.id, "timelog_id": timeLog.id }) }}" class="red-text">X</a>
+                    </td>
+                {% endif %}
             </tr>
         {% endfor %}
     </tbody>

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -53,9 +53,6 @@ twig:
     registration_duration: '%registration_duration%'
     support_email: '%transactional_mailer_user%'
     images_tmp_dir: '%images_tmp_dir%'
-    beneficiary_service: "@beneficiary_service"
-    membership_service: "@membership_service"
-    shift_service: "@shift_service"
     maximum_nb_of_beneficiaries_in_membership: '%maximum_nb_of_beneficiaries_in_membership%'
     allow_extra_shifts: '%allow_extra_shifts%'
     time_after_which_members_are_late_with_shifts: '%time_after_which_members_are_late_with_shifts%'
@@ -96,6 +93,11 @@ twig:
     role_admin_icon: verified_user
     role_super_admin_name: Super admin
     role_super_admin_icon: 
+    # services
+    beneficiary_service: "@beneficiary_service"
+    membership_service: "@membership_service"
+    shift_service: "@shift_service"
+    time_log_service: "@time_log_service"
 
 # Doctrine Configuration
 doctrine:

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -195,9 +195,9 @@ services:
         class: AppBundle\Service\TimeLogService
         public: true
         arguments:
-            - "@doctrine.orm.entity_manager"
-            - '@membership_service'
-            - "%due_duration_by_cycle%"
+            $em: "@doctrine.orm.entity_manager"
+            $membershipService: '@membership_service'
+            $due_duration_by_cycle: "%due_duration_by_cycle%"
 
     beneficiary_service:
             class: AppBundle\Service\BeneficiaryService

--- a/src/AppBundle/Command/FixTimeLogCommand.php
+++ b/src/AppBundle/Command/FixTimeLogCommand.php
@@ -38,7 +38,7 @@ class FixTimeLogCommand extends ContainerAwareCommand
                     });
                     // Insert log if it doesn't exist fot this shift
                     if ($logs->count() == 0) {
-                        $log = $this->getContainer()->get('time_log_service')->initShiftLog($shift, $shift->getStart(), "Créneau réalisé");
+                        $log = $this->getContainer()->get('time_log_service')->initShiftTimeLog($shift, $shift->getStart(), "Créneau réalisé");
                         $em->persist($log);
                         $countShiftLogs++;
                     }

--- a/src/AppBundle/Command/InitTimeLogCommand.php
+++ b/src/AppBundle/Command/InitTimeLogCommand.php
@@ -41,13 +41,13 @@ class InitTimeLogCommand extends ContainerAwareCommand
                 $current_cycle_end = $this->getContainer()->get('membership_service')->getEndOfCycle($member, 0);
                 $shifts = $em->getRepository('AppBundle:Shift')->findShiftsForMembership($member, $previous_cycle_start, $current_cycle_end);
                 foreach ($shifts as $shift) {
-                    $log = $this->getContainer()->get('time_log_service')->initShiftLog($shift, $shift->getStart());
+                    $log = $this->getContainer()->get('time_log_service')->initShiftTimeLog($shift, $shift->getStart());
                     $em->persist($log);
                     $countShiftLogs++;
                 }
 
                 if ($member->getFirstShiftDate() < $beginningOfLastCycle) {
-                    $log = $this->getContainer()->get('time_log_service')->initCurrentCycleBeginningLog($member);
+                    $log = $this->getContainer()->get('time_log_service')->initCurrentCycleBeginningTimeLog($member);
                     $em->persist($log);
                     $countCycleBeginning++;
                 }

--- a/src/AppBundle/Controller/MembershipController.php
+++ b/src/AppBundle/Controller/MembershipController.php
@@ -205,7 +205,7 @@ class MembershipController extends Controller
 
     private function createNewTimeLogForm(Membership $member)
     {
-        $newTimeLogAction = $this->generateUrl('time_log_new', array('id' => $member->getId()));
+        $newTimeLogAction = $this->generateUrl('timelog_new', array('id' => $member->getId()));
         return $this->createForm(TimeLogType::class, new TimeLog(), array('action' => $newTimeLogAction));
     }
 

--- a/src/AppBundle/Controller/TimeLogController.php
+++ b/src/AppBundle/Controller/TimeLogController.php
@@ -48,7 +48,7 @@ class TimeLogController extends Controller
     /**
      * Create a new log
      *
-     * @Route("/{id}/new", name="time_log_new", methods={"GET","POST"})
+     * @Route("/{id}/new", name="timelog_new", methods={"GET","POST"})
      * @Security("has_role('ROLE_SHIFT_MANAGER')")
      * @param Membership $member
      */

--- a/src/AppBundle/Controller/TimeLogController.php
+++ b/src/AppBundle/Controller/TimeLogController.php
@@ -55,23 +55,19 @@ class TimeLogController extends Controller
     public function newAction(Request $request, Membership $member)
     {
         $session = new Session();
-        $timeLog = new TimeLog();
+        $timeLog = $this->get('time_log_service')->initCustomTimeLog($member);
 
         $form = $this->createForm(TimeLogType::class, $timeLog);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-
-            $timeLog->setMembership($member);
             $timeLog->setTime($form->get('time')->getData());
-            $current_user = $this->get('security.token_storage')->getToken()->getUser();
-            $timeLog->setCreatedBy($current_user);
             $timeLog->setDescription($form->get('description')->getData());
-            $timeLog->setType(TimeLog::TYPE_CUSTOM);
 
             $em = $this->getDoctrine()->getManager();
             $em->persist($timeLog);
             $em->flush();
+
             $session->getFlashBag()->add('success', 'Le log de temps a bien été créé !');
             return $this->redirectToShow($member);
         }

--- a/src/AppBundle/Entity/ShiftFreeLog.php
+++ b/src/AppBundle/Entity/ShiftFreeLog.php
@@ -160,5 +160,4 @@ class ShiftFreeLog
 
         return $this;
     }
-
 }

--- a/src/AppBundle/Entity/TimeLog.php
+++ b/src/AppBundle/Entity/TimeLog.php
@@ -79,6 +79,13 @@ class TimeLog
     private $shift;
 
     /**
+     * @var string
+     *
+     * @ORM\Column(type="string", length=255, nullable=true)
+     */
+    private $requestRoute;
+
+    /**
      * @ORM\PrePersist
      */
     public function setCreatedAtValue()

--- a/src/AppBundle/Entity/TimeLog.php
+++ b/src/AppBundle/Entity/TimeLog.php
@@ -123,6 +123,7 @@ class TimeLog
     public function setCreatedBy(\AppBundle\Entity\User $user = null)
     {
         $this->createdBy = $user;
+
         return $this;
     }
 

--- a/src/AppBundle/Entity/TimeLog.php
+++ b/src/AppBundle/Entity/TimeLog.php
@@ -243,6 +243,7 @@ class TimeLog
     public function setCreatedAt($date)
     {
         $this->createdAt = $date;
+
         return $this;
     }
 
@@ -254,6 +255,17 @@ class TimeLog
         $this->type = $type;
     }
 
+    public function getRequestRoute(): ?string
+    {
+        return $this->requestRoute;
+    }
+
+    public function setRequestRoute(?string $requestRoute): self
+    {
+        $this->requestRoute = $requestRoute;
+
+        return $this;
+    }
 
     /**
      * @return string

--- a/src/AppBundle/EventListener/TimeLogEventListener.php
+++ b/src/AppBundle/EventListener/TimeLogEventListener.php
@@ -158,7 +158,7 @@ class TimeLogEventListener
      */
     private function createShiftLog(Shift $shift, \DateTime $date = null, $description = null)
     {
-        $log = $this->container->get('time_log_service')->initShiftLog($shift, $date, $description);
+        $log = $this->container->get('time_log_service')->initShiftTimeLog($shift, $date, $description);
         $this->em->persist($log);
         $this->em->flush();
     }
@@ -187,7 +187,7 @@ class TimeLogEventListener
      */
     private function createCycleBeginningLog(Membership $member, \DateTime $date)
     {
-        $log = $this->container->get('time_log_service')->initCycleBeginningLog($member);
+        $log = $this->container->get('time_log_service')->initCycleBeginningTimeLog($member);
         $this->em->persist($log);
 
         $counter_today = $member->getTimeCount($date);

--- a/src/AppBundle/Service/ShiftFreeLogService.php
+++ b/src/AppBundle/Service/ShiftFreeLogService.php
@@ -7,7 +7,6 @@ use AppBundle\Entity\Beneficiary;
 use AppBundle\Entity\Shift;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 
 class ShiftFreeLogService

--- a/src/AppBundle/Service/TimeLogService.php
+++ b/src/AppBundle/Service/TimeLogService.php
@@ -17,7 +17,7 @@ class TimeLogService
     private $membershipService;
     private $due_duration_by_cycle;
 
-    public function __construct(EntityManagerInterface $em, RequestStack $requestStack, TokenStorage $tokenStorage, MembershipService $membershipService, $due_duration_by_cycle)
+    public function __construct(EntityManagerInterface $em, RequestStack $requestStack, TokenStorage $tokenStorage, MembershipService $membershipService, int $due_duration_by_cycle)
     {
         $this->em = $em;
         $this->requestStack = $requestStack;
@@ -39,6 +39,7 @@ class TimeLogService
         if ($date) {
             $log->setCreatedAt($date);
         } // else defaults to 'now'
+        $log->setCreatedBy($current_user);
         $log->setRequestRoute($request->get('_route'));
 
         return $log;

--- a/src/AppBundle/Service/TimeLogService.php
+++ b/src/AppBundle/Service/TimeLogService.php
@@ -87,4 +87,20 @@ class TimeLogService
 
         return $log;
     }
+
+    /**
+     * Initialize a custom log with the member data
+     * @param Membership $member
+     * @return TimeLog
+     */
+    public function initCustomTimeLog(Membership $member, $time = null, \DateTime $date = null, $description = null)
+    {
+        $log = $this->initTimeLog($member, $date, $description);
+        $log->setType(TimeLog::TYPE_CUSTOM);
+        if ($time) {
+            $log->setTime($time);
+        }
+
+        return $log;
+    }
 }

--- a/src/AppBundle/Service/TimeLogService.php
+++ b/src/AppBundle/Service/TimeLogService.php
@@ -49,7 +49,7 @@ class TimeLogService
      * @param Shift $shift
      * @return TimeLog
      */
-    public function initShiftLog(Shift $shift, \DateTime $date = null, $description = null)
+    public function initShiftTimeLog(Shift $shift, \DateTime $date = null, $description = null)
     {
         $log = $this->initTimeLog($shift->getShifter()->getMembership(), $date, $description);
         $log->setType(TimeLog::TYPE_SHIFT);
@@ -65,7 +65,7 @@ class TimeLogService
      * @param \DateTime $date
      * @return TimeLog
      */
-    public function initCycleBeginningLog(Membership $member, \DateTime $date = null)
+    public function initCycleBeginningTimeLog(Membership $member, \DateTime $date = null)
     {
         $log = $this->initTimeLog($member, $date);
         $log->setType(TimeLog::TYPE_CYCLE_END);
@@ -79,10 +79,10 @@ class TimeLogService
      * @param Membership $member
      * @return TimeLog
      */
-    public function initCurrentCycleBeginningLog(Membership $member)
+    public function initCurrentCycleBeginningTimeLog(Membership $member)
     {
         $date = $this->membershipService->getStartOfCycle($member, 0);
-        $log = $this->initCycleBeginningLog($member, $date);
+        $log = $this->initCycleBeginningTimeLog($member, $date);
 
         return $log;
     }


### PR DESCRIPTION
### Quoi ?

dans le modèle `TimeLog`
- nouveau champ `requestRoute` (similaire à `ShiftFreeLog`)

dans le service `TimeLogService`
- s'inspirer de `ShiftFreeLogService` (importer RequestStack, TokenStorage)
- stocker par défaut le `createdBy` & `requestRoute`
- nouvelle fonction `initTimeLog`
- renommer les autres fonctions pour bien indiquer "TimeLog" dans leur suffix

dans Admin > Membres : 
- dans le tableau "Compteur temps", nouvelle colonne "Route"