### PR TITLE
Compte épargne : incrémenter après un créneau "extra" validé

### DIFF
--- a/src/AppBundle/Entity/TimeLog.php
+++ b/src/AppBundle/Entity/TimeLog.php
@@ -21,8 +21,9 @@ class TimeLog
     const TYPE_CYCLE_END = 2;
     const TYPE_CYCLE_END_FROZEN = 3;
     const TYPE_CYCLE_END_EXPIRED_REGISTRATION = 4;
-    const TYPE_CYCLE_END_REGULATE_OPTIONAL_SHIFTS = 5;
     const TYPE_CYCLE_END_EXEMPTED = 6;
+
+    const TYPE_REGULATE_OPTIONAL_SHIFTS = 5;
 
     const TYPE_SAVING = 20;
 
@@ -298,14 +299,14 @@ class TimeLog
                 return "Début de cycle (compte gelé)";
             case self::TYPE_CYCLE_END_EXPIRED_REGISTRATION:
                 return "Début de cycle (compte expiré)";
-            case self::TYPE_CYCLE_END_REGULATE_OPTIONAL_SHIFTS:
-                return "Régulation du bénévolat facultatif";
             case self::TYPE_CYCLE_END_EXEMPTED:
                 return "Début de cycle (compte exempté de créneau - exemption n°" . join(",", $this->membership->getMembershipShiftExemptions()->filter(function($membershipShiftExemption) {
                     return $membershipShiftExemption->isCurrent($this->createdAt);
                 })->map(function($element) {
                     return $element->getId();
                 })->toArray()) . ")";
+            case self::TYPE_REGULATE_OPTIONAL_SHIFTS:
+                return "Régulation du bénévolat facultatif";
             case self::TYPE_SAVING:
                 if ($this->getTime() >= 0) {
                     return "Compteur épargne incrémenté de " . $this->getTime() . " minutes";

--- a/src/AppBundle/EventListener/TimeLogEventListener.php
+++ b/src/AppBundle/EventListener/TimeLogEventListener.php
@@ -256,14 +256,14 @@ class TimeLogEventListener
         $this->em->persist($log);
 
         $counter_today = $member->getShiftTimeCount($date);
-
         $allowed_cumul = $this->max_time_at_end_of_shift;
+        $extra_counter_time = $counter_today - ($this->due_duration_by_cycle + $allowed_cumul);  // surbook
 
-        if ($counter_today > ($this->due_duration_by_cycle + $allowed_cumul)) { //surbook
-            $log = $this->container->get('time_log_service')->initCycleEndRegulateOptionalShiftsTimeLog($member);
-            $log->setTime(-1 * ($counter_today - ($this->due_duration_by_cycle + $allowed_cumul)));
+        if ($extra_counter_time > 0) {
+            $log = $this->container->get('time_log_service')->initRegulateOptionalShiftsTimeLog($member, -1 * $extra_counter_time);
             $this->em->persist($log);
         }
+
         $this->em->flush();
     }
 

--- a/src/AppBundle/EventListener/TimeLogEventListener.php
+++ b/src/AppBundle/EventListener/TimeLogEventListener.php
@@ -217,10 +217,11 @@ class TimeLogEventListener
 
         $log = $this->container->get('time_log_service')->initShiftValidatedTimeLog($shift, $date, $description);
         $this->em->persist($log);
+        $this->em->flush();
 
         if ($this->use_time_log_saving) {
-            $counter_today = $member->getShiftTimeCount($date);
-            $extra_counter_time = $counter_today - $this->due_duration_by_cycle; // + max_time_at_end_of_shift ??
+            $counter_now = $member->getShiftTimeCount();
+            $extra_counter_time = $counter_now - $this->due_duration_by_cycle; // + max_time_at_end_of_shift ??
 
             // the extra time will go in the member's saving account
             if ($extra_counter_time > 0) {
@@ -230,10 +231,9 @@ class TimeLogEventListener
                 // then increment the savingTimeCount
                 $log = $this->container->get('time_log_service')->initSavingTimeLog($member, $extra_counter_time);
                 $this->em->persist($log);
+                $this->em->flush();
             }
         }
-
-        $this->em->flush();
     }
 
     /**

--- a/src/AppBundle/Service/TimeLogService.php
+++ b/src/AppBundle/Service/TimeLogService.php
@@ -119,16 +119,19 @@ class TimeLogService
     }
 
     /**
-     * Initialize a "cycle end regulation" log with the member data
+     * Initialize a "regulation optjonal shifts" log with the member data
      * 
      * @param Membership $member
      * @param \DateTime $date
      * @return TimeLog
      */
