### PR TITLE
Evenement : nouvelle fonction findFutures dans le Repository

### DIFF
--- a/app/Resources/views/default/event/_event.html.twig
+++ b/app/Resources/views/default/event/_event.html.twig
@@ -31,7 +31,7 @@
                             <div><b>{{ proxy_received_item.owner.membership.memberNumberWithBeneficiaryListString }}</b> accepte une procuration. <a href="{{ path("event_proxy_lite_remove",{'event':event.id,'proxy':proxy_received_item.id}) }}" class="red-text">X</a></div>
                         {% endif %}
                     {% endfor %}
-                    {% if (proxy_given is null) and (proxy_received|length == 0) %}
+                    {% if (proxy_given is null) and (proxy_received | length == 0) %}
                         <button class="activator waves-effect waves-light btn orange hide-on-small-only">
                             <i class="material-icons">list</i>
                             {% if event.anonymousProxy %}
@@ -49,7 +49,7 @@
             {% endif %}
             {% if is_granted("ROLE_SUPER_ADMIN") %}
                 <a href="{{ path("event_edit",{'id':event.id}) }}" class="btn">
-                    <i class="material-icons">edit</i> Editer
+                    <i class="material-icons">edit</i>&nbsp;Editer
                 </a>
             {% endif %}
         </div>
@@ -63,18 +63,20 @@
                 {% if not app.user.beneficiary or not app.user.beneficiary.membership or not app.user.beneficiary.membership.lastRegistration %}
                     <b>Oups, nous n'avons enregistré aucune adhésion pour ton compte. Tu ne pourras pas voter pour cet événement.</b>
                 {% else %}
+                    {% set member = app.user.beneficiary.membership %}
                     {% set proxy_given = event | givenProxy %}
                     {% set proxy_received = event | receivedProxies %}
+
                     {% if (registration_duration is not null) %}
                         {% set minDateOfLastRegistration = event.maxDateOfLastRegistration | date_modify('-' ~ registration_duration) %}
                     {% else %}
                         {% set minDateOfLastRegistration = null %}
                     {% endif %}
-                    {% if (minDateOfLastRegistration is not null and app.user.beneficiary.membership.lastRegistration.date < minDateOfLastRegistration) %}
+                    {% if (minDateOfLastRegistration is not null and member.lastRegistration.date < minDateOfLastRegistration) %}
                         <b>Oups</b>, seuls les membres qui ont adhéré ou ré-adhéré <b>après le {{ minDateOfLastRegistration | date('d M Y') }}</b> peuvent voter à cet événement.
                         <br />
                         Pense à mettre à jour ton adhésion pour participer ! :)
-                    {% elseif (app.user.beneficiary.membership.getTimeCount(event.maxDateOfLastRegistration) < time_after_which_members_are_late_with_shifts * 60) %}
+                    {% elseif (member.getTimeCount(event.maxDateOfLastRegistration) < time_after_which_members_are_late_with_shifts * 60) %}
                         <b>Oups</b>, seuls les membres avec un compteur de créneaux supérieur à <b>{{ time_after_which_members_are_late_with_shifts }} à la date du {{ event.maxDateOfLastRegistration | date('d M Y') }}</b> peuvent voter à cet événement.
                         <br />
                         Pense à rattraper tes créneaux pour la prochaine fois ! :)

--- a/src/AppBundle/Controller/DefaultController.php
+++ b/src/AppBundle/Controller/DefaultController.php
@@ -42,6 +42,7 @@ class DefaultController extends Controller
         $first = null;
         $em = $this->getDoctrine()->getManager();
         $securityContext = $this->container->get('security.authorization_checker');
+
         if ($securityContext->isGranted('IS_AUTHENTICATED_REMEMBERED')) {
             $session = new Session();
             $current_app_user = $this->get('security.token_storage')->getToken()->getUser();
@@ -110,18 +111,12 @@ class DefaultController extends Controller
                 'hours' => $this->getHours()
             ]);
         }
-        $qb = $em->createQueryBuilder();
-        $futur_events = $qb->select('e')->from('AppBundle\Entity\Event', 'e')
-            ->Where("e.date > :now")
-            ->orderBy("e.id", 'ASC')
-            ->setParameter('now', new \DateTime())
-            ->getQuery()
-            ->getResult();
 
+        $eventsFuture = $em->getRepository('AppBundle:Event')->findFutures();
         $dynamicContent = $em->getRepository('AppBundle:DynamicContent')->findOneByCode("HOME")->getContent();
 
         return $this->render('default/index.html.twig', [
-            'events' => $futur_events,
+            'events' => $eventsFuture,
             'dynamicContent' => $dynamicContent
         ]);
     }

--- a/src/AppBundle/Repository/EventRepository.php
+++ b/src/AppBundle/Repository/EventRepository.php
@@ -15,15 +15,16 @@ class EventRepository extends \Doctrine\ORM\EntityRepository
         $qb = $this->createQueryBuilder('e');
 
         $qb
-            ->Where("e.date > :now")
-            ->setParameter('now', new \Datetime('now'))
-            ->Where("e.date > :now");
+            ->where("e.date > :now")
+            ->setParameter('now', new \Datetime('now'));
 
         if ($max) {
             $qb
                 ->andWhere('e.date < :max')
                 ->setParameter('max', $max);
         }
+
+        $qb->orderBy("e.id", 'ASC');
 
         return $qb
             ->getQuery()

--- a/src/AppBundle/Repository/EventRepository.php
+++ b/src/AppBundle/Repository/EventRepository.php
@@ -10,4 +10,23 @@ namespace AppBundle\Repository;
  */
 class EventRepository extends \Doctrine\ORM\EntityRepository
 {
+    public function findFutures(\DateTime $max = null)
+    {
+        $qb = $this->createQueryBuilder('e');
+
+        $qb
+            ->Where("e.date > :now")
+            ->setParameter('now', new \Datetime('now'))
+            ->Where("e.date > :now");
+
+        if ($max) {
+            $qb
+                ->andWhere('e.date < :max')
+                ->setParameter('max', $max);
+        }
+
+        return $qb
+            ->getQuery()
+            ->getResult();
+    }
 }

--- a/src/AppBundle/Repository/ShiftRepository.php
+++ b/src/AppBundle/Repository/ShiftRepository.php
@@ -53,14 +53,15 @@ class ShiftRepository extends \Doctrine\ORM\EntityRepository
             ->select('s, j')
             ->leftJoin('s.job', 'j')
             ->where('s.start > :now')
-            ->setParameter('now', new \Datetime('now'))
-            ->orderBy('s.start', 'ASC');
+            ->setParameter('now', new \Datetime('now'));
 
         if ($max) {
             $qb
                 ->andWhere('s.end < :max')
                 ->setParameter('max', $max);
         }
+
+        $qb->orderBy('s.start', 'ASC');
 
         return $qb
             ->getQuery()


### PR DESCRIPTION
### Quoi ?

- s'inspirer de `ShiftRepository.findFutures()` pour créer un `EventRepository.findFutures()`
- s'en servir dans `DefaultController`
- léger cleanup dans `default/event/_event.html.twig`

### Pourquoi ?

Pour simplifier le code du controlleur