### PR TITLE
Exemption : nouveau filtre par membre

### DIFF
--- a/app/Resources/views/admin/membershipshiftexemption/index.html.twig
+++ b/app/Resources/views/admin/membershipshiftexemption/index.html.twig
@@ -22,6 +22,12 @@
                 <div class="row">
                     <div class="col s4">
                         <div class="input-field">
+                            {{ form_widget(filter_form.membership) }}
+                            {{ form_label(filter_form.membership) }}
+                        </div>
+                    </div>
+                    <div class="col s4">
+                        <div class="input-field">
                             {{ form_widget(filter_form.shiftExemption) }}
                             {{ form_label(filter_form.shiftExemption) }}
                         </div>

--- a/app/Resources/views/form/fields.html.twig
+++ b/app/Resources/views/form/fields.html.twig
@@ -9,6 +9,21 @@
     </div>
 {%- endblock form_row -%}
 
+{% block autocomplete_membership_widget %}
+    {% spaceless %}
+        <input type="text" {{ block('widget_attributes') }} {% if value is not empty %}value="{{ value }}" {% endif %}/>
+    {% endspaceless %}
+    <script>
+        defer(function(){
+            // Init autocomplete
+            $('#{{ id }}').autocomplete({
+                data: {{ membership_service.autocompleteMemberships | json_encode(constant('JSON_UNESCAPED_UNICODE')) | raw }},
+                limit: 6,
+            });
+        });
+    </script>
+{% endblock %}
+
 {% block autocomplete_beneficiary_widget %}
     {% spaceless %}
         <input type="text" {{ block('widget_attributes') }} {% if value is not empty %}value="{{ value }}" {% endif %}/>

--- a/src/AppBundle/Controller/MembershipShiftExemptionController.php
+++ b/src/AppBundle/Controller/MembershipShiftExemptionController.php
@@ -4,6 +4,7 @@ namespace AppBundle\Controller;
 
 use AppBundle\Entity\Beneficiary;
 use AppBundle\Entity\MembershipShiftExemption;
+use AppBundle\Form\AutocompleteMembershipType;
 use AppBundle\Repository\ShiftExemptionRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
