### PR TITLE
Home : section dédié à la (ré)adhésion

### DIFF
--- a/app/Resources/views/default/index.html.twig
+++ b/app/Resources/views/default/index.html.twig
@@ -106,9 +106,9 @@
                     </div>
                 </div>
             {% endif %}
-            <div class="homebox">
-                <h5><span class="white">Mon compte</span></h5>
-                {% if (member.registrations | length) %}
+            {% if (member.registrations | length) %}
+                <div class="homebox">
+                    <h5><span class="white">Mon compte</span></h5>
                     <div>
                         <a href="{{ path("fos_user_profile_show") }}" class="waves-effect waves-light blue-grey btn">
                             <i class="material-icons left">settings</i>Gérer mon compte
@@ -119,8 +119,8 @@
                             {{ render(controller("AppBundle:Membership:homepageFreeze")) }}
                         {% endif %}
                     </div>
-                {% endif %}
-            </div>
+                </div>
+            {% endif %}
             <div class="homebox">
                 <h5><span class="white">En ce moment à {{ project_name }}</span></h5>
                 <a href="{{ path("schedule") }}" class="waves-effect waves-light btn teal darken-1">

--- a/app/Resources/views/default/index.html.twig
+++ b/app/Resources/views/default/index.html.twig
@@ -35,11 +35,6 @@
                     Tu partages ton compte avec {% for beneficiary in member.beneficiaries %}{% if beneficiary != app.user.beneficiary %}<strong>{{ beneficiary.firstname }}</strong>{% endif %}{% endfor %}
                 {% endif %}
             </p>
-            {% if (member | uptodate) and (member | can_register) %}
-                <a href="{{ path("user_self_register") }}" class="waves-effect waves-light light-green btn"><i class="material-icons left">card_membership</i>Je ré-adhère en ligne</a>
-                <br />
-                <br />
-            {% endif %}
         </div>
     {% else %}
         <div class="col s12">
@@ -77,38 +72,54 @@
             <div class="col show-on-xl-only xl3"></div>
         {% endif %}
         <div class="col s12 l6">
+            {% if not (member | uptodate) or (member | uptodate) and (member | can_register) %}
+                <div class="homebox">
+                    <h5><span class="white">Adhésion</span></h5>
+                    <div>
+                        {% if not (member | uptodate) %}
+                            {% if (member.registrations | length) %}{# existing member #}
+                                <p>
+                                    <i class="material-icons">warning</i>
+                                    {% if member.beneficiaries | length %}Votre{% else %}Ton{% endif %} adhésion a expirée le {{ "now" | date_modify((member | remainder | date("%R%a"))~" days")| date_fr_long }}.
+                                </p>
+                                <a href="{{ path("user_self_register") }}" class="waves-effect waves-light light-green btn">
+                                    <i class="material-icons left">card_membership</i>Ré-adhèrer en ligne
+                                </a>
+                            {% else %}{# new member #}
+                                <p>
+                                    <i class="material-icons">warning</i>
+                                    Il est temps d'adhérer :)
+                                </p>
+                                <a href="{{ path("user_self_register") }}" class="waves-effect waves-light light-green btn">
+                                    <i class="material-icons left">card_membership</i>Adhèrer en ligne
+                                </a>
+                            {% endif %}
+                        {% elseif (member | uptodate) and (member | can_register) %}
+                            <p>
+                                <i class="material-icons">warning</i>
+                                {% if member.beneficiaries | length %}Votre{% else %}Ton{% endif %} adhésion expire dans {{ membership_service.getRemainder(member) | date("%a") }} jours.
+                            </p>
+                            <a href="{{ path("user_self_register") }}" class="waves-effect waves-light light-green btn">
+                                <i class="material-icons left">card_membership</i>Je ré-adhère en ligne
+                            </a>
+                        {% endif %}
+                    </div>
+                </div>
+            {% endif %}
             <div class="homebox">
                 <h5><span class="white">Mon compte</span></h5>
-                <div>
-                    {% if (member.registrations | length) and not member | uptodate %}
-                        <p>
-                            <i class="material-icons">warning</i>
-                            {% if member.beneficiaries | length %}Votre{% else %}Ton{% endif %} adhésion a expirée le {{ "now" | date_modify((member | remainder | date("%R%a"))~" days")| date_fr_long }}
-                        </p>
-                        <a href="{{ path("user_self_register") }}" class="waves-effect waves-light light-green btn">
-                            <i class="material-icons left">card_membership</i>Ré-adhèrer en ligne
+                {% if (member.registrations | length) %}
+                    <div>
+                        <a href="{{ path("fos_user_profile_show") }}" class="waves-effect waves-light blue-grey btn">
+                            <i class="material-icons left">settings</i>Gérer mon compte
                         </a>
-                    {% elseif not member | uptodate %}
-                        <p>
-                            <i class="material-icons">warning</i>
-                            Il est temps d'adhérer.
-                        </p>
-                        <a href="{{ path("user_self_register") }}" class="waves-effect waves-light light-green btn">
-                            <i class="material-icons left">card_membership</i>Adhèrer en ligne
-                        </a>
-                    {% else %}
-                        <div>
-                            <a href="{{ path("fos_user_profile_show") }}" class="waves-effect waves-light blue-grey btn">
-                                <i class="material-icons left">settings</i>Gérer mon compte
-                            </a>
-                            {% if display_freeze_account %}
-                                <br />
-                                {# why render instead of include? because of forms init #}
-                                {{ render(controller("AppBundle:Membership:homepageFreeze")) }}
-                            {% endif %}
-                        </div>
-                    {% endif %}
-                </div>
+                        {% if display_freeze_account %}
+                            <br />
+                            {# why render instead of include? because of forms init #}
+                            {{ render(controller("AppBundle:Membership:homepageFreeze")) }}
+                        {% endif %}
+                    </div>
+                {% endif %}
             </div>
             <div class="homebox">
                 <h5><span class="white">En ce moment à {{ project_name }}</span></h5>


### PR DESCRIPTION
### Quoi ?

- sur la home, créer une section ("homebox") dédié à l'adhésion
- s'affiche dans les 3 cas de figure déjà gérés : 
  - nouveau membre sans adhésion
  - membre existant avec une adhésion bientôt expirée
  - membre existant avec une adhésion expirée

### Pourquoi ?

Pour clarifier le template et tout centraliser au même endroit

### Capture d'écran

![Screenshot from 2023-02-08 16-10-24](https://user-images.githubusercontent.com/7147385/217569397-045b1191-418f-4efa-b28d-1871f539e625.png)
