### PR TITLE
Compteur épargne : fin de cycle

### DIFF
--- a/src/AppBundle/Entity/TimeLog.php
+++ b/src/AppBundle/Entity/TimeLog.php
@@ -23,6 +23,7 @@ class TimeLog
     const TYPE_CYCLE_END_FROZEN = 3;
     const TYPE_CYCLE_END_EXPIRED_REGISTRATION = 4;
     const TYPE_CYCLE_END_EXEMPTED = 6;
+    const TYPE_CYCLE_END_SAVING = 7;
 
     const TYPE_REGULATE_OPTIONAL_SHIFTS = 5;
 
@@ -286,6 +287,8 @@ class TimeLog
                 return "Créneau invalidé";
             case self::TYPE_SHIFT_FREED_SAVING:
                 return "Créneau libéré et compteur temps incrémenté (grâce au compteur épargne)";
+            case self::TYPE_SHIFT_END_SAVING:
+                return "Compteur temps incrémenté grâce au compteur épargne";
             case self::TYPE_CYCLE_END:
                 return "Début de cycle";
             case self::TYPE_CYCLE_END_FROZEN:

--- a/src/AppBundle/Entity/TimeLog.php
+++ b/src/AppBundle/Entity/TimeLog.php
@@ -287,8 +287,6 @@ class TimeLog
                 return "Créneau invalidé";
             case self::TYPE_SHIFT_FREED_SAVING:
                 return "Créneau libéré et compteur temps incrémenté (grâce au compteur épargne)";
-            case self::TYPE_SHIFT_END_SAVING:
-                return "Compteur temps incrémenté grâce au compteur épargne";
             case self::TYPE_CYCLE_END:
                 return "Début de cycle";
             case self::TYPE_CYCLE_END_FROZEN:
@@ -301,6 +299,8 @@ class TimeLog
                 })->map(function($element) {
                     return $element->getId();
                 })->toArray()) . ")";
+            case self::TYPE_CYCLE_END_SAVING:
+                return "Début de cycle (compteur temps incrémenté grâce au compteur épargne)";
             case self::TYPE_REGULATE_OPTIONAL_SHIFTS:
                 return "Régulation du bénévolat facultatif";
             case self::TYPE_SAVING:

--- a/src/AppBundle/Entity/TimeLog.php
+++ b/src/AppBundle/Entity/TimeLog.php
@@ -300,7 +300,11 @@ class TimeLog
                     return $element->getId();
                 })->toArray()) . ")";
             case self::TYPE_CYCLE_END_SAVING:
-                return "Début de cycle (compteur temps incrémenté grâce au compteur épargne)";
+                if ($this->getTime() > 0) {
+                    return "Début de cycle (compteur temps incrémenté grâce au compteur épargne)";
+                } else {
+                    return "Début de cycle " . $this->description;
+                }
             case self::TYPE_REGULATE_OPTIONAL_SHIFTS:
                 return "Régulation du bénévolat facultatif";
             case self::TYPE_SAVING:

--- a/src/AppBundle/EventListener/EmailingEventListener.php
+++ b/src/AppBundle/EventListener/EmailingEventListener.php
@@ -298,7 +298,6 @@ class EmailingEventListener
                     );
                 $this->mailer->send($mail);
             }
-
         }
     }
 

