### PR TITLE
Semaine type : fix sur le filtre par type de créneau

### DIFF
--- a/app/Resources/views/admin/period/index.html.twig
+++ b/app/Resources/views/admin/period/index.html.twig
@@ -275,21 +275,17 @@
         <div class="section">
             <table>
                 <thead>
-                <tr>
-                    {% for day in ["Lundi", "Mardi", "Mercredi", "Jeudi", "Vendredi", "Samedi", "Dimanche"] %}
-                        {% if periods_by_day[loop.index0]|length %}
-                            <th> {{ day }} </th>
-                        {% endif %}
-                    {% endfor %}
-                </tr>
+                    <tr>
+                        {% for key,day in days_of_week %}
+                            <th>{{ day }}</th>
+                        {% endfor %}
+                    </tr>
                 </thead>
                 <tbody>
-                <tr>
-                    {% for i in 0..6 %}
-                        {# for the 7 days of a week #}
-                        <td>
-                            {% if periods_by_day[0]|length %}
-                                {% for period in periods_by_day[i] %}
+                    <tr>
+                        {% for key,day in days_of_week %}
+                            <td>
+                                {% for period in periods_by_day[key] %}
                                     {% if ((filling_filter == null) and (beneficiary_filter == null))
                                         or (filling_filter == "problematic" and period.isProblematic(week_filter))
                                         or (filling_filter == "empty" and period.isEmpty(week_filter))
@@ -299,10 +295,9 @@
                                         {{ _self.period_card(period, week_filter) }}
                                     {% endif %}
                                 {% endfor %}
-                            {% endif %}
-                        </td>
-                    {% endfor %}
-                </tr>
+                            </td>
+                        {% endfor %}
+                    </tr>
                 </tbody>
             </table>
         </div>

--- a/src/AppBundle/Controller/PeriodController.php
+++ b/src/AppBundle/Controller/PeriodController.php
@@ -124,11 +124,12 @@ class PeriodController extends Controller
      */
     public function indexAction(Request $request, EntityManagerInterface $em): Response
     {
+        $daysOfWeek = ["Lundi", "Mardi", "Mercredi", "Jeudi", "Vendredi", "Samedi", "Dimanche"];
         $filter = $this->filterFormFactory($request);
         $periodsByDay = array();
         $order = array('start' => 'ASC');
 
-        for($i=0; $i<7; $i++) {
+        foreach ($daysOfWeek as $i => $value) {
             $findByFilter = array('dayOfWeek' => $i);
 
             if ($filter['job']) {
@@ -140,6 +141,7 @@ class PeriodController extends Controller
         }
 
         return $this->render('admin/period/index.html.twig', array(
+            'days_of_week' => $daysOfWeek,
             'periods_by_day' => $periodsByDay,
             'filter_form' => $filter['form']->createView(),
             'beneficiary_filter' => $filter['beneficiary'],


### PR DESCRIPTION
### Quoi ?

Dans la semaine type, si l'on filtre par un type de créneau qui n'a pas d'occurence "Lundi", alors rien ne s'affichait

### Captures d'écran

||Image|
|---|---|
|Avant|![Screenshot from 2023-02-22 12-49-34](https://user-images.githubusercontent.com/7147385/220611948-5ecb6cdf-eca0-45c6-9b5a-780b36269c2c.png)|
|Après|![Screenshot from 2023-02-22 12-49-14](https://user-images.githubusercontent.com/7147385/220611899-aefbb63e-6a46-420f-897d-419839b1b631.png)|

