### PR TITLE
Home : remonter l'info d'exemption, créer un template dédié

### DIFF
--- a/app/Resources/views/booking/home_booked_shifts.html.twig
+++ b/app/Resources/views/booking/home_booked_shifts.html.twig
@@ -2,18 +2,6 @@
     {% set beneficiary = app.user.beneficiary %}
     {% set member = beneficiary.membership %}
 
-    {% if member.isCurrentlyExemptedFromShifts() %}
-        <div class="card-panel teal white-text">
-            <i class="material-icons left">beach_access</i>
-            <strong>{% if member.beneficiaries | length %}Votre{% else %}Ton{% endif %} compte est exempté de créneau !</strong>
-            <ul class="list-unstyled">
-                {% for currentMembershipShiftExemption in member.getCurrentMembershipShiftExemptions() %}
-                    <li><i>{{ currentMembershipShiftExemption.shiftExemption }}</i> du {{ currentMembershipShiftExemption.start | date_fr_full }} au {{ currentMembershipShiftExemption.end | date_fr_full }}</li>
-                {% endfor %}
-            </ul>
-        </div>
-    {% endif %}
-
     <ul class="collapsible collapsible-expandable">
         {% if use_fly_and_fixed %}
             <li class="active">

--- a/app/Resources/views/default/index.html.twig
+++ b/app/Resources/views/default/index.html.twig
@@ -58,6 +58,18 @@
     </div>
 
     {% if app.user.beneficiary %}
+        {% if app.user.beneficiary.membership.isCurrentlyExemptedFromShifts() %}
+            <div class="card-panel teal white-text">
+                <i class="material-icons left">beach_access</i>
+                <strong>{% if app.user.beneficiary.membership.beneficiaries | length %}Votre{% else %}Ton{% endif %} compte est exempté de créneau !</strong>
+                <ul class="list-unstyled">
+                    {% for currentMembershipShiftExemption in app.user.beneficiary.membership.getCurrentMembershipShiftExemptions() %}
+                        <li><i>{{ currentMembershipShiftExemption.shiftExemption }}</i> du {{ currentMembershipShiftExemption.start | date_fr_full }} au {{ currentMembershipShiftExemption.end | date_fr_full }}</li>
+                    {% endfor %}
+                </ul>
+            </div>
+        {% endif %}
+
         <div id="home-actions" class="row center">
             {% if app.user.beneficiary.membership | uptodate %}
                 <div class="col s12 l6">

--- a/app/Resources/views/default/index.html.twig
+++ b/app/Resources/views/default/index.html.twig
@@ -59,15 +59,7 @@
 
     {% if app.user.beneficiary %}
         {% if app.user.beneficiary.membership.isCurrentlyExemptedFromShifts() %}
-            <div class="card-panel teal white-text">
-                <i class="material-icons left">beach_access</i>
-                <strong>{% if app.user.beneficiary.membership.beneficiaries | length %}Votre{% else %}Ton{% endif %} compte est exempté de créneau !</strong>
-                <ul class="list-unstyled">
-                    {% for currentMembershipShiftExemption in app.user.beneficiary.membership.getCurrentMembershipShiftExemptions() %}
-                        <li><i>{{ currentMembershipShiftExemption.shiftExemption }}</i> du {{ currentMembershipShiftExemption.start | date_fr_full }} au {{ currentMembershipShiftExemption.end | date_fr_full }}</li>
-                    {% endfor %}
-                </ul>
-            </div>
+            {% include "member/_partial/exempted.html.twig" with { member: app.user.beneficiary.membership } %}
         {% endif %}
 
         <div id="home-actions" class="row center">

--- a/app/Resources/views/member/_partial/exempted.html.twig
+++ b/app/Resources/views/member/_partial/exempted.html.twig
@@ -2,7 +2,11 @@
     <div class="col-12">
         <div class="card-panel teal white-text">
             <i class="material-icons left">beach_access</i>
-            <strong>{% if member.beneficiaries | length %}Votre{% else %}Ton{% endif %} compte est exempté de créneau !</strong>
+            {% if (from_admin ?? false) %}
+                <strong>Compte exempté de créneau !</strong>
+            {% else %}
+                <strong>{% if member.beneficiaries | length %}Votre{% else %}Ton{% endif %} compte est exempté de créneau !</strong>
+            {% endif %}
 
             <ul class="list-unstyled" style="margin-bottom: 0;">
                 {% for currentMembershipShiftExemption in member.getCurrentMembershipShiftExemptions() %}

--- a/app/Resources/views/member/_partial/exempted.html.twig
+++ b/app/Resources/views/member/_partial/exempted.html.twig
@@ -1,0 +1,14 @@
+<div class="row">
+    <div class="col-12">
+        <div class="card-panel teal white-text">
+            <i class="material-icons left">beach_access</i>
+            <strong>{% if member.beneficiaries | length %}Votre{% else %}Ton{% endif %} compte est exempté de créneau !</strong>
+
+            <ul class="list-unstyled" style="margin-bottom: 0;">
+                {% for currentMembershipShiftExemption in member.getCurrentMembershipShiftExemptions() %}
+                    <li><i>{{ currentMembershipShiftExemption.shiftExemption }}</i> du {{ currentMembershipShiftExemption.start | date_fr_full }} au {{ currentMembershipShiftExemption.end | date_fr_full }}</li>
+                {% endfor %}
+            </ul>
+        </div>
+    </div>
+</div>

--- a/app/Resources/views/member/_partial/shifts.html.twig
+++ b/app/Resources/views/member/_partial/shifts.html.twig
@@ -1,17 +1,7 @@
 {% set firstShiftDate = member.firstShiftDate %}
 
 {% if member.isCurrentlyExemptedFromShifts() %}
-    <div class="row">
-        <div class="card-panel teal white-text">
-            <i class="material-icons left">beach_access</i>
-            <strong>Compte exempté de créneau !</strong>
-            <ul class="list-unstyled">
-                {% for currentMembershipShiftExemption in member.getCurrentMembershipShiftExemptions() %}
-                    <li><i>{{ currentMembershipShiftExemption.shiftExemption }}</i> du {{ currentMembershipShiftExemption.start | date_fr_full }} au {{ currentMembershipShiftExemption.end | date_fr_full }}</li>
-                {% endfor %}
-            </ul>
-        </div>
-    </div>
+    {% include "member/_partial/exempted.html.twig" with { member: member, from_admin: true } %}
 {% endif %}
 
 {% if use_fly_and_fixed %}


### PR DESCRIPTION
### Quoi ?

- Sur la home, remonter l'info que son compte est exempté
- créer un template `member/_partial/exempted.html.twig`
- s'en servir dans la home & dans l'admin