### PR TITLE
Compte épargne : initialisation

### DIFF
--- a/app/Resources/views/admin/event/signatures.html.twig
+++ b/app/Resources/views/admin/event/signatures.html.twig
@@ -18,10 +18,10 @@
                 Bénéficiaire de <strong>{{ beneficiary.membership.mainBeneficiary.displayName }}</strong>
             </td>
 
-        {% elseif (beneficiary.membership.getTimeCount(event.maxDateOfLastRegistration) <= time_after_which_members_are_late_with_shifts * 60) %}
+        {% elseif (beneficiary.membership.getShiftTimeCount(event.maxDateOfLastRegistration) <= time_after_which_members_are_late_with_shifts * 60) %}
             {# this member is too late in his/her shifts cannot vote ---------------------------------- #}
             <td colspan="2" class="wrong" style="background: gray; color: white;">
-                Compteur de créneaux à {{ beneficiary.membership.getTimeCount(event.maxDateOfLastRegistration) | duration_from_minutes }}
+                Compteur de créneaux à {{ beneficiary.membership.getShiftTimeCount(event.maxDateOfLastRegistration) | duration_from_minutes }}
                 <br />
                 &#9888&nbsp;<strong>VOTE IMPOSSIBLE</strong>&nbsp;&#9888
             </td>
@@ -113,11 +113,11 @@
                     <td class="center">#{{ proxy.giver.mainBeneficiary.memberNumber }}</td>
                     <td class="center">{{ proxy.giver.mainBeneficiary.membership.lastRegistration.date | date('d/m/Y') }}</td>
 
-                {% if (proxy.giver.mainBeneficiary.membership.getTimeCount(event.maxDateOfLastRegistration) <= time_after_which_members_are_late_with_shifts * 60) %}
+                {% if (proxy.giver.mainBeneficiary.membership.getShiftTimeCount(event.maxDateOfLastRegistration) <= time_after_which_members_are_late_with_shifts * 60) %}
                     {# this member is too late in his/her shifts cannot vote ---------------------------------- #}
                     {# Todo: Maybe it should be put in the sign_cells macro #}
                     <td colspan="2" class="wrong" style="background: gray; color: white;">
-                        Compteur de créneaux de #{{ proxy.giver.mainBeneficiary.memberNumber }} à {{ proxy.giver.mainBeneficiary.membership.getTimeCount(event.maxDateOfLastRegistration) | duration_from_minutes }}
+                        Compteur de créneaux de #{{ proxy.giver.mainBeneficiary.memberNumber }} à {{ proxy.giver.mainBeneficiary.membership.getShiftTimeCount(event.maxDateOfLastRegistration) | duration_from_minutes }}
                         <br />
                         &#9888&nbsp;<strong>VOTE IMPOSSIBLE</strong>&nbsp;&#9888
                     </td>
@@ -156,7 +156,7 @@
         {% set number_of_proxy = 0 %}
 
         {% for beneficiary in beneficiaries %}
-            {% set time_count_ok = not (beneficiary.membership.getTimeCount(event.maxDateOfLastRegistration) <= time_after_which_members_are_late_with_shifts * 60) %}
+            {% set time_count_ok = not (beneficiary.membership.getShiftTimeCount(event.maxDateOfLastRegistration) <= time_after_which_members_are_late_with_shifts * 60) %}
 
             {% if (event.proxiesByGiver(beneficiary.membership) | length > 0) and beneficiary.isMain %}
                 {% set number_of_proxy = number_of_proxy + 1 %}

--- a/app/Resources/views/ambassador/phone/list.html.twig
+++ b/app/Resources/views/ambassador/phone/list.html.twig
@@ -163,7 +163,7 @@
                     {% endif %}
                 </td>
                 <td class="center">
-                    {{ member.timeCount | duration_from_minutes }}
+                    {{ member.shiftTimeCount | duration_from_minutes }}
                 </td>
                 <td>
                     <blockquote class="truncate">

--- a/app/Resources/views/booking/home_dashboard.html.twig
+++ b/app/Resources/views/booking/home_dashboard.html.twig
@@ -4,6 +4,7 @@
     {% set beneficiariesWhoCanBook = shift_service.beneficiariesWhoCanBook(member) %}
     {% set due_duration_hour = due_duration_by_cycle / 60 %}
     {% set end_current_cycle = membership_service.endOfCycle(member) %}
+
     {% if not member.frozen %}
         {% if display_gauge %}
             <div class="gauge_container">
@@ -11,12 +12,12 @@
                         data-type="radial-gauge"
                         data-width="300"
                         data-height="300"
-                        data-units="{{ member.timeCount / 60 }}h"
+                        data-units="{{ member.shiftTimeCount / 60 }}h"
                         data-min-value="{{ due_duration_hour * -3 }}"
                         data-start-angle="90"
                         data-ticks-angle="180"
                         data-value-box="false"
-                        data-value="{{ member.timeCount / 60 }}"
+                        data-value="{{ member.shiftTimeCount / 60 }}"
                         data-max-value="{{ ((member.beneficiaries | length) * due_duration_by_cycle) / 60 }}"
                         data-major-ticks="{{ due_duration_hour * -3 }}h,{{ due_duration_hour * -2 }}h,{{ due_duration_hour * -1}}h,0,{{ due_duration_hour }}h{% if (member.beneficiaries | length) > 1 %},{{ due_duration_hour *2 }}h{% endif %}"
                         data-minor-ticks="2"
@@ -40,7 +41,7 @@
                 </canvas>
             </div>
         {% endif %}
-        {% if member.timeCount < 0 %}
+        {% if member.shiftTimeCount < 0 %}
             <p>
                 <i class="material-icons">warning</i>
                 {% if member.beneficiaries | length > 1 %}
@@ -59,7 +60,7 @@
                     <span>{% if member.beneficiaries | length > 1 %}Vous avez{% else %}Tu as{% endif %} encore {{ remaining | duration_from_minutes }} à effectuer.</span>
                 </p>
             {% else %}
-                {% set duration_to_book = (shift_service.shiftTimeByCycle(member) - member.timeCount(end_current_cycle)) %}
+                {% set duration_to_book = (shift_service.shiftTimeByCycle(member) - member.shiftTimeCount(end_current_cycle)) %}
                 <p>
                     Bravo ! {% if member.beneficiaries | length > 1 %}Vos{% else %}Tes{% endif %} {{ due_duration_by_cycle | duration_from_minutes }}
                     ont été planifiées sur le cycle actuel.

--- a/app/Resources/views/default/event/_event.html.twig
+++ b/app/Resources/views/default/event/_event.html.twig
@@ -76,7 +76,7 @@
                         <b>Oups</b>, seuls les membres qui ont adhéré ou ré-adhéré <b>après le {{ minDateOfLastRegistration | date('d M Y') }}</b> peuvent voter à cet événement.
                         <br />
                         Pense à mettre à jour ton adhésion pour participer ! :)
-                    {% elseif (member.getTimeCount(event.maxDateOfLastRegistration) < time_after_which_members_are_late_with_shifts * 60) %}
+                    {% elseif (member.getShiftTimeCount(event.maxDateOfLastRegistration) < time_after_which_members_are_late_with_shifts * 60) %}
                         <b>Oups</b>, seuls les membres avec un compteur de créneaux supérieur à <b>{{ time_after_which_members_are_late_with_shifts }} à la date du {{ event.maxDateOfLastRegistration | date('d M Y') }}</b> peuvent voter à cet événement.
                         <br />
                         Pense à rattraper tes créneaux pour la prochaine fois ! :)

--- a/app/Resources/views/emails/shift_late_alerts_default.html.twig
+++ b/app/Resources/views/emails/shift_late_alerts_default.html.twig
@@ -1,5 +1,5 @@
-{% for membership_late_alert in membership_late_alerts %}
-{% set beneficiaries = membership_late_alert.beneficiaries | map(b => b.displayNameWithMemberNumber) | join(', ') %}
-{% set timeCount = membership_late_alert.timeCount | duration_from_minutes %}
-- Compteur de {{ beneficiaries }} : {{ timeCount }}
+{% for member in membership_late_alerts %}
+    {% set beneficiaries = member.beneficiaries | map(b => b.displayNameWithMemberNumber) | join(', ') %}
+    {% set timeCount = member.shiftTimeCount | duration_from_minutes %}
+    - Compteur de {{ beneficiaries }} : {{ timeCount }}
 {% endfor %}

--- a/app/Resources/views/member/_partial/time_logs.html.twig
+++ b/app/Resources/views/member/_partial/time_logs.html.twig
@@ -7,8 +7,8 @@
     </thead>
     <tbody>
         <tr>
-            <td>{{ member.timeCount | duration_from_minutes }}</td>
-            <td>{{ member.timeCount(membership_service.endOfCycle(member)) | duration_from_minutes }}</td>
+            <td>{{ member.shiftTimeCount | duration_from_minutes }}</td>
+            <td>{{ member.shiftTimeCount(membership_service.endOfCycle(member)) | duration_from_minutes }}</td>
         </tr>
     </tbody>
 </table>

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -61,6 +61,7 @@ twig:
     local_currency_name: '%local_currency_name%'
     use_fly_and_fixed: '%use_fly_and_fixed%'
     max_event_proxy_per_member: '%max_event_proxy_per_member%'
+    use_time_log_saving: '%use_time_log_saving%'
     display_gauge: '%display_gauge%'
     max_nb_of_past_cycles_to_display: '%max_nb_of_past_cycles_to_display%'
     profile_display_task_list: '%profile_display_task_list%'

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -106,6 +106,7 @@ parameters:
     use_card_reader_to_validate_shifts: false
     max_time_at_end_of_shift: 0
     max_nb_of_past_cycles_to_display: 3
+    use_time_log_saving: false
 
     # Events
     max_event_proxy_per_member: 1

--- a/src/AppBundle/Controller/CardReaderController.php
+++ b/src/AppBundle/Controller/CardReaderController.php
@@ -61,7 +61,7 @@ class CardReaderController extends Controller
             $beneficiary = $card->getBeneficiary();
             $membership = $beneficiary->getMembership();
             $cycle_end = $this->get('membership_service')->getEndOfCycle($membership, 0);
-            $counter = $membership->getTimeCount($cycle_end);
+            $counter = $membership->getShiftTimeCount($cycle_end);
             if ($this->swipeCardLogging) {
                 $dispatcher = $this->get('event_dispatcher');
                 if ($this->swipeCardLoggingAnonymous) {

--- a/src/AppBundle/Controller/EventController.php
+++ b/src/AppBundle/Controller/EventController.php
@@ -510,7 +510,7 @@ class EventController extends Controller
 
             $filtered_beneficiaries = array_filter(
                 $beneficiaries,
-                function($b) use ($min_time_count) {return $b->getMembership()->getTimeCount()>$min_time_count*60;}
+                function($b) use ($min_time_count) { return $b->getMembership()->getShiftTimeCount()>$min_time_count*60; }
             );
 
             if (count($filtered_beneficiaries) != count($beneficiaries)){

--- a/src/AppBundle/Entity/Membership.php
+++ b/src/AppBundle/Entity/Membership.php
@@ -655,6 +655,66 @@ class Membership
     }
 
     /**
+     * Get shiftTimeLogs
+     *
+     * @return \Doctrine\Common\Collections\Collection
+     */
+    public function getShiftTimeLogs()
+    {
+        return $this->timeLogs->filter(function (TimeLog $log) {
+            return ($log->getType() != TimeLog::TYPE_SAVING);
+        });
+    }
+
+    /**
+     * Get savingTimeLogs
+     *
+     * @return \Doctrine\Common\Collections\Collection
+     */
+    public function getSavingTimeLogs()
+    {
+        return $this->timeLogs->filter(function (TimeLog $log) {
+            return ($log->getType() == TimeLog::TYPE_SAVING);
+        });
+    }
+
+    public function getShiftTimeCount($before = null)
+    {
+        $sum = function($carry, TimeLog $log)
+        {
+            $carry += $log->getTime();
+            return $carry;
+        };
+
+        $logs = $this->getShiftTimeLogs();
+        if ($before) {
+            $logs = $this->getShiftTimeLogs()->filter(function (TimeLog $log) use ($before) {
+                return ($log->getCreatedAt() < $before);
+            });
+        }
+
+        return array_reduce($logs->toArray(), $sum, 0);
+    }
+
+    public function getSavingTimeCount($before = null)
+    {
+        $sum = function($carry, TimeLog $log)
+        {
+            $carry += $log->getTime();
+            return $carry;
+        };
+
+        $logs = $this->getSavingTimeLogs();
+        if ($before) {
+            $logs = $logs->filter(function (TimeLog $log) use ($before) {
+                return ($log->getCreatedAt() < $before);
+            });
+        }
+
+        return array_reduce($logs->toArray(), $sum, 0);
+    }
+
+    /**
      * Get createdAt
      *
      * @return \DateTime
@@ -662,22 +722,6 @@ class Membership
     public function getCreatedAt()
     {
         return $this->createdAt;
-    }
-
-    public function getTimeCount($before = null)
-    {
-        $sum = function($carry, TimeLog $log)
-        {
-            $carry += $log->getTime();
-            return $carry;
-        };
-        if ($before)
-            $logs = $this->getTimeLogs()->filter(function ($log) use ($before){
-                return ($log->getCreatedAt() < $before);
-            });
-        else
-            $logs = $this->getTimeLogs();
-        return array_reduce($logs->toArray(), $sum, 0);
     }
 
     /**

--- a/src/AppBundle/Entity/TimeLog.php
+++ b/src/AppBundle/Entity/TimeLog.php
@@ -24,6 +24,8 @@ class TimeLog
     const TYPE_CYCLE_END_REGULATE_OPTIONAL_SHIFTS = 5;
     const TYPE_CYCLE_END_EXEMPTED = 6;
 
+    const TYPE_SAVING = 20;
+
     /**
      * @var int
      *
@@ -304,6 +306,12 @@ class TimeLog
                 })->map(function($element) {
                     return $element->getId();
                 })->toArray()) . ")";
+            case self::TYPE_SAVING:
+                if ($this->getTime() >= 0) {
+                    return "Compteur épargne incrémenté de " . $this->getTime() . " minutes";
+                } else {
+                    return "Compteur épargne décrémenté de " . $this->getTime() . " minutes";
+                }
         }
         return "Type de log de temps inconnu: " . $this->type;
     }

--- a/src/AppBundle/Service/BeneficiaryService.php
+++ b/src/AppBundle/Service/BeneficiaryService.php
@@ -41,7 +41,7 @@ class BeneficiaryService
         return $returnArray;
     }
 
-    public function getTimeCount(Beneficiary $beneficiary, $cycle = 0)
+    public function getCycleShiftDurationSum(Beneficiary $beneficiary, $cycle = 0)
     {
         $member = $beneficiary->getMembership();
         $cycle_start = $this->membershipService->getStartOfCycle($member, $cycle);

--- a/src/AppBundle/Service/ShiftService.php
+++ b/src/AppBundle/Service/ShiftService.php
@@ -48,7 +48,7 @@ class ShiftService
     public function remainingToBook(Membership $member)
     {
         $cycle_end = $this->membershipService->getEndOfCycle($member);
-        return $this->due_duration_by_cycle - $member->getTimeCount($cycle_end);
+        return $this->due_duration_by_cycle - $member->getShiftTimeCount($cycle_end);
     }
 
     /**
@@ -135,13 +135,13 @@ class ShiftService
         }
 
         $member = $beneficiary->getMembership();
-        $beneficiary_counter = $this->beneficiaryService->getTimeCount($beneficiary, $cycle);
+        $beneficiary_cycle_shift_duration = $this->beneficiaryService->getCycleShiftDurationSum($beneficiary, $cycle);
         $cycle_end = $this->membershipService->getEndOfCycle($member, $cycle);
-        $membership_counter = $member->getTimeCount($cycle_end);
+        $membership_counter = $member->getShiftTimeCount($cycle_end);
 
         //check if beneficiary booked time is ok
         //if timecount < due_duration_by_cycle : some shift to catchup, can book more than what's due
-        if ($membership_counter >= $this->due_duration_by_cycle && $beneficiary_counter >= $this->due_duration_by_cycle) { //Beneficiary is already ok
+        if ($membership_counter >= $this->due_duration_by_cycle && $beneficiary_cycle_shift_duration >= $this->due_duration_by_cycle) { //Beneficiary is already ok
             return false;
         }
 
@@ -151,7 +151,7 @@ class ShiftService
         }
 
         // No time to catchup, check if this beneficiary can book on this cycle
-        return $duration + $beneficiary_counter <= ($cycle + 1) * $this->due_duration_by_cycle;
+        return $duration + $beneficiary_cycle_shift_duration <= ($cycle + 1) * $this->due_duration_by_cycle;
     }
 
     /**

--- a/src/AppBundle/Service/TimeLogService.php
+++ b/src/AppBundle/Service/TimeLogService.php
@@ -119,6 +119,21 @@ class TimeLogService
     }
 
     /**
+     * Initialize a "cycle end regulation" log with the member data
+     * 
+     * @param Membership $member
+     * @param \DateTime $date
+     * @return TimeLog
+     */
+    public function initCycleEndRegulateOptionalShiftsTimeLog(Membership $member)
+    {
+        $log = $this->initTimeLog($member);
+        $log->setType(TimeLog::TYPE_CYCLE_END_REGULATE_OPTIONAL_SHIFTS);
+
+        return $log;
+    }
+
+    /**
      * Initialize a "custom" log with the member data
      * 
      * @param Membership $member


### PR DESCRIPTION
### Quoi ?

- nouveau type `TimeLog.TYPE_SAVING`
- nouveau paramètre `use_time_log_saving`
- dans l'entité `Membership` :
  - créé `getShiftTimeLogs()` (tous les timeLogs qui ne sont pas TYPE_SAVING)
  - créé `getSavingTimeLogs()` (tous les timeLogs qui sont TYPE_SAVING)
  - renommé `getTimeCount()` en `getShiftTimeCount` (impact sur d'autres fichiers & templates)
  - créé `getSavingTimeCount()`
- dans `BeneficiaryService` : 
  - renommé `getTimeCount()` en `getCycleShiftDurationSum()` pour éviter de confondre avec celles de Membership
- dans `TimeLogEventListener` :
  - faire appel au nouveau `initCycleEndRegulateOptionalShiftsTimeLog()`

### Pourquoi ?

Pour séparer la notion de "compteur-temps" et de "compteur-épargne"

### Captures d'écran

Aucun impact sur l'interface dans cette PR