--- a/src/AppBundle/EventListener/TimeLogEventListener.php
+++ b/src/AppBundle/EventListener/TimeLogEventListener.php
@@ -319,12 +319,15 @@ class TimeLogEventListener
                 // retrieve member's savings
                 $member_saving_now = $member->getSavingTimeCount();
                 if ($member_saving_now > 0) {
-                    // count missed shifts for last cycle
                     $date_minus_one_day = clone($date)->modify("-1 days");
+                    // count missed shifts in the previous cycle
                     $previous_cycle_missed_shifts_count = $this->get('membership_service')->getCycleShiftsMissedCount($membership, $date_minus_one_day);
+                    // count freed shifts within the min_time_in_advance in the previous cycle
+                    $previous_cycle_freed_shifts_less_than_min_time_in_advance_count = $this->get('membership_service')->getCycleShiftsFreedCount($membership, $date_minus_one_day, $this->time_log_saving_shift_free_min_time_in_advance_days);
                     // we can use the member's savings only if:
                     // - the member has no missed shifts in the previous cycle
-                    if ($previous_cycle_missed_shifts_count == 0) {
+                    // - the member has no freed shifts within the min_time_in_advance 
+                    if ($previous_cycle_missed_shifts_count == 0 && previous_cycle_freed_shifts_less_than_min_time_in_advance_count == 0) {
                         $missing_due_time = ($member_counter_date > 0) ? $this->due_duration_by_cycle - $member_counter_date : $this->due_duration_by_cycle;
                         $withdraw_from_saving = min($member_saving_now, $missing_due_time);
                         // first decrement the savingTimeCount

--- a/src/AppBundle/EventListener/TimeLogEventListener.php
+++ b/src/AppBundle/EventListener/TimeLogEventListener.php
@@ -327,7 +327,7 @@ class TimeLogEventListener
                 $log = $this->container->get('time_log_service')->initSavingTimeLog($member, -1 * $withdraw_from_saving);
                 $this->em->persist($log);
                 // then increment the shiftTimeCount
-                $log = $this->container->get('time_log_service')->initShiftFreedSavingTimeLog($member, 1 * $withdraw_from_saving);
+                $log = $this->container->get('time_log_service')->initShiftEndSavingTimeLog($member, 1 * $withdraw_from_saving);
                 $this->em->persist($log);
             }
         }

--- a/src/AppBundle/EventListener/TimeLogEventListener.php
+++ b/src/AppBundle/EventListener/TimeLogEventListener.php
@@ -336,6 +336,18 @@ class TimeLogEventListener
                         // then increment the shiftTimeCount
                         $log = $this->container->get('time_log_service')->initCycleEndSavingTimeLog($member, 1 * $withdraw_from_saving);
                         $this->em->persist($log);
+                    } else {
+                        // not allowed to use member's saving
+                        // give explanation
+                        $description = "(compteur épargne (" . $member_saving_now . " minutes) non utilisé car ";
+                        if ($previous_cycle_missed_shifts_count) {
+                            $description = $description . $previous_cycle_missed_shifts_count . " créneau" . (($previous_cycle_missed_shifts_count > 1) ? 'x' : '') . " raté" . (($previous_cycle_missed_shifts_count > 1) ? 's' : '');
+                        }
+                        if ($previous_cycle_freed_shifts_less_than_min_time_in_advance_count) {
+                            $description = $description . (($previous_cycle_missed_shifts_count > 0) ? ' & ' : '') . $previous_cycle_freed_shifts_less_than_min_time_in_advance_count . " créneau" . (($previous_cycle_freed_shifts_less_than_min_time_in_advance_count > 1) ? 'x' : '') . " annulé" . (($previous_cycle_freed_shifts_less_than_min_time_in_advance_count > 1) ? 's' : '') . " sous les " . $this->time_log_saving_shift_free_min_time_in_advance_days . " jours)";
+                        }
+                        $log = $this->container->get('time_log_service')->initCycleEndSavingTimeLog($member, 0, $description);
+                        $this->em->persist($log);
                     }
                 }
             }

