### PR TITLE
Roles : restreindre la suppression de créneaux (et de bucket) aux ADMIN

### DIFF
--- a/app/Resources/views/admin/booking/_partial/bucket_modal.html.twig
+++ b/app/Resources/views/admin/booking/_partial/bucket_modal.html.twig
@@ -62,7 +62,7 @@ id = "modal-bucket"
                     </p>
                     {% if is_granted('free',shift) %}
                         {% if use_card_reader_to_validate_shifts and shift.isPastOrCurrent %}
-                            {{ form_start(shift_validate_invalidate_forms[shift.id], {'attr': { 'style':  'display:inline;'}}) }}
+                            {{ form_start(shift_validate_invalidate_forms[shift.id], {'attr': { 'style': 'display:inline;' }}) }}
                                 {% if shift.wasCarriedOut %}
                                     <button type="submit" class="btn orange" title="Invalider la participation">
                                         <i class="material-icons left">highlight_off</i>Invalider la participation
@@ -74,7 +74,7 @@ id = "modal-bucket"
                                 {% endif %}
                             {{ form_end(shift_validate_invalidate_forms[shift.id]) }}
                         {% endif %}
-                        {{ form_start(shift_free_forms[shift.id], {'attr': { 'style':  'display:inline;' }}) }}
+                        {{ form_start(shift_free_forms[shift.id], {'attr': { 'style': 'display:inline;' }}) }}
                             {% do shift_free_forms[shift.id].reason.setRendered() %} <!-- hidden -->
                             {% if shift.isPast %}
                                 <button type="submit" class="btn red" title="Supprimer la participation">
@@ -110,7 +110,7 @@ id = "modal-bucket"
                     </div>
                 </div>
                 <div class="collapsible-body">
-                    {{ form_start(shift_book_forms[shift.id], {'attr': { 'style':  'display:inline;'}}) }}
+                    {{ form_start(shift_book_forms[shift.id], {'attr': { 'style': 'display:inline;' }}) }}
                     <div class="row">
                         <div class="col {% if use_fly_and_fixed %}s7{% else %}s9{% endif %} input-field">
                             {{ form_label(shift_book_forms[shift.id].shifter) }}
@@ -131,12 +131,14 @@ id = "modal-bucket"
                         </div>
                     </div>
                     {{ form_end(shift_book_forms[shift.id]) }}
-                    {% if not shift.lastShifter %}
-                        {{ form_start(shift_delete_forms[shift.id]) }}
-                        <button type="submit" title="Supprimer le poste" class="btn red">
-                            <i class="material-icons left">delete</i>Supprimer
-                        </button>
-                        {{ form_end(shift_delete_forms[shift.id]) }}
+                    {% if is_granted("ROLE_ADMIN") %}
+                        {% if not shift.lastShifter %}
+                            {{ form_start(shift_delete_forms[shift.id]) }}
+                            <button type="submit" title="Supprimer le poste" class="btn red">
+                                <i class="material-icons left">delete</i>Supprimer
+                            </button>
+                            {{ form_end(shift_delete_forms[shift.id]) }}
+                        {% endif %}
                     {% endif %}
                 </div>
             </li>
