### PR TITLE
Mettre en avant les nouveux membres

### DIFF
--- a/app/Resources/views/admin/booking/_partial/bucket_card.html.twig
+++ b/app/Resources/views/admin/booking/_partial/bucket_card.html.twig
@@ -20,17 +20,22 @@
                 {% for shift in bucket.sortedShifts() %}
                     {% if (shiftercount < 4) %}
                         {% if (shift.shifter) %}{# is booked #}
-                            <li id="main-shift-{{shift.id}}">
+                            <li id="main-shift-{{ shift.id }}">
                                 {% if shift.formation %}<b data-formation="{{ shift.formation.name }}">{% endif %}
                                 {% if use_card_reader_to_validate_shifts and shift.isPastOrCurrent %}
                                     <span class="{% if shift.wasCarriedOut %}green-text{% else %}red-text{% endif %}">&#9673;</span>&nbsp;
                                 {% endif %}
                                 {{ shift.shifter.publicDisplayName }}
                                 {% if shift.formation %}</b>{% endif %}
-                                {% if not shift.formation and shift.shifter.formations | length > 0 %}&nbsp;<b class="orange-text">(q)</b>{% endif %}
+                                {% if not shift.formation and shift.shifter.formations | length > 0 %}
+                                    &nbsp;<strong class="orange-text">(q)</strong>
+                                {% endif %}
+                                {% if shift.shifter.isNew %}
+                                    &nbsp;<strong class="red-text" title="Nouveau membre">{{ beneficiary_new_icon }}</strong>
+                                {% endif %}
                             </li>
                         {% else %}
-                            <li id="main-shift-{{shift.id}}">
+                            <li id="main-shift-{{ shift.id }}">
                                 <b>
                                     {% if use_card_reader_to_validate_shifts and shift.isPastOrCurrent %}
                                         <span class="red-text">&#9673;</span>&nbsp;

--- a/app/Resources/views/beneficiary/_partial/info.html.twig
+++ b/app/Resources/views/beneficiary/_partial/info.html.twig
@@ -2,10 +2,12 @@
     <img src="{{ gravatar(beneficiary.email,40) }}" alt="{{ beneficiary.firstname | lower | capitalize }}" class="circle responsive-img" />
     {{ beneficiary.firstname | lower | capitalize }} {{ beneficiary.lastname | upper }}
     {% if beneficiary.isMain and maximum_nb_of_beneficiaries_in_membership > 1 %}
-        <span class="teal white-text badge">⚐ principal</span>
+        <span class="teal white-text badge">{{ beneficiary_main_icon }} principal</span>
     {% endif %}
     {% if beneficiary.membership.withdrawn %}
         <span class="red white-text badge">{{ member_withdrawn_icon }} fermé</span>
+    {% elseif beneficiary.isNew %}
+        <span class="red white-text badge">{{ beneficiary_new_icon }} nouveau</span>
     {% endif %}
     {% if beneficiary.membership.frozenChange %}
         {% if beneficiary.membership.frozen %}

--- a/app/Resources/views/default/card_reader/_partial/bucket_card.html.twig
+++ b/app/Resources/views/default/card_reader/_partial/bucket_card.html.twig
@@ -36,10 +36,14 @@
                             <strong><i>libre</i></strong>
                         {% endif %}
                         {% if shift.formation %}
-                            <span class="chip" style="margin-left: 5px"><b>{{ shift.formation }}</b></span>
+                            <span class="chip" style="margin-left: 5px">
+                                <strong>{{ shift.formation }}</strong>
+                            </span>
                         {% endif %}
-                        {% if shift.shifter and shift.shifter.shifts | length == 1 %}
-                            <span class="chip red white-text" style="margin-left: 5px">Premier créneau</span>
+                        {% if shift.shifter and shift.shifter.isNew %}
+                            <span class="chip red white-text" style="margin-left: 5px">
+                                {{ beneficiary_new_icon }} <strong>Premier créneau</strong>
+                            </span>
                         {% endif %}
                     </div>
                 </li>

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -82,6 +82,7 @@ twig:
     member_registration_missing_material_icon: '%member_registration_missing_material_icon%'
     member_registration_missing_background_color: '%member_registration_missing_background_color%'
     # beneficiary
+    beneficiary_main_icon: '%beneficiary_main_icon%'
     beneficiary_new_icon: '%beneficiary_new_icon%'
     beneficiary_flying_icon: '%beneficiary_flying_icon%'
     # swipe card

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -82,6 +82,7 @@ twig:
     member_registration_missing_material_icon: '%member_registration_missing_material_icon%'
     member_registration_missing_background_color: '%member_registration_missing_background_color%'
     # beneficiary
+    beneficiary_new_icon: '%beneficiary_new_icon%'
     beneficiary_flying_icon: '%beneficiary_flying_icon%'
     # swipe card
     display_swipe_cards_settings: '%display_swipe_cards_settings%'

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -134,6 +134,7 @@ parameters:
     member_registration_missing_background_color: rgb(0, 150, 136, 0.1)
 
     # Beneficiary configuration
+    beneficiary_new_icon: '★'
     beneficiary_flying_icon: '✈'
 
     # Swipe card configuration

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -134,6 +134,7 @@ parameters:
     member_registration_missing_background_color: rgb(0, 150, 136, 0.1)
 
     # Beneficiary configuration
+    beneficiary_main_icon: '⚐'
     beneficiary_new_icon: '★'
     beneficiary_flying_icon: '✈'
 

--- a/src/AppBundle/Entity/Beneficiary.php
+++ b/src/AppBundle/Entity/Beneficiary.php
@@ -691,4 +691,11 @@ class Beneficiary
         return $this->createdAt;
     }
 
+    /**
+     * @return bool
+     */
+    public function isNew()
+    {
+        return $this->shifts->count() <= 1;
+    }
 }


### PR DESCRIPTION
### Quoi ?

Mettre un peu en avant les nouveaux membres (plus exactement les nouveaux "bénéficiaires")

Il existait déjà un badge "Premier créneau" sur l'écran d'accueil (badgeuse)

Modifications apportées : 
- nouvelle fonction `Beneficiary.isNew()` qui regarde si le bénéficiaire a 0 ou 1 créneau
- badgeuse : afficher une étoile à coté du badge "Premier créneau"
- admin > créneaux : afficher une étoile à coté du bénéficiaire
- admin > membre : afficher un petit badge à coté du bénéficiaire


