### PR TITLE
Filtre sur les membres : disable certains champs coté Ambassadeur

### DIFF
--- a/app/Resources/views/ambassador/phone/list.html.twig
+++ b/app/Resources/views/ambassador/phone/list.html.twig
@@ -1,11 +1,11 @@
 {% extends 'layout.html.twig' %}
 
-{% block title %}Liste des retardataires - {{ site_name }}{% endblock %}
+{% block title %}Liste des membres en retard {{ reason }} - {{ site_name }}{% endblock %}
 
 {% block breadcrumbs %}
 <a href="{{ path('homepage') }}"><i class="material-icons">home</i></a><i class="material-icons">chevron_right</i>
 <a href="{{ path('admin') }}"><i class="material-icons">build</i>&nbsp;Administration</a><i class="material-icons">chevron_right</i>
-<i class="material-icons">list</i>&nbsp;Liste des retardataires
+<i class="material-icons">list</i>&nbsp;Liste des membres en retard {{ reason }}
 {% endblock %}
 
 {% block content %}

--- a/src/AppBundle/Controller/AmbassadorController.php
+++ b/src/AppBundle/Controller/AmbassadorController.php
@@ -58,8 +58,9 @@ class AmbassadorController extends Controller
             'withdrawn' => 1,
             'lastregistrationdatelt' => $endLastRegistration
         ];
+        $disabledFields = ['withdrawn', 'lastregistrationdatelt'];
 
-        $form = $formHelper->createMembershipFilterForm($this->createFormBuilder(), $defaults);
+        $form = $formHelper->createMembershipFilterForm($this->createFormBuilder(), $defaults, $disabledFields);
         $form->handleRequest($request);
 
         $qb = $formHelper->initSearchQuery($this->getDoctrine()->getManager());
@@ -123,7 +124,9 @@ class AmbassadorController extends Controller
             'frozen' => 1,
             'compteurlt' => 0
         ];
-        $form = $formHelper->createShiftTimeLogFilterForm($this->createFormBuilder(), $defaults);
+        $disabledFields = ['withdrawn', 'compteurlt'];
+
+        $form = $formHelper->createShiftTimeLogFilterForm($this->createFormBuilder(), $defaults, $disabledFields);
         $form->handleRequest($request);
 
         $qb = $formHelper->initSearchQuery($this->getDoctrine()->getManager());

--- a/src/AppBundle/Service/SearchUserFormHelper.php
+++ b/src/AppBundle/Service/SearchUserFormHelper.php
@@ -27,15 +27,16 @@ class SearchUserFormHelper {
         $this->container = $container;
     }
 
-    public function getSearchForm($formBuilder, $type = null) {
+    public function getSearchForm($formBuilder, $type = null, $disabledFields = []) {
         $formBuilder->add('withdrawn', ChoiceType::class, [
-            'data' => 1,
             'label' => $this->container->getParameter('member_withdrawn_icon') . ' fermé',
             'required' => false,
+            'disabled' => in_array("withdrawn", $disabledFields) ? true : false,
             'choices' => [
                 'fermé' => 2,
                 'ouvert' => 1,
-            ]
+            ],
+            'data' => 1
         ]);
         if (!$type) {
             $formBuilder->add('enabled', ChoiceType::class, [
@@ -135,8 +136,9 @@ class SearchUserFormHelper {
             'html5' => false,
             'label' => 'avant le',
             'required' => false,
+            'disabled' => in_array("lastregistrationdatelt", $disabledFields) ? true : false,
             'attr' => [
-                'class' => 'datepicker'
+                'class' => 'datepicker',
             ]
         ]);
         if (!$type) {
@@ -147,7 +149,8 @@ class SearchUserFormHelper {
         }
         $formBuilder->add('compteurlt', NumberType::class, [
             'label' => 'max',
-            'required' => false
+            'required' => false,
+            'disabled' => in_array("compteurlt", $disabledFields) ? true : false,
         ])
         ->add('compteurgt', NumberType::class, [
             'label' => 'min',
@@ -261,8 +264,8 @@ class SearchUserFormHelper {
         return $form;
     }
 
-    public function createShiftTimeLogFilterForm($formBuilder, $defaults) {
-        $form = $this->getSearchForm($formBuilder, "shifttimelog");
+    public function createShiftTimeLogFilterForm($formBuilder, $defaults = [], $disabledFields = []) {
+        $form = $this->getSearchForm($formBuilder, "shifttimelog", $disabledFields);
         // set compteurlt default
         $options = $form->get('compteurlt')->getConfig()->getOptions();
         $options['required'] = true;
@@ -277,8 +280,8 @@ class SearchUserFormHelper {
         return $form;
     }
 
-    public function createMembershipFilterForm($formBuilder, $defaults) {
-        $form = $this->getSearchForm($formBuilder, "membership");
+    public function createMembershipFilterForm($formBuilder, $defaults, $disabledFields = []) {
+        $form = $this->getSearchForm($formBuilder, "membership", $disabledFields);
         // set lastregistrationdatelt default
         $options = $form->get('lastregistrationdatelt')->getConfig()->getOptions();
         $options['required'] = true;


### PR DESCRIPTION
### Quoi ?

Coté Admin, il y a 3 endroits où l'on peut filtrer sur la liste des membres : "Liste des membres", "Liste des membres en retard d'adhésion" et "Liste des membres en retard de créneaux". Mais les 2 derniers sont restreint à un certains type de membres.

Pour éviter de pouvoir trop élargir les résultats, je propose de disable certains champs dans les pages "Liste des membres en retard d'adhésion" & "Liste des membres en retard de créneaux"

J'ai aussi rendu plus explicite le title & breadcrumb

### Capture d'écran

![Screenshot from 2023-02-10 10-53-44](https://user-images.githubusercontent.com/7147385/218060986-f0be38a0-5192-4fb9-a49c-34569efcb9df.png)
