### PR TITLE
Créneau fixe : nouveau paramètre pour autoriser l'annulation de créneaux fixes

### DIFF
--- a/app/Resources/views/booking/_partial/home_shift_card.html.twig
+++ b/app/Resources/views/booking/_partial/home_shift_card.html.twig
@@ -26,43 +26,28 @@
                 {% endif %}
             </div>
             <div id="free{{ shift.id }}" class="modal black-text">
-                {% if use_time_log_saving and shift.duration > member.savingTimeCount %}
+                {{ form_start(shift_free_forms[shift.id]) }}
                     <div class="modal-content">
-                        <h5>Annuler mon créneau</h5>
-                        <br />
-                        <div class="card-panel teal warning">
-                            Vous ne pouvez pas annuler ce créneau.
-                            <br />
-                            La durée du créneau (<strong>{{ shift.duration | duration_from_minutes }}</strong>) dépasse la capacité de votre compteur épargne (<strong>{{ member.savingTimeCount | duration_from_minutes }}</strong>).
+                        <h5>Je ne peux pas faire mon créneau</h5>
+                        <div class="input-field">
+                            {{ form_label(shift_free_forms[shift.id].reason) }}
+                            {{ form_errors(shift_free_forms[shift.id].reason) }}
+                            {{ form_widget(shift_free_forms[shift.id].reason) }}
                         </div>
+                        {% if use_time_log_saving %}
+                            <div class="card-panel blue lighten-3">
+                                <i class="material-icons left">info</i>
+                                Grâce au compteur épargne, ce créneau sera tout de même comptabilisé.
+                                <br />
+                                En échange, <strong>{{ shift.duration | duration_from_minutes }}</strong> seront décrémentés de votre compteur épargne (<strong>{{ member.savingTimeCount | duration_from_minutes }}</strong>).
+                            </div>
+                        {% endif %}
                     </div>
                     <div class="modal-footer">
                         <a href="#!" class="modal-action modal-close waves-effect waves-green btn-flat grey-text">Annuler</a>
+                        <button type="submit" class="modal-action modal-close waves-effect waves-green btn red">Oui, je me désiste !</button>
                     </div>
-                {% else %}
-                    {{ form_start(shift_free_forms[shift.id]) }}
-                        <div class="modal-content">
-                            <h5>Je ne peux pas faire mon créneau</h5>
-                            <div class="input-field">
-                                {{ form_label(shift_free_forms[shift.id].reason) }}
-                                {{ form_errors(shift_free_forms[shift.id].reason) }}
-                                {{ form_widget(shift_free_forms[shift.id].reason) }}
-                            </div>
-                            {% if use_time_log_saving %}
-                                <div class="card-panel blue lighten-3">
-                                    <i class="material-icons left">info</i>
-                                    Grâce au compteur épargne, ce créneau sera tout de même comptabilisé.
-                                    <br />
-                                    En échange, <strong>{{ shift.duration | duration_from_minutes }}</strong> seront décrémentés de votre compteur épargne (<strong>{{ member.savingTimeCount | duration_from_minutes }}</strong>).
-                                </div>
-                            {% endif %}
-                        </div>
-                        <div class="modal-footer">
-                            <a href="#!" class="modal-action modal-close waves-effect waves-green btn-flat grey-text">Annuler</a>
-                            <button type="submit" class="modal-action modal-close waves-effect waves-green btn red">Oui, je me désiste !</button>
-                        </div>
-                    {{ form_end(shift_free_forms[shift.id]) }}
-                {% endif %}
+                {{ form_end(shift_free_forms[shift.id]) }}
             </div>
         {% endif %}
     {% endif %}

--- a/app/Resources/views/booking/_partial/home_shift_card.html.twig
+++ b/app/Resources/views/booking/_partial/home_shift_card.html.twig
@@ -28,7 +28,7 @@
             <div id="free{{ shift.id }}" class="modal black-text">
                 {{ form_start(shift_free_forms[shift.id]) }}
                     <div class="modal-content">
