### PR TITLE
Compte épargne : affichage basique

### DIFF
--- a/app/Resources/views/booking/home_dashboard.html.twig
+++ b/app/Resources/views/booking/home_dashboard.html.twig
@@ -91,6 +91,17 @@
                 {% endif %}
             {% endif %}
         {% endif %}
+        {% if use_time_log_saving %}
+            <div class="row">
+                <div class="col s12">
+                    <div class="card">
+                        <div class="card-content">
+                            <p>Compteur épargne : <strong>{{ member.savingTimeCount | duration_from_minutes }}</strong></p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        {% endif %}
     {% endif %}
 
     <a href="{{ path("booking") }}" class="btn teal hide-on-small-only" title="Je réserve un créneau{% if use_fly_and_fixed %} volant{% endif %}" {% if beneficiariesWhoCanBook | length == 0 %}disabled{% endif %}>

--- a/app/Resources/views/member/_partial/time_logs.html.twig
+++ b/app/Resources/views/member/_partial/time_logs.html.twig
@@ -1,14 +1,25 @@
 <table>
     <thead>
         <tr>
-            <th>TOTAL</th>
+            <th>
+                TOTAL
+                {% if use_time_log_saving %}
+                    <span>TEMPS</span>
+                {% endif %}
+            </th>
             <th>TOTAL CYCLE EN COURS</th>
+            {% if use_time_log_saving %}
+                <th>TOTAL EPARGNE</th>
+            {% endif %}
         </tr>
     </thead>
     <tbody>
         <tr>
             <td>{{ member.shiftTimeCount | duration_from_minutes }}</td>
             <td>{{ member.shiftTimeCount(membership_service.endOfCycle(member)) | duration_from_minutes }}</td>
+            {% if use_time_log_saving %}
+                <td>{{ member.savingTimeCount | duration_from_minutes }}</td>
+            {% endif %}
         </tr>
     </tbody>
 </table>
@@ -48,7 +59,7 @@
     </thead>
     <tbody>
         {% for timeLog in member.timeLogs %}
-            <tr class="{% if timeLog.time > 0 %}green{% elseif timeLog.time < 0 %}red{% else %}grey{% endif %} lighten-5">
+            <tr class="{% if timeLog.type == 20 %}blue{% elseif timeLog.time > 0 %}green{% elseif timeLog.time < 0 %}red{% else %}grey{% endif %} lighten-5">
                 <td title="{{ timeLog.createdAt | date_fr_with_time }}">{{ timeLog.createdAt | date("d/m/Y") }}</td>
                 <td>{{ timeLog.createdBy }}</td>
                 <td>{{ timeLog.time | duration_from_minutes }}</td>

--- a/src/AppBundle/Entity/Membership.php
+++ b/src/AppBundle/Entity/Membership.php
@@ -110,7 +110,7 @@ class Membership
 
     /**
      * @ORM\OneToMany(targetEntity="TimeLog", mappedBy="membership", cascade={"persist", "remove"})
-     * @OrderBy({"createdAt" = "DESC"})
+     * @OrderBy({"createdAt" = "DESC", "type" = "DESC"})
      */
     private $timeLogs;
 


### PR DESCRIPTION
### Quoi ?

Modifications apportées : 
- afficher le compteur épargne dans le dashboard du membre
- afficher les événements du compte épargne dans l'onglet "Compteur de temps" (en bleu) : coté membre et coté admin
- onglet "compteur de temps" : nouvelle colonne "Créneau" pour simplifier la colonne "Motif"

### Capture d'écran

|Page|Image|
|---|---|
|Membre > dashboard|![Screenshot from 2023-02-26 23-35-18](https://user-images.githubusercontent.com/7147385/221441636-f3694303-b22b-4f7b-8267-9a5fb7dbfeb5.png)|
|Membre > Gérer mon compte > Compteur de temps (cas d'un créneau validé, puis d'un créneau annulé)|![Screenshot from 2023-03-02 17-13-41](https://user-images.githubusercontent.com/7147385/222486201-a0c29c63-7cf3-4dae-928d-df45323808e7.png)|

### Info supplémentaire

J'ai dû changer l'ordering des timeLogs, car j'ai l'impression que Doctrine stock les DateTime sans les miliseconds ?? du coup impossible de les ordonner par date lorsque les 3 time logs sont créés quasi en même temps (cf https://github.com/doctrine/dbal/issues/2873)