--- a/src/AppBundle/EventListener/TimeLogEventListener.php
+++ b/src/AppBundle/EventListener/TimeLogEventListener.php
@@ -245,9 +245,9 @@ class TimeLogEventListener
         $this->em->flush();
 
         if ($this->use_time_log_saving) {
-            $this->em->refresh($member);  // added to prevent getShiftTimeCount() from returning a cached (old) value
-            $counter_now = $member->getShiftTimeCount();
-            $extra_counter_time = $counter_now - $this->due_duration_by_cycle; // + max_time_at_end_of_shift ??
+            $this->em->refresh($member);  // added to prevent from returning cached (old) data
+            $member_counter_now = $member->getShiftTimeCount();
+            $extra_counter_time = $member_counter_now - ($this->due_duration_by_cycle + $this->max_time_at_end_of_shift);
 
             // the extra time will go in the member's saving account
             if ($extra_counter_time > 0) {
@@ -300,10 +300,10 @@ class TimeLogEventListener
     {
         $log = $this->container->get('time_log_service')->initCycleBeginningTimeLog($member);
         $this->em->persist($log);
+        $this->em->flush();
 
-        $counter_today = $member->getShiftTimeCount($date);
-        $allowed_cumul = $this->max_time_at_end_of_shift;
-        $extra_counter_time = $counter_today - ($this->due_duration_by_cycle + $allowed_cumul);  // surbook
+        $member_counter_date = $member->getShiftTimeCount($date);
+        $extra_counter_time = $member_counter_date - ($this->due_duration_by_cycle + $this->max_time_at_end_of_shift);
 
         if ($extra_counter_time > 0) {
             $log = $this->container->get('time_log_service')->initRegulateOptionalShiftsTimeLog($member, -1 * $extra_counter_time);
@@ -313,22 +313,28 @@ class TimeLogEventListener
                 $log = $this->container->get('time_log_service')->initSavingTimeLog($member, 1 * $extra_counter_time);
                 $this->em->persist($log);
             }
-        } elseif ($this->use_time_log_saving && $extra_counter_time < 0) {
-            // retrieve member's savings
-            $saving_now = $member->getSavingTimeCount();
-            // count missed shifts for last cycle
-            $date_minus_one_day = clone($date)->modify("-1 days");
-            $previous_cycle_missed_shifts_count = $this->get('membership_service')->getCycleMissedShiftsCount($membership, $date_minus_one_day);
-            // check if member has savings and no missed shifts
-            if ($saving_now > 0 && $previous_cycle_missed_shifts_count == 0) {
-                $missing_due_time = ($counter_today > 0) ? $this->due_duration_by_cycle - $counter_today : $this->due_duration_by_cycle;
-                $withdraw_from_saving = min($saving_now, $missing_due_time);
-                // first decrement the savingTimeCount
-                $log = $this->container->get('time_log_service')->initSavingTimeLog($member, -1 * $withdraw_from_saving);
-                $this->em->persist($log);
-                // then increment the shiftTimeCount
-                $log = $this->container->get('time_log_service')->initCycleEndSavingTimeLog($member, 1 * $withdraw_from_saving);
-                $this->em->persist($log);
+        } elseif ($extra_counter_time < 0) {
+            if ($this->use_time_log_saving) {
+                $this->em->refresh($member);  // added to prevent from returning cached (old) data
+                // retrieve member's savings
+                $member_saving_now = $member->getSavingTimeCount();
+                if ($member_saving_now > 0) {
+                    // count missed shifts for last cycle
+                    $date_minus_one_day = clone($date)->modify("-1 days");
+                    $previous_cycle_missed_shifts_count = $this->get('membership_service')->getCycleShiftsMissedCount($membership, $date_minus_one_day);
+                    // we can use the member's savings only if:
+                    // - the member has no missed shifts in the previous cycle
+                    if ($previous_cycle_missed_shifts_count == 0) {
+                        $missing_due_time = ($member_counter_date > 0) ? $this->due_duration_by_cycle - $member_counter_date : $this->due_duration_by_cycle;
+                        $withdraw_from_saving = min($member_saving_now, $missing_due_time);
+                        // first decrement the savingTimeCount
+                        $log = $this->container->get('time_log_service')->initSavingTimeLog($member, -1 * $withdraw_from_saving);
+                        $this->em->persist($log);
+                        // then increment the shiftTimeCount
+                        $log = $this->container->get('time_log_service')->initCycleEndSavingTimeLog($member, 1 * $withdraw_from_saving);
+                        $this->em->persist($log);
+                    }
+                }
             }
         }
 

--- a/src/AppBundle/EventListener/TimeLogEventListener.php
+++ b/src/AppBundle/EventListener/TimeLogEventListener.php
@@ -321,9 +321,9 @@ class TimeLogEventListener
                 if ($member_saving_now > 0) {
                     $date_minus_one_day = clone($date)->modify("-1 days");
                     // count missed shifts in the previous cycle
-                    $previous_cycle_missed_shifts_count = $this->get('membership_service')->getCycleShiftsMissedCount($membership, $date_minus_one_day);
+                    $previous_cycle_missed_shifts_count = $this->get('membership_service')->getCycleShiftsMissedCount($member, $date_minus_one_day);
                     // count freed shifts within the min_time_in_advance in the previous cycle
-                    $previous_cycle_freed_shifts_less_than_min_time_in_advance_count = $this->get('membership_service')->getCycleShiftsFreedCount($membership, $date_minus_one_day, $this->time_log_saving_shift_free_min_time_in_advance_days);
+                    $previous_cycle_freed_shifts_less_than_min_time_in_advance_count = $this->get('membership_service')->getCycleShiftsFreedCount($member, $date_minus_one_day, $this->time_log_saving_shift_free_min_time_in_advance_days);
                     // we can use the member's savings only if:
                     // - the member has no missed shifts in the previous cycle
                     // - the member has no freed shifts within the min_time_in_advance 

--- a/src/AppBundle/EventListener/TimeLogEventListener.php
+++ b/src/AppBundle/EventListener/TimeLogEventListener.php
@@ -316,15 +316,12 @@ class TimeLogEventListener
         } elseif ($this->use_time_log_saving && $extra_counter_time < 0) {
             // retrieve member's savings
             $saving_now = $member->getSavingTimeCount();
-            // count missing shifts for last cycle
+            // count missed shifts for last cycle
             $date_minus_one_day = clone($date)->modify("-1 days");
-            $shift_cycle = $this->membershipService->getCycleNumber($member, $date_minus_one_day);
-            $cycle_start = $this->get('membership_service')->getStartOfCycle($membership, $shift_cycle);
-            $cycle_end = $this->get('membership_service')->getEndOfCycle($membership, $shift_cycle);
-            $missing_shifts = $em->getRepository('AppBundle:Shift')->hasMissingShifts($member, $cycle_start, $cycle_end);
-            // check if member has savings and no missing shifts
-            if ($saving_now > 0 && $missing_shifts == 0) {
-                $missing_due_time = ($counter_today <= 0) ? $this->due_duration_by_cycle : $this->due_duration_by_cycle - $counter_today;
+            $previous_cycle_missed_shifts_count = $this->get('membership_service')->getCycleMissedShiftsCount($membership, $date_minus_one_day);
+            // check if member has savings and no missed shifts
+            if ($saving_now > 0 && $previous_cycle_missed_shifts_count == 0) {
+                $missing_due_time = ($counter_today > 0) ? $this->due_duration_by_cycle - $counter_today : $this->due_duration_by_cycle;
                 $withdraw_from_saving = min($saving_now, $missing_due_time);
                 // first decrement the savingTimeCount
                 $log = $this->container->get('time_log_service')->initSavingTimeLog($member, -1 * $withdraw_from_saving);

--- a/src/AppBundle/EventListener/TimeLogEventListener.php
+++ b/src/AppBundle/EventListener/TimeLogEventListener.php
@@ -321,13 +321,13 @@ class TimeLogEventListener
                 if ($member_saving_now > 0) {
                     $date_minus_one_day = clone($date)->modify("-1 days");
                     // count missed shifts in the previous cycle
-                    $previous_cycle_missed_shifts_count = $this->get('membership_service')->getCycleShiftsMissedCount($member, $date_minus_one_day);
+                    $previous_cycle_missed_shifts_count = $this->container->get('membership_service')->getCycleShiftMissedCount($member, $date_minus_one_day);
                     // count freed shifts within the min_time_in_advance in the previous cycle
-                    $previous_cycle_freed_shifts_less_than_min_time_in_advance_count = $this->get('membership_service')->getCycleShiftsFreedCount($member, $date_minus_one_day, $this->time_log_saving_shift_free_min_time_in_advance_days);
+                    $previous_cycle_freed_shifts_less_than_min_time_in_advance_count = $this->container->get('membership_service')->getCycleShiftFreedCount($member, $date_minus_one_day, $this->time_log_saving_shift_free_min_time_in_advance_days);
                     // we can use the member's savings only if:
                     // - the member has no missed shifts in the previous cycle
                     // - the member has no freed shifts within the min_time_in_advance 
-                    if ($previous_cycle_missed_shifts_count == 0 && previous_cycle_freed_shifts_less_than_min_time_in_advance_count == 0) {
+                    if ($previous_cycle_missed_shifts_count == 0 && $previous_cycle_freed_shifts_less_than_min_time_in_advance_count == 0) {
                         $missing_due_time = ($member_counter_date > 0) ? $this->due_duration_by_cycle - $member_counter_date : $this->due_duration_by_cycle;
                         $withdraw_from_saving = min($member_saving_now, $missing_due_time);
                         // first decrement the savingTimeCount

--- a/src/AppBundle/EventListener/TimeLogEventListener.php
+++ b/src/AppBundle/EventListener/TimeLogEventListener.php
@@ -327,7 +327,7 @@ class TimeLogEventListener
                 $log = $this->container->get('time_log_service')->initSavingTimeLog($member, -1 * $withdraw_from_saving);
                 $this->em->persist($log);
                 // then increment the shiftTimeCount
-                $log = $this->container->get('time_log_service')->initShiftEndSavingTimeLog($member, 1 * $withdraw_from_saving);
+                $log = $this->container->get('time_log_service')->initCycleEndSavingTimeLog($member, 1 * $withdraw_from_saving);
                 $this->em->persist($log);
             }
         }

--- a/src/AppBundle/Repository/ShiftFreeLogRepository.php
+++ b/src/AppBundle/Repository/ShiftFreeLogRepository.php
@@ -3,6 +3,7 @@
 namespace AppBundle\Repository;
 
 use AppBundle\Entity\Beneficiary;
+use AppBundle\Entity\Membership;
 use AppBundle\Entity\PeriodPosition;
 
 /**
@@ -32,12 +33,12 @@ class ShiftFreeLogRepository extends \Doctrine\ORM\EntityRepository
                 ->setParameter('position', $position);
         }
 
-        return $qb
+        return (int) $qb
             ->getQuery()
             ->getSingleScalarResult();
     }
 
-    public function countMemberShiftsFreed($membership, $start_after, $end_before, $less_than_min_time_in_advance_days = null) {
+    public function getMemberShiftFreedCount(Membership $membership, \DateTime $start_after, \DateTime $end_before, $less_than_min_time_in_advance_days = null) {
         $qb = $this->createQueryBuilder('sfl')
             ->leftJoin('sfl.shift', 's')
             ->addSelect('s')
@@ -54,7 +55,7 @@ class ShiftFreeLogRepository extends \Doctrine\ORM\EntityRepository
                 ->setParameter('min_time_in_advance_days', $less_than_min_time_in_advance_days);
         }
 
-        return $qb->getQuery()
+        return (int) $qb->getQuery()
             ->getSingleScalarResult();
     }
 }

--- a/src/AppBundle/Repository/ShiftRepository.php
+++ b/src/AppBundle/Repository/ShiftRepository.php
@@ -458,4 +458,23 @@ class ShiftRepository extends \Doctrine\ORM\EntityRepository
             ->getQuery()
             ->getSingleScalarResult();
     }
+
+    /**
+     * Note: dates must be in the past to have valid results 
+     */
+    private function hasMissingShifts($beneficiaries, $start_after, $end_before) {
+        $qb = $this->createQueryBuilder('s')
+            ->select('count(s.id)')
+            ->where('s.shifter IN (:beneficiaries)')
+            ->andwhere('s.start > :start_after')
+            ->andwhere('s.end < :end_before')
+            ->andwhere('s.wasCarriedOut = 0')
+            ->setParameter('beneficiaries', $membership->getBeneficiaries())
+            ->setParameter('start_after', $start_after)
+            ->setParameter('end_before', $end_before);
+
+        return $qb
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
 }

--- a/src/AppBundle/Repository/ShiftRepository.php
+++ b/src/AppBundle/Repository/ShiftRepository.php
@@ -472,7 +472,7 @@ class ShiftRepository extends \Doctrine\ORM\EntityRepository
             ->setParameter('beneficiaries', $member->getBeneficiaries())
             ->setParameter('start_after', $start_after)
             ->setParameter('end_before', $end_before);
-
+     
         return $qb->getQuery()
             ->getSingleScalarResult();
     }

--- a/src/AppBundle/Repository/ShiftRepository.php
+++ b/src/AppBundle/Repository/ShiftRepository.php
@@ -462,19 +462,18 @@ class ShiftRepository extends \Doctrine\ORM\EntityRepository
     /**
      * Note: dates must be in the past to have valid results 
      */
-    private function hasMissingShifts($beneficiaries, $start_after, $end_before) {
+    public function countMemberShiftsMissed(Membership $member, $start_after, $end_before) {
         $qb = $this->createQueryBuilder('s')
             ->select('count(s.id)')
             ->where('s.shifter IN (:beneficiaries)')
             ->andwhere('s.start > :start_after')
             ->andwhere('s.end < :end_before')
             ->andwhere('s.wasCarriedOut = 0')
-            ->setParameter('beneficiaries', $membership->getBeneficiaries())
+            ->setParameter('beneficiaries', $member->getBeneficiaries())
             ->setParameter('start_after', $start_after)
             ->setParameter('end_before', $end_before);
 
-        return $qb
-            ->getQuery()
+        return $qb->getQuery()
             ->getSingleScalarResult();
     }
 }

--- a/src/AppBundle/Repository/ShiftRepository.php
+++ b/src/AppBundle/Repository/ShiftRepository.php
@@ -454,7 +454,7 @@ class ShiftRepository extends \Doctrine\ORM\EntityRepository
                 ->setParameter('now', new \Datetime('now'));
         }
 
-        return $qb
+        return (int) $qb
             ->getQuery()
             ->getSingleScalarResult();
     }
@@ -462,7 +462,7 @@ class ShiftRepository extends \Doctrine\ORM\EntityRepository
     /**
      * Note: dates must be in the past to have valid results 
      */
-    public function countMemberShiftsMissed(Membership $member, $start_after, $end_before) {
+    public function getMemberShiftMissedCount(Membership $member, $start_after, $end_before) {
         $qb = $this->createQueryBuilder('s')
             ->select('count(s.id)')
             ->where('s.shifter IN (:beneficiaries)')
@@ -473,7 +473,7 @@ class ShiftRepository extends \Doctrine\ORM\EntityRepository
             ->setParameter('start_after', $start_after)
             ->setParameter('end_before', $end_before);
      
-        return $qb->getQuery()
+        return (int) $qb->getQuery()
             ->getSingleScalarResult();
     }
 }

--- a/src/AppBundle/Service/MembershipService.php
+++ b/src/AppBundle/Service/MembershipService.php
@@ -175,6 +175,13 @@ class MembershipService
         return null
     }
 
+    public function getCycleMissedShiftsCount(Membership $membership, $date) {
+        $shift_cycle = $this->getCycleNumber($membership, $date);
+        $cycle_start = $this->getStartOfCycle($membership, $shift_cycle);
+        $cycle_end = $this->getEndOfCycle($membership, $shift_cycle);
+        return $this->em->getRepository('AppBundle:Shift')->getMissedShiftsCount($membership, $cycle_start, $cycle_end);
+    }
+
     /**
      * Return true if the membership is in a "warning" status
      */

--- a/src/AppBundle/Service/MembershipService.php
+++ b/src/AppBundle/Service/MembershipService.php
@@ -175,18 +175,18 @@ class MembershipService
         return null;
     }
 
-    public function getCycleShiftsMissedCount(Membership $member, $date) {
+    public function getCycleShiftMissedCount(Membership $member, $date) {
         $shift_cycle = $this->getCycleNumber($member, $date);
         $cycle_start = $this->getStartOfCycle($member, $shift_cycle);
         $cycle_end = $this->getEndOfCycle($member, $shift_cycle);
-        return $this->em->getRepository('AppBundle:Shift')->countMemberShiftsMissed($member, $cycle_start, $cycle_end);
+        return $this->em->getRepository('AppBundle:Shift')->getMemberShiftMissedCount($member, $cycle_start, $cycle_end);
     }
 
-    public function getCycleShiftsFreedCount(Membership $member, $date, $less_than_min_time_in_advance_days = null) {
+    public function getCycleShiftFreedCount(Membership $member, $date, $less_than_min_time_in_advance_days = null) {
         $shift_cycle = $this->getCycleNumber($member, $date);
         $cycle_start = $this->getStartOfCycle($member, $shift_cycle);
         $cycle_end = $this->getEndOfCycle($member, $shift_cycle);
-        return $this->em->getRepository('AppBundle:ShiftFreeLog')->countMemberShiftsFreed($member, $cycle_start, $cycle_end, $less_than_min_time_in_advance_days);
+        return $this->em->getRepository('AppBundle:ShiftFreeLog')->getMemberShiftFreedCount($member, $cycle_start, $cycle_end, $less_than_min_time_in_advance_days);
     }
 
     /**

--- a/src/AppBundle/Service/MembershipService.php
+++ b/src/AppBundle/Service/MembershipService.php
@@ -182,6 +182,13 @@ class MembershipService
         return $this->em->getRepository('AppBundle:Shift')->countMemberShiftsMissed($member, $cycle_start, $cycle_end);
     }
 
+    public function getCycleShiftsFreedCount(Membership $member, $date, $less_than_min_time_in_advance_days = null) {
+        $shift_cycle = $this->getCycleNumber($member, $date);
+        $cycle_start = $this->getStartOfCycle($member, $shift_cycle);
+        $cycle_end = $this->getEndOfCycle($member, $shift_cycle);
+        return $this->em->getRepository('AppBundle:ShiftFreeLog')->countMemberShiftsFreed($member, $cycle_start, $cycle_end, $less_than_min_time_in_advance_days);
+    }
+
     /**
      * Return true if the membership is in a "warning" status
      */

--- a/src/AppBundle/Service/MembershipService.php
+++ b/src/AppBundle/Service/MembershipService.php
@@ -164,6 +164,17 @@ class MembershipService
         return $date;
     }
 
+    public function getCycleNumber(Membership $membership, $date) {
+        $cycle_end = $this->getEndOfCycle($member, -1);
+        for ($cycle = -1; $cycle < 3; $cycle++) {
+            if ($date <= $current_cycle_end) {
+                return $cycle
+            }
+            $cycle_end->modify("+28 days");
+        }
+        return null
+    }
+
     /**
      * Return true if the membership is in a "warning" status
      */

--- a/src/AppBundle/Service/MembershipService.php
+++ b/src/AppBundle/Service/MembershipService.php
@@ -152,34 +152,34 @@ class MembershipService
 
     /**
      * Get end date of current cycle
-     * @param Membership $membership
+     * @param Membership $member
      * @param int $cycleIndex
      * @return DateTime|null
      */
-    public function getEndOfCycle(Membership $membership, $cycleOffset = 0)
+    public function getEndOfCycle(Membership $member, $cycleOffset = 0)
     {
-        $date = clone($this->getStartOfCycle($membership, $cycleOffset));
+        $date = clone($this->getStartOfCycle($member, $cycleOffset));
         $date->modify("+27 days");
         $date->setTime(23, 59, 59);
         return $date;
     }
 
-    public function getCycleNumber(Membership $membership, $date) {
+    public function getCycleNumber(Membership $member, $date) {
         $cycle_end = $this->getEndOfCycle($member, -1);
         for ($cycle = -1; $cycle < 3; $cycle++) {
-            if ($date <= $current_cycle_end) {
-                return $cycle
+            if ($date <= $cycle_end) {
+                return $cycle;
             }
             $cycle_end->modify("+28 days");
         }
-        return null
+        return null;
     }
 
-    public function getCycleMissedShiftsCount(Membership $membership, $date) {
-        $shift_cycle = $this->getCycleNumber($membership, $date);
-        $cycle_start = $this->getStartOfCycle($membership, $shift_cycle);
-        $cycle_end = $this->getEndOfCycle($membership, $shift_cycle);
-        return $this->em->getRepository('AppBundle:Shift')->getMissedShiftsCount($membership, $cycle_start, $cycle_end);
+    public function getCycleShiftsMissedCount(Membership $member, $date) {
+        $shift_cycle = $this->getCycleNumber($member, $date);
+        $cycle_start = $this->getStartOfCycle($member, $shift_cycle);
+        $cycle_end = $this->getEndOfCycle($member, $shift_cycle);
+        return $this->em->getRepository('AppBundle:Shift')->countMemberShiftsMissed($member, $cycle_start, $cycle_end);
     }
 
     /**

--- a/src/AppBundle/Service/ShiftService.php
+++ b/src/AppBundle/Service/ShiftService.php
@@ -252,15 +252,7 @@ class ShiftService
 
         // TODO refactor code to remove shift_cycle
         // canBookDuration method should not use TimeLog but request shifts
-        $shift_cycle = 0;
-        for ($cycle = 0; $cycle < 3; $cycle++) {
-            $current_cycle_end = $this->membershipService->getEndOfCycle($member, $cycle);
-            if ($shift->getStart() <= $current_cycle_end) {
-                $shift_cycle = $cycle;
-                break;
-            }
-        }
-
+        $shift_cycle = $this->membershipService->getCycleNumber($member, $shift->getStart());
         return $this->canBookDuration($beneficiary, $shift->getDuration(), $shift_cycle) or $this->canBookExtraShift($beneficiary, $shift);
     }
 

--- a/src/AppBundle/Service/TimeLogService.php
+++ b/src/AppBundle/Service/TimeLogService.php
@@ -112,6 +112,22 @@ class TimeLogService
     }
 
     /**
+     * Initialize an "shift end saving" log with the shift data
+     * 
+     * @param Shift $shift
+     * @param \DateTime $date
+     * @return TimeLog
+     */
+    public function initShiftEndSavingTimeLog(Membership $member, $time)
+    {
+        $log = $this->initTimeLog($member);
+        $log->setType(TimeLog::TYPE_SHIFT_END_SAVING);
+        $log->setTime($time);
+
+        return $log;
+    }
+
+    /**
      * Initialize a "cycle beginning" log with the member data
      * 
      * @param Membership $member

--- a/src/AppBundle/Service/TimeLogService.php
+++ b/src/AppBundle/Service/TimeLogService.php
@@ -148,9 +148,9 @@ class TimeLogService
      * @param \DateTime $date
      * @return TimeLog
      */
-    public function initCycleEndSavingTimeLog(Membership $member, $time)
+    public function initCycleEndSavingTimeLog(Membership $member, $time, $description = null)
     {
-        $log = $this->initTimeLog($member);
+        $log = $this->initTimeLog($member, null, $description);
         $log->setType(TimeLog::TYPE_CYCLE_END_SAVING);
         $log->setTime($time);
 

--- a/src/AppBundle/Service/TimeLogService.php
+++ b/src/AppBundle/Service/TimeLogService.php
@@ -112,22 +112,6 @@ class TimeLogService
     }
 
     /**
-     * Initialize an "shift end saving" log with the shift data
-     * 
-     * @param Shift $shift
-     * @param \DateTime $date
-     * @return TimeLog
-     */
-    public function initShiftEndSavingTimeLog(Membership $member, $time)
-    {
-        $log = $this->initTimeLog($member);
-        $log->setType(TimeLog::TYPE_SHIFT_END_SAVING);
-        $log->setTime($time);
-
-        return $log;
-    }
-
-    /**
      * Initialize a "cycle beginning" log with the member data
      * 
      * @param Membership $member
@@ -153,6 +137,22 @@ class TimeLogService
     {
         $date = $this->membershipService->getStartOfCycle($member, 0);
         $log = $this->initCycleBeginningTimeLog($member, $date);
+
+        return $log;
+    }
+
+    /**
+     * Initialize a "cycle end saving" log
+     * 
+     * @param Shift $shift
+     * @param \DateTime $date
+     * @return TimeLog
+     */
+    public function initCycleEndSavingTimeLog(Membership $member, $time)
+    {
+        $log = $this->initTimeLog($member);
+        $log->setType(TimeLog::TYPE_CYCLE_END_SAVING);
+        $log->setTime($time);
 
         return $log;
     }


### PR DESCRIPTION
Ajout de la logique d'utilisation du compte épargne en fin de cycle.

1. Si il y a du temps supplémentaire sur le compteur temps : 
- on bascule le surplus sur le compteur épargne

2. Si il manque du temps sur le compteur temps, et le membre a du temps sur son compteur épargne, on utilise son compteur épargne : 
- si le membre n'a pas raté de créneau sur son cycle précédent
- si le membre n'a pas annulé de créneau à moins de 10 jours