-    public function initCycleEndRegulateOptionalShiftsTimeLog(Membership $member)
+    public function initRegulateOptionalShiftsTimeLog(Membership $member, $time = null)
     {
         $log = $this->initTimeLog($member);
-        $log->setType(TimeLog::TYPE_CYCLE_END_REGULATE_OPTIONAL_SHIFTS);
+        $log->setType(TimeLog::TYPE_REGULATE_OPTIONAL_SHIFTS);
+        if ($time) {
+            $log->setTime($time);
+        }
 
         return $log;
     }

--- a/src/AppBundle/Service/TimeLogService.php
+++ b/src/AppBundle/Service/TimeLogService.php
@@ -129,13 +129,11 @@ class TimeLogService
      * @param int $time
      * @return TimeLog
      */
-    public function initRegulateOptionalShiftsTimeLog(Membership $member, $time = null)
+    public function initRegulateOptionalShiftsTimeLog(Membership $member, $time)
     {
         $log = $this->initTimeLog($member);
         $log->setType(TimeLog::TYPE_REGULATE_OPTIONAL_SHIFTS);
-        if ($time) {
-            $log->setTime($time);
-        }
+        $log->setTime($time);
 
         return $log;
     }
@@ -147,13 +145,11 @@ class TimeLogService
      * @param int $time
      * @return TimeLog
      */
-    public function initSavingTimeLog(Membership $member, $time = null)
+    public function initSavingTimeLog(Membership $member, $time)
     {
         $log = $this->initTimeLog($member);
         $log->setType(TimeLog::TYPE_SAVING);
-        if ($time) {
-            $log->setTime($time);
-        }
+        $log->setTime($time);
 
         return $log;
     }

--- a/src/AppBundle/Service/TimeLogService.php
+++ b/src/AppBundle/Service/TimeLogService.php
@@ -63,7 +63,9 @@ class TimeLogService
      */
     public function initShiftValidatedTimeLog(Shift $shift, \DateTime $date = null, $description = null)
     {
-        $log = $this->initTimeLog($shift->getShifter()->getMembership(), $date, $description);
+        $member = $shift->getShifter()->getMembership();
+
+        $log = $this->initTimeLog($member, $date, $description);
         $log->setType(TimeLog::TYPE_SHIFT_VALIDATED);
         $log->setShift($shift);
         $log->setTime($shift->getDuration());
@@ -80,7 +82,9 @@ class TimeLogService
      */
     public function initShiftInvalidatedTimeLog(Shift $shift, \DateTime $date = null, $description = null)
     {
-        $log = $this->initTimeLog($shift->getShifter()->getMembership(), $date, $description);
+        $member = $shift->getShifter()->getMembership();
+
+        $log = $this->initTimeLog($member, $date, $description);
         $log->setType(TimeLog::TYPE_SHIFT_INVALIDATED);
         $log->setShift($shift);
         $log->setTime(-1 * $shift->getDuration());
@@ -122,13 +126,31 @@ class TimeLogService
      * Initialize a "regulation optjonal shifts" log with the member data
      * 
      * @param Membership $member
-     * @param \DateTime $date
+     * @param int $time
      * @return TimeLog
      */
     public function initRegulateOptionalShiftsTimeLog(Membership $member, $time = null)
     {
         $log = $this->initTimeLog($member);
         $log->setType(TimeLog::TYPE_REGULATE_OPTIONAL_SHIFTS);
+        if ($time) {
+            $log->setTime($time);
+        }
+
+        return $log;
+    }
+
+    /**
+     * Initialize a "saving" log with the member data
+     * 
+     * @param Membership $member
+     * @param int $time
+     * @return TimeLog
+     */
+    public function initSavingTimeLog(Membership $member, $time = null)
+    {
+        $log = $this->initTimeLog($member);
+        $log->setType(TimeLog::TYPE_SAVING);
         if ($time) {
             $log->setTime($time);
         }


### PR DESCRIPTION
### Quoi ?

- renommé `TimeLog.TYPE_CYCLE_END_REGULATE_OPTIONAL_SHIFTS` en `TYPE_REGULATE_OPTIONAL_SHIFTS` pour le rendre plus ré-utilisable (pas seulement "cycle end")
- onShiftValidated : basculer le temps "en trop" vers le compteur épargne
  - ajout d'un log négatif "TYPE_REGULATE_OPTIONAL_SHIFTS"
  - et d'un log positif "TYPE_SAVING"