-                        <h5>Je ne peux pas faire mon créneau</h5>
+                        <h5>Je ne peux pas faire mon créneau{% if shift.fixe %} fixe{% endif %}</h5>
                         <div class="input-field">
                             {{ form_label(shift_free_forms[shift.id].reason) }}
                             {{ form_errors(shift_free_forms[shift.id].reason) }}

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -93,6 +93,8 @@ twig:
     display_keys_shop: '%display_keys_shop%'
     display_name_shifters: '%display_name_shifters%'
     use_card_reader_to_validate_shifts: '%use_card_reader_to_validate_shifts%'
+    # fly and fixed
+    fly_and_fixed_allow_fixed_shift_free: '%fly_and_fixed_allow_fixed_shift_free%'
     # time log saving
     time_log_saving_shift_free_min_time_in_advance_days: '%time_log_saving_shift_free_min_time_in_advance_days%'
     # role names & icons

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -146,6 +146,9 @@ parameters:
     swipe_card_logging_anonymous: true
     display_swipe_cards_settings: true
 
+    # Fly and fixed
+    fly_and_fixed_allow_fixed_shift_free: false
+
     # Time log saving
     time_log_saving_shift_free_min_time_in_advance_days: null
 

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -192,6 +192,8 @@ services:
                 - "%allow_extra_shifts%"
                 - "%max_time_in_advance_to_book_extra_shifts%"
                 - "%forbid_shift_overlap_time%"
+                - "%use_fly_and_fixed%"
+                - "%fly_and_fixed_allow_fixed_shift_free%"
                 - "%use_time_log_saving%"
                 - "%time_log_saving_shift_free_min_time_in_advance_days%"
     shift_free_log_service:

--- a/src/AppBundle/Service/ShiftService.php
+++ b/src/AppBundle/Service/ShiftService.php
@@ -25,11 +25,14 @@ class ShiftService
     private $allowExtraShifts;
     private $maxTimeInAdvanceToBookExtraShifts;
     private $forbidShiftOverlapTime;
+    private $use_fly_and_fixed;
+    private $fly_and_fixed_allow_fixed_shift_free;
     private $use_time_log_saving;
     private $time_log_saving_shift_free_min_time_in_advance_days;
 
     public function __construct(EntityManagerInterface $em, BeneficiaryService $beneficiaryService, MembershipService $membershipService,
         $due_duration_by_cycle, $min_shift_duration, $newUserStartAsBeginner, $allowExtraShifts, $maxTimeInAdvanceToBookExtraShifts, $forbidShiftOverlapTime,
+        $use_fly_and_fixed, $fly_and_fixed_allow_fixed_shift_free,
         $use_time_log_saving, $time_log_saving_shift_free_min_time_in_advance_days)
     {
         $this->em = $em;
@@ -41,6 +44,8 @@ class ShiftService
         $this->allowExtraShifts = $allowExtraShifts;
         $this->maxTimeInAdvanceToBookExtraShifts = $maxTimeInAdvanceToBookExtraShifts;
         $this->forbidShiftOverlapTime = $forbidShiftOverlapTime;
+        $this->use_fly_and_fixed = $use_fly_and_fixed;
+        $this->fly_and_fixed_allow_fixed_shift_free = $fly_and_fixed_allow_fixed_shift_free;
         $this->use_time_log_saving = $use_time_log_saving;
         $this->time_log_saving_shift_free_min_time_in_advance_days = $time_log_saving_shift_free_min_time_in_advance_days;
     }
@@ -277,9 +282,12 @@ class ShiftService
         if ($shift->getShifter() != $beneficiary) {
             return false;
         }
-        // cannot free a fixed shift
-        if ($shift->isFixe()) {
-            return false;
+
+        // Fly & fixed: check if there is a rule allowing to free fixed shifts
+        if ($this->use_fly_and_fixed) {
+            if ($shift->isFixe() && !$this->fly_and_fixed_allow_fixed_shift_free) {
+                return false;
+            }
         }
 
         // Time log saving: check if there is a min time in advance rule


### PR DESCRIPTION
Suite de https://github.com/elefan-grenoble/gestion-compte/pull/787

### Quoi ?

Actuellement, seul les créneaux volants sont annulable par le membre. Cette PR vise à changer cela grâce à un nouveau paramètre.

Modifications apportées : 
- nouveau paramètre `fly_and_fixed_allow_fixed_shift_free`
- si l'épicerie utilise les créneaux fixe (`use_fly_and_fixed=true`) et ce nouveau paramètre est `true`, alors les créneaux fixes sont aussi annulables