@@ -28,12 +29,17 @@ class MembershipShiftExemptionController extends Controller
     {
         // default values
         $res = [
+            "membership" => null,
             "shiftExemption" => null,
         ];
 
         // filter creation ----------------------
         $res["form"] = $this->createFormBuilder()
             ->setAction($this->generateUrl('admin_membershipshiftexemption_index'))
+            ->add('membership', AutocompleteMembershipType::class, array(
+                'label' => 'Membre',
+                'required' => false,
+            ))
             ->add('shiftExemption', EntityType::class, array(
                 'label' => 'Motif',
                 'class' => 'AppBundle:ShiftExemption',
@@ -50,6 +56,7 @@ class MembershipShiftExemptionController extends Controller
         $res['form']->handleRequest($request);
 
         if ($res['form']->isSubmitted() && $res['form']->isValid()) {
+            $res["membership"] = $res["form"]->get("membership")->getData();
             $res["shiftExemption"] = $res["form"]->get("shiftExemption")->getData();
         }
 
@@ -70,8 +77,11 @@ class MembershipShiftExemptionController extends Controller
         $sort = 'createdAt';
         $order = 'DESC';
 
-        if ($filter["shiftExemption"]) {
-            $findByFilter["shiftExemption"] = $filter["shiftExemption"];
+        if ($filter['membership']) {
+            $findByFilter['membership'] = $filter['membership'];
+        }
+        if ($filter['shiftExemption']) {
+            $findByFilter['shiftExemption'] = $filter['shiftExemption'];
         }
 
         $page = $request->get('page', 1);

--- a/src/AppBundle/Form/AutocompleteMembershipType.php
+++ b/src/AppBundle/Form/AutocompleteMembershipType.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace AppBundle\Form;
+
+use AppBundle\Form\DataTransformer\MembershipToStringTransformer;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\AbstractType;
+
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+
+class AutocompleteMembershipType extends AbstractType
+{
+
+    private $transformer;
+
+    public function __construct(MembershipToStringTransformer $transformer)
+    {
+        $this->transformer = $transformer;
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'block_prefix' => 'autocomplete_membership',
+            'attr' => ['class' => 'autocomplete'],
+        ]);
+    }
+
+    public function getParent()
+    {
+        return TextType::class;
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->addModelTransformer($this->transformer);
+    }
+
+}

--- a/src/AppBundle/Form/DataTransformer/MembershipToStringTransformer.php
+++ b/src/AppBundle/Form/DataTransformer/MembershipToStringTransformer.php
@@ -2,13 +2,13 @@
 
 namespace AppBundle\Form\DataTransformer;
 
-use AppBundle\Entity\Beneficiary;
+use AppBundle\Entity\Membership;
 use AppBundle\Entity\User;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Exception\TransformationFailedException;
 
-class BeneficiaryToStringTransformer implements DataTransformerInterface
+class MembershipToStringTransformer implements DataTransformerInterface
 {
     private $entityManager;
 
@@ -18,26 +18,26 @@ class BeneficiaryToStringTransformer implements DataTransformerInterface
     }
 
     /**
-    * Transforms an object (Beneficiary) to a string.
+    * Transforms an object (Membership) to a string.
     *
-    * @param  Beneficiary|null $beneficiary
+    * @param  Membership|null $membership
     * @return string
     */
-    public function transform($beneficiary)
+    public function transform($membership)
     {
-        if ($beneficiary === null) {
+        if (null === $membership) {
             return '';
         }
 
-        return $beneficiary->getDisplayNameWithMemberNumber();
+        return $membership->getDisplayNameWithMemberNumber();
     }
 
     /**
-     * Transforms a string to an object (Beneficiary).
+     * Transforms a string to an object (Membership).
      *
      * @param  string $autocomplete
-     * @return Beneficiary
-     * @throws TransformationFailedException if object (Beneficiary) is not found
+     * @return Membership
+     * @throws TransformationFailedException if object (Membership) is not found
      */
     public function reverseTransform($autocomplete)
     {
@@ -45,17 +45,17 @@ class BeneficiaryToStringTransformer implements DataTransformerInterface
             return null;
         }
 
-        $beneficiary = $this->entityManager
-            ->getRepository(Beneficiary::class)
+        $membership = $this->entityManager
+            ->getRepository(Membership::class)
             ->findOneFromAutoComplete($autocomplete);
 
-        if ($beneficiary === null) {
+        if ($membership === null) {
             throw new TransformationFailedException(sprintf(
                 'Aucun utilisateur trouvé avec ces données "%s".',
                 $autocomplete
             ));
         }
 
-        return $beneficiary;
+        return $membership;
     }
 }

--- a/src/AppBundle/Repository/BeneficiaryRepository.php
+++ b/src/AppBundle/Repository/BeneficiaryRepository.php
@@ -18,13 +18,14 @@ class BeneficiaryRepository extends \Doctrine\ORM\EntityRepository
      */
     public function findOneFromAutoComplete($beneficiary)
     {
-        $qb = $this->createQueryBuilder('b');
-
-        $qb->leftJoin('b.membership', 'm')
+        $qb = $this->createQueryBuilder('b')
+            ->leftJoin('b.membership', 'm')
             ->where('CONCAT(\'#\', m.member_number, \' \', b.firstname, \' \', b.lastname) = :fullname')
             ->setParameter('fullname', $beneficiary);
 
-        return $qb->getQuery()->getOneOrNullResult();
+        return $qb
+            ->getQuery()
+            ->getOneOrNullResult();
     }
 
     /**
@@ -35,13 +36,14 @@ class BeneficiaryRepository extends \Doctrine\ORM\EntityRepository
      */
     public function findFromAutoComplete($beneficiaries)
     {
-        $qb = $this->createQueryBuilder('b');
+        $qb = $this->createQueryBuilder('b')
+            ->leftJoin('b.membership', 'm')
+            ->where('CONCAT(\'#\', m.member_number, \' \', b.firstname, \' \', b.lastname) IN (:fullnameList)')
+            ->setParameter('fullnameList', $beneficiaries);
 
-        $qb->leftJoin('b.membership', 'm')
-            ->where('CONCAT(\'#\', m.member_number, \' \', b.firstname, \' \', b.lastname) IN (:fullname)')
-            ->setParameter('fullname', $beneficiaries);
-
-        return $qb->getQuery()->getResult();
+        return $qb
+            ->getQuery()
+            ->getResult();
     }
 
     /**
@@ -53,29 +55,30 @@ class BeneficiaryRepository extends \Doctrine\ORM\EntityRepository
     public function findAllActive()
     {
 
-        $qb = $this->createQueryBuilder('beneficiary');
-
-        $qb->select('beneficiary, membership')
+        $qb = $this->createQueryBuilder('beneficiary')
+            ->select('beneficiary, membership')
             ->join('beneficiary.user', 'user')
             ->join('beneficiary.membership', 'membership')
             ->where('membership.withdrawn = 0');
 
-        return $qb->getQuery()->getResult();
+        return $qb
+            ->getQuery()
+            ->getResult();
     }
 
     public function findCoShifters($shift)
     {
         $qb = $this->createQueryBuilder('b')
-                   ->leftJoin('b.shifts', 's')
-                    ->where('s.start = :start')
-                    ->andWhere('s.end = :end')
-                    ->andWhere('s.job = :job')
-                    ->andWhere('s.id != :id')
-                    ->andWhere('s.shifter IS NOT NULL')
-                    ->setParameter('start', $shift->getStart())
-                    ->setParameter('end', $shift->getEnd())
-                    ->setParameter('job', $shift->getJob())
-                    ->setParameter('id', $shift->getId());
+            ->leftJoin('b.shifts', 's')
+            ->where('s.start = :start')
+            ->andWhere('s.end = :end')
+            ->andWhere('s.job = :job')
+            ->andWhere('s.id != :id')
+            ->andWhere('s.shifter IS NOT NULL')
+            ->setParameter('start', $shift->getStart())
+            ->setParameter('end', $shift->getEnd())
+            ->setParameter('job', $shift->getJob())
+            ->setParameter('id', $shift->getId());
 
         return $qb
             ->getQuery()

--- a/src/AppBundle/Repository/MembershipRepository.php
+++ b/src/AppBundle/Repository/MembershipRepository.php
@@ -23,10 +23,11 @@ class MembershipRepository extends \Doctrine\ORM\EntityRepository
     {
         // extract member_number from $membership string
         preg_match('/#(.*?)\s/s', $membership, $matches);
-        $membershipMemberNumber = $matches[0];
+        $membershipMemberNumber = $matches[1];
+
 
         $qb = $this->createQueryBuilder('m')
-            ->where('member_number = :memberNumber')
+            ->where('m.member_number = :memberNumber')
             ->setParameter('memberNumber', $membershipMemberNumber);
 
         return $qb
@@ -43,14 +44,15 @@ class MembershipRepository extends \Doctrine\ORM\EntityRepository
      */
     public function findFromAutoComplete($memberships)
     {
+        // extract member_number from $memberships list of string
         $membershipMemberNumberList = array();
         foreach ($memberships as $memberships) {
             preg_match('/#(.*?)\s/s', $membership, $matches);
-            $membershipMemberNumberList[] = $matches[0];
+            $membershipMemberNumberList[] = $matches[1];
         }
 
         $qb = $this->createQueryBuilder('m')
-            ->where('member_number IN (:memberNumberList)')
+            ->where('m.member_number IN (:memberNumberList)')
             ->setParameter('memberNumberList', $membershipMemberNumberList);
 
         return $qb

--- a/src/AppBundle/Repository/MembershipRepository.php
+++ b/src/AppBundle/Repository/MembershipRepository.php
@@ -12,6 +12,15 @@ use Doctrine\ORM\Query\Expr\Join;
  */
 class MembershipRepository extends \Doctrine\ORM\EntityRepository
 {
+    public function findAllActive()
+    {
+        $qb = $this->createQueryBuilder('m')
+            ->where('m.withdrawn = 0');
+
+        return $qb
+            ->getQuery()
+            ->getResult();
+    }
 
     public function findWithNewCycleStarting($date, $cycle_type)
     {
@@ -73,7 +82,9 @@ class MembershipRepository extends \Doctrine\ORM\EntityRepository
             ->where('u.roles LIKE :roles')
             ->setParameter('roles', '%"' . $role . '"%');
 
-        return $qb->getQuery()->getResult();
+        return $qb
+            ->getQuery()
+            ->getResult();
     }
 
     /**
@@ -93,7 +104,9 @@ class MembershipRepository extends \Doctrine\ORM\EntityRepository
             ->andWhere("r.date <= :from")
             ->setParameter('from', $from);
 
-        return $qb->getQuery()->getResult();
+        return $qb
+            ->getQuery()
+            ->getResult();
     }
 
     public function findLateShifters($time_after_which_members_are_late_with_shifts = null)
@@ -105,9 +118,9 @@ class MembershipRepository extends \Doctrine\ORM\EntityRepository
             ->andWhere('m.frozen = 0')
             ->andWhere('m IN (SELECT IDENTITY(t.membership) FROM AppBundle\Entity\TimeLog t GROUP BY t.membership HAVING SUM(t.time) < :compteurlt * 60)')
             ->setParameter('compteurlt', $time_after_which_members_are_late_with_shifts);
+
         return $qb
               ->getQuery()
               ->getResult();
     }
-
 }

--- a/src/AppBundle/Repository/MembershipRepository.php
+++ b/src/AppBundle/Repository/MembershipRepository.php
@@ -22,7 +22,7 @@ class MembershipRepository extends \Doctrine\ORM\EntityRepository
     public function findOneFromAutoComplete($membership)
     {
         // extract member_number from $membership string
-        preg_match('/#(.*?)\s/s', $membership, $matches);
+        preg_match('/#(\d+)\s/s', $membership, $matches);
         $membershipMemberNumber = $matches[1];
 
 
@@ -33,31 +33,6 @@ class MembershipRepository extends \Doctrine\ORM\EntityRepository
         return $qb
             ->getQuery()
             ->getOneOrNullResult();
-    }
-
-    /**
-     * findFromAutoComplete
-     *
-     * We consider that each string of $memberships has the following format:
-     * "#<Membership.member_number> <Beneficiary1.firstname> <Beneficiary1.lastname>"
-     * or "#<Membership.member_number> <Beneficiary1.firstname> <Beneficiary1.lastname> & <Beneficiary2.firstname> <Beneficiary2.lastname>"
-     */
-    public function findFromAutoComplete($memberships)
-    {
-        // extract member_number from $memberships list of string
-        $membershipMemberNumberList = array();
-        foreach ($memberships as $memberships) {
-            preg_match('/#(.*?)\s/s', $membership, $matches);
-            $membershipMemberNumberList[] = $matches[1];
-        }
-
-        $qb = $this->createQueryBuilder('m')
-            ->where('m.member_number IN (:memberNumberList)')
-            ->setParameter('memberNumberList', $membershipMemberNumberList);
-
-        return $qb
-            ->getQuery()
-            ->getResult();
     }
 
     public function findAllActive()
@@ -111,24 +86,6 @@ class MembershipRepository extends \Doctrine\ORM\EntityRepository
                     ->andWhere('MOD(DATE_DIFF(:now, u.firstShiftDate), 28) != 0')
                     ->setParameter('now', $date);
         }
-
-        return $qb
-            ->getQuery()
-            ->getResult();
-    }
-
-    /**
-     * @param string $role
-     *
-     * @return array
-     */
-    public function findByRole($role)
-    {
-        $qb = $this->createQueryBuilder()
-            ->select('u')
-            ->from($this->_entityName, 'u')
-            ->where('u.roles LIKE :roles')
-            ->setParameter('roles', '%"' . $role . '"%');
 
         return $qb
             ->getQuery()

--- a/src/AppBundle/Service/BeneficiaryService.php
+++ b/src/AppBundle/Service/BeneficiaryService.php
@@ -29,12 +29,13 @@ class BeneficiaryService
      */
     public function getAutocompleteBeneficiaries()
     {
+        $returnArray = array();
         $beneficiaries = $this->em->getRepository('AppBundle:Beneficiary')->findAllActive();
 
-        $returnArray = array();
-        foreach ($beneficiaries as $beneficiary){
+        foreach ($beneficiaries as $beneficiary) {
             $returnArray[$beneficiary->getDisplayNameWithMemberNumber()] = '';
         }
+
         return $returnArray;
     }
 

--- a/src/AppBundle/Service/MembershipService.php
+++ b/src/AppBundle/Service/MembershipService.php
@@ -34,7 +34,7 @@ class MembershipService
     public function getAutocompleteMemberships()
     {
         $returnArray = array();
-        $beneficiaries = $this->em->getRepository('AppBundle:Membership')->findAllActive();
+        $memberships = $this->em->getRepository('AppBundle:Membership')->findAllActive();
 
         foreach ($memberships as $membership) {
             $returnArray[$membership->getMemberNumberWithBeneficiaryListString()] = '';

--- a/src/AppBundle/Service/MembershipService.php
+++ b/src/AppBundle/Service/MembershipService.php
@@ -28,6 +28,21 @@ class MembershipService
         $this->cycle_type = $cycle_type;
     }
 
+     /**
+     * Return autocomplete information
+     */
+    public function getAutocompleteMemberships()
+    {
+        $returnArray = array();
+        $beneficiaries = $this->em->getRepository('AppBundle:Membership')->findAllActive();
+
+        foreach ($memberships as $membership) {
+            $returnArray[$membership->getMemberNumberWithBeneficiaryListString()] = '';
+        }
+
+        return $returnArray;
+    }
+
     /**
      * get remainder
      * @param Membership $membership


### PR DESCRIPTION
### Quoi ?

Dans la page "Liste des membres exempté.e.s de bénévolat", nouveau filtre par membre

Cela a permis/nécessité la création d'un autocomplete par membre (similaire à l'autocomplete par bénéficiaire qui existe déjà).
J'ai simplifié le matching ensuite en ne regardant que le `member_number` fourni