@@ -145,7 +147,7 @@ id = "modal-bucket"
 </ul>
 
 {# add shift form #}
-{{ form_start(bucket_add_form, {'attr': { 'style':  'display:inline;'}}) }}
+{{ form_start(bucket_add_form, {'attr': { 'style': 'display:inline;' }}) }}
 <input type="hidden" id="{{ bucket_add_form.start.date.vars.id }}" name="{{ bucket_add_form.start.date.vars.full_name }}" value="{{ bucket_add_form.start.date.vars.value }}">
 <input type="hidden" id="{{ bucket_add_form.start.time.vars.id }}" name="{{ bucket_add_form.start.time.vars.full_name }}" value="{{ bucket_add_form.start.time.vars.value }}">
 <input type="hidden" id="{{ bucket_add_form.end.date.vars.id }}" name="{{ bucket_add_form.end.date.vars.full_name }}" value="{{ bucket_add_form.end.date.vars.value }}">
@@ -167,13 +169,13 @@ id = "modal-bucket"
     </div>
 </div>
 {{ form_row(bucket_add_form._token) }}
-{{ form_end(bucket_add_form,  {'render_rest': false}) }}
+{{ form_end(bucket_add_form, {'render_rest': false}) }}
 
 {# bucket actions #}
 <a href="{{ path('mail_bucketshift', { 'id': bucket.id }) }}" class="btn">
     <i class="material-icons left">mail</i>Envoyer un email
 </a>
-{{ form_start(bucket_lock_unlock_form, {'attr': { 'style':  'display:inline;'}}) }}
+{{ form_start(bucket_lock_unlock_form, {'attr': { 'style': 'display:inline;' }}) }}
 {% if bucket.locked %}
     <button type="submit" class="btn orange">
         <i class="material-icons left">lock_open</i>Déverrouiller
@@ -187,7 +189,7 @@ id = "modal-bucket"
 <a href="{{ path('bucket_edit', { 'id': bucket.id }) }}" class="btn deep-purple">
     <i class="material-icons left">edit</i>Editer
 </a>
-{{ form_start(bucket_delete_form, {'attr': { 'style':  'display:inline;'}}) }}
+{{ form_start(bucket_delete_form, {'attr': { 'style': 'display:inline;' }}) }}
 <button id="bucket_delete" class="btn red" title="Supprimer tous les créneaux à cette heure et ce poste">
     <i class="material-icons left">delete</i>Supprimer
 </button>

--- a/app/Resources/views/admin/booking/_partial/bucket_modal.html.twig
+++ b/app/Resources/views/admin/booking/_partial/bucket_modal.html.twig
@@ -147,20 +147,20 @@ id = "modal-bucket"
 </ul>
 
 {# add shift form #}
-{{ form_start(bucket_add_form, {'attr': { 'style': 'display:inline;' }}) }}
-<input type="hidden" id="{{ bucket_add_form.start.date.vars.id }}" name="{{ bucket_add_form.start.date.vars.full_name }}" value="{{ bucket_add_form.start.date.vars.value }}">
-<input type="hidden" id="{{ bucket_add_form.start.time.vars.id }}" name="{{ bucket_add_form.start.time.vars.full_name }}" value="{{ bucket_add_form.start.time.vars.value }}">
-<input type="hidden" id="{{ bucket_add_form.end.date.vars.id }}" name="{{ bucket_add_form.end.date.vars.full_name }}" value="{{ bucket_add_form.end.date.vars.value }}">
-<input type="hidden" id="{{ bucket_add_form.end.time.vars.id }}" name="{{ bucket_add_form.end.time.vars.full_name }}" value="{{ bucket_add_form.end.time.vars.value }}">
-{{ form_widget(bucket_add_form.job) }}
+{{ form_start(bucket_shift_add_form, {'attr': { 'style': 'display:inline;' }}) }}
+<input type="hidden" id="{{ bucket_shift_add_form.start.date.vars.id }}" name="{{ bucket_shift_add_form.start.date.vars.full_name }}" value="{{ bucket_shift_add_form.start.date.vars.value }}">
+<input type="hidden" id="{{ bucket_shift_add_form.start.time.vars.id }}" name="{{ bucket_shift_add_form.start.time.vars.full_name }}" value="{{ bucket_shift_add_form.start.time.vars.value }}">
+<input type="hidden" id="{{ bucket_shift_add_form.end.date.vars.id }}" name="{{ bucket_shift_add_form.end.date.vars.full_name }}" value="{{ bucket_shift_add_form.end.date.vars.value }}">
+<input type="hidden" id="{{ bucket_shift_add_form.end.time.vars.id }}" name="{{ bucket_shift_add_form.end.time.vars.full_name }}" value="{{ bucket_shift_add_form.end.time.vars.value }}">
+{{ form_widget(bucket_shift_add_form.job) }}
 <div class="row valign-wrapper">
     <div class="col s3">
-        {{ form_label(bucket_add_form.number) }}
-        {{ form_widget(bucket_add_form.number) }}
+        {{ form_label(bucket_shift_add_form.number) }}
+        {{ form_widget(bucket_shift_add_form.number) }}
     </div>
     <div class="col s6">
-        {{ form_label(bucket_add_form.formation) }}
-        {{ form_widget(bucket_add_form.formation) }}
+        {{ form_label(bucket_shift_add_form.formation) }}
+        {{ form_widget(bucket_shift_add_form.formation) }}
     </div>
     <div class="col s3">
         <button type="submit" class="btn waves-effect waves-light teal">
@@ -168,8 +168,8 @@ id = "modal-bucket"
         </button>
     </div>
 </div>
-{{ form_row(bucket_add_form._token) }}
-{{ form_end(bucket_add_form, {'render_rest': false}) }}
+{{ form_row(bucket_shift_add_form._token) }}
+{{ form_end(bucket_shift_add_form, {'render_rest': false}) }}
 
 {# bucket actions #}
 <a href="{{ path('mail_bucketshift', { 'id': bucket.id }) }}" class="btn">
@@ -189,11 +189,13 @@ id = "modal-bucket"
 <a href="{{ path('bucket_edit', { 'id': bucket.id }) }}" class="btn deep-purple">
     <i class="material-icons left">edit</i>Editer
 </a>
-{{ form_start(bucket_delete_form, {'attr': { 'style': 'display:inline;' }}) }}
-<button id="bucket_delete" class="btn red" title="Supprimer tous les créneaux à cette heure et ce poste">
-    <i class="material-icons left">delete</i>Supprimer
-</button>
-{{ form_end(bucket_delete_form) }}
+{% if is_granted("ROLE_ADMIN") %}
+    {{ form_start(bucket_delete_form, {'attr': { 'style': 'display:inline;' }}) }}
+    <button id="bucket_delete" class="btn red" title="Supprimer tous les créneaux à cette heure et ce poste">
+        <i class="material-icons left">delete</i>Supprimer
+    </button>
+    {{ form_end(bucket_delete_form) }}
+{% endif %}
 
 <script>
     function makeAjaxCall(event) {
@@ -234,7 +236,7 @@ id = "modal-bucket"
     $('form[name="bucket_delete_form"]').on('submit', {confirmation: "Etes-vous sûr de vouloir supprimer ces créneaux et leurs réservations ?!"}, makeAjaxCall);
     $('form[name^="shift_delete_forms_"]').on('submit', {confirmation: "Etes-vous sûr de vouloir supprimer ce poste ?!"}, makeAjaxCall);
     $('form[name^="shift_free_forms_"]').on('submit', {confirmation: "Etes-vous sûr de vouloir libérer ce poste ?!"}, makeAjaxCall);
-    $('form[name="bucket_add_form"]').on('submit', {}, makeAjaxCall);
+    $('form[name="bucket_shift_add_form"]').on('submit', {}, makeAjaxCall);
     $('form[name="bucket_lock_unlock_form"]').on('submit', {}, makeAjaxCall);
     $('form[name^="shift_book_forms_"]').on('submit', {}, makeAjaxCall);
     $('form[name^="shift_validate_invalidate_forms_"]').on('submit', {}, makeAjaxCall);

--- a/src/AppBundle/Controller/BookingController.php
+++ b/src/AppBundle/Controller/BookingController.php
@@ -343,20 +343,13 @@ class BookingController extends Controller
             $shiftFreeForms[$shift->getId()] = $this->createShiftFreeAdminForm($shift)->createView();
             $shiftValidateInvalidateForms[$shift->getId()] = $this->createShiftValidateInvalidateForm($shift)->createView();
         }
-        $bucketAddForm = $this->get('form.factory')->createNamed(
-            'bucket_add_form',
-            ShiftType::class,
-            $bucket,
-            array(
-                'action' => $this->generateUrl('shift_new'),
-                'only_add_formation' => true,
-            ));
+        $bucketShiftAddForm = $this->createBucketShiftAddForm($bucket);
         $bucketDeleteform = $this->createBucketDeleteForm($bucket);
         $bucketLockUnlockForm = $this->createBucketLockUnlockForm($bucket);
 
         return $this->render('admin/booking/_partial/bucket_modal.html.twig', [
             'shifts' => $shifts,
-            'bucket_add_form' => $bucketAddForm->createView(),
+            'bucket_shift_add_form' => $bucketShiftAddForm->createView(),
             'shift_book_forms' => $shiftBookForms,
             'shift_delete_forms' => $shiftDeleteForms,
             'shift_free_forms' => $shiftFreeForms,
@@ -464,11 +457,11 @@ class BookingController extends Controller
     }
 
     /**
-     * delete all shifts in bucket, used when the user click on the 'supprimer'
-     * button on the bucket popup.
+     * delete all shifts in bucket
+     * (used when the user clicks on the 'supprimer' button in the bucket popup)
      *
      * @Route("/bucket/{id}", name="bucket_delete", methods={"DELETE"})
-     * @Security("has_role('ROLE_SHIFT_MANAGER')")
+     * @Security("has_role('ROLE_ADMIN')")
      */
     public function deleteBucketAction(Request $request, Shift $bucket)
     {
@@ -523,6 +516,25 @@ class BookingController extends Controller
             ])
             ->setMethod('POST')
             ->getForm();
+    }
+
+    /**
+     * Creates a form to add a bucket (shift(s)).
+     *
+     * @param Shift $bucket One shift of the bucket
+     *
+     * @return \Symfony\Component\Form\Form The form
+     */
+    private function createBucketShiftAddForm(Shift $bucket)
+    {
+        return $this->get('form.factory')->createNamed(
+            'bucket_shift_add_form',
+            ShiftType::class,
+            $bucket,
+            array(
+                'action' => $this->generateUrl('shift_new'),
+                'only_add_formation' => true,
+            ));
     }
 
     /**

--- a/src/AppBundle/Controller/ShiftController.php
+++ b/src/AppBundle/Controller/ShiftController.php
@@ -9,6 +9,7 @@ use AppBundle\Event\ShiftBookedEvent;
 use AppBundle\Event\ShiftFreedEvent;
 use AppBundle\Event\ShiftValidatedEvent;
 use AppBundle\Event\ShiftInvalidatedEvent;
+use AppBundle\Event\ShiftDeletedEvent;
 use AppBundle\Form\AutocompleteBeneficiaryType;
 use AppBundle\Form\RadioChoiceType;
 use AppBundle\Form\ShiftType;
@@ -60,7 +61,7 @@ class ShiftController extends Controller
         }
 
         $shift = new Shift();
-        $form = $this->get('form.factory')->createNamed('bucket_add_form', ShiftType::class, $shift);
+        $form = $this->get('form.factory')->createNamed('bucket_shift_add_form', ShiftType::class, $shift);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {

--- a/src/AppBundle/Controller/ShiftController.php
+++ b/src/AppBundle/Controller/ShiftController.php
@@ -506,15 +506,18 @@ class ShiftController extends Controller
      * delete a shift.
      *
      * @Route("/{id}", name="shift_delete", methods={"DELETE"})
-     * @Security("has_role('ROLE_SHIFT_MANAGER')")
+     * @Security("has_role('ROLE_ADMIN')")
      */
-    public function removeShiftAction(Request $request, Shift $shift)
+    public function deleteShiftAction(Request $request, Shift $shift)
     {
         $form = $this->createShiftDeleteForm($shift);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
             $em = $this->getDoctrine()->getManager();
+            $beneficiary = $shift->getShifter();
+            $dispatcher = $this->get('event_dispatcher');
+            $dispatcher->dispatch(ShiftDeletedEvent::NAME, new ShiftDeletedEvent($shift, $beneficiary));
             $em->remove($shift);
             $em->flush();
 


### PR DESCRIPTION
### Quoi ?

Restreindre les routes `shift_delete` et `bucket_delete` aux ROLE_ADMIN

### Pourquoi ?

- pour éviter les erreurs
- actuellement on ne log pas les actions de suppression effectuées sur ces objets