### PR TITLE
Planning : afficher tous les créneaux à venir (et non seulement +7 jours)

### DIFF
--- a/src/AppBundle/Controller/DefaultController.php
+++ b/src/AppBundle/Controller/DefaultController.php
@@ -100,12 +100,9 @@ class DefaultController extends Controller
                 }
             }
         } else {
-            $today = strtotime('today');
-            $from = new \DateTime();
-            $from->setTimestamp($today);
             $to = new \DateTime();
             $to->modify('+7 days');
-            $shifts = $em->getRepository('AppBundle:Shift')->findFrom($from, $to);
+            $shifts = $em->getRepository('AppBundle:Shift')->findFutures($to);
             $bucketsByDay = $this->get('shift_service')->generateShiftBucketsByDayAndJob($shifts);
 
             return $this->render('default/index_anon.html.twig', [

--- a/src/AppBundle/Repository/ShiftRepository.php
+++ b/src/AppBundle/Repository/ShiftRepository.php
@@ -45,14 +45,22 @@ class ShiftRepository extends \Doctrine\ORM\EntityRepository
             ->getResult();
     }
 
-    public function findFutures()
+    public function findFutures(\DateTime $max = null)
     {
         $qb = $this->createQueryBuilder('s');
 
         $qb
+            ->select('s, j')
+            ->leftJoin('s.job', 'j')
             ->where('s.start > :now')
             ->setParameter('now', new \Datetime('now'))
             ->orderBy('s.start', 'ASC');
+
+        if ($max) {
+            $qb
+                ->andWhere('s.end < :max')
+                ->setParameter('max', $max);
+        }
 
         return $qb
             ->getQuery()


### PR DESCRIPTION
### Quoi ?

Sur la page `/schedule` (authentification nécessaire), afficher tous les créneaux à venir.
Actuellement c'est limité aux 7 prochains jours.

Sur la page `/` en mode anonyme, le planning reste limité à 7 jours

### Pourquoi ?

Tous les membres peuvent déjà accéder à cette vue lorsqu'ils souhaitent réserver un créneau.
Donc pas de raison de limiter à 7j