### PR TITLE
Accueil : ordonner les créneaux

### DIFF
--- a/app/Resources/views/default/card_reader/_partial/bucket_card.html.twig
+++ b/app/Resources/views/default/card_reader/_partial/bucket_card.html.twig
@@ -22,7 +22,7 @@
             <b>{{ bucket.start | date('H:i') }} à {{ bucket.end | date('H:i') }}</b>
         </div>
         <ul>
-            {% for shift in bucket.shifts %}
+            {% for shift in bucket.sortedShifts %}
                 <li style="height: 30px">
                     <div>
                         {% if use_card_reader_to_validate_shifts %}


### PR DESCRIPTION
### Quoi ?

Sur la page d'accueil (`/cardReader`), ordonner les créneaux pour afficher toujours "libre" en dernier

Similaire aux autres pages de booking

### Pourquoi ?

Pour clarifier l'affichage

### Captures d'écran

|Avant|Après|
|---|---|
|![Screenshot from 2023-02-03 14-33-33](https://user-images.githubusercontent.com/7147385/216616370-a9a1014e-259f-43f0-8384-99cd7c06a07d.png)|![Screenshot from 2023-02-03 14-34-21](https://user-images.githubusercontent.com/7147385/216616400-94aa556d-eb87-4d23-9ef3-abe6e7c74f4d.png)|


