### PR TITLE
Membre : nouveau filtre pour trouver les membres sans adhésion

### DIFF
--- a/app/Resources/views/admin/user/list.html.twig
+++ b/app/Resources/views/admin/user/list.html.twig
@@ -84,19 +84,25 @@
                         </div>
                         <h5>Adhésion(s)</h5>
                         <div class="row">
-                            <div class="col s4">
+                            <div class="col s3">
+                                <div class="input-field">
+                                    {{ form_widget(form.registration) }}
+                                    {{ form_label(form.registration) }}
+                                </div>
+                            </div>
+                            <div class="col s3">
                                 <div class="input-field">
                                     {{ form_widget(form.registrationdate) }}
                                     {{ form_label(form.registrationdate) }}
                                 </div>
                             </div>
-                            <div class="col s4">
+                            <div class="col s3">
                                 <div class="input-field">
                                     {{ form_widget(form.registrationdategt) }}
                                     {{ form_label(form.registrationdategt) }}
                                 </div>
                             </div>
-                            <div class="col s4">
+                            <div class="col s3">
                                 <div class="input-field">
                                     {{ form_widget(form.registrationdatelt) }}
                                     {{ form_label(form.registrationdatelt) }}

--- a/app/Resources/views/ambassador/phone/list.html.twig
+++ b/app/Resources/views/ambassador/phone/list.html.twig
@@ -65,6 +65,14 @@
                         </div>
                     </div>
                     <div class="col s12 m4">
+                        <h5>Adhésion(s)</h5>
+                        <div class="row">
+                            <div class="col s6 input-field">
+                                {{ form_widget(form.registration) }}
+                                {{ form_label(form.registration) }}
+                                {{ form_errors(form.registration) }}
+                            </div>
+                        </div>
                         <h5>Dernière Adhésion</h5>
                         <div class="row">
                             <div class="col s6 input-field">

--- a/src/AppBundle/Controller/AmbassadorController.php
+++ b/src/AppBundle/Controller/AmbassadorController.php
@@ -36,7 +36,7 @@ class AmbassadorController extends Controller
     }
 
     /**
-     * List all users with a registration date older than one year.
+     * List all members with a registration date older than one year.
      *
      * @Route("/membership", name="ambassador_membership_list", methods={"GET","POST"})
      * @Security("has_role('ROLE_USER_VIEWER')")
@@ -56,9 +56,10 @@ class AmbassadorController extends Controller
             'sort' => 'r.date',
             'dir' => 'DESC',
             'withdrawn' => 1,
-            'lastregistrationdatelt' => $endLastRegistration
+            'lastregistrationdatelt' => $endLastRegistration,
+            'registration' => 2,
         ];
-        $disabledFields = ['withdrawn', 'lastregistrationdatelt'];
+        $disabledFields = ['withdrawn', 'lastregistrationdatelt', 'registration'];
 
         $form = $formHelper->createMembershipFilterForm($this->createFormBuilder(), $defaults, $disabledFields);
         $form->handleRequest($request);
@@ -97,7 +98,7 @@ class AmbassadorController extends Controller
             ->setMaxResults($limitPerPage); // set the limit
 
         return $this->render('ambassador/phone/list.html.twig', array(
-            'reason' => "d'adhésion",
+            'reason' => "de ré-adhésion",
             'members' => $paginator,
             'form' => $form->createView(),
             'nb_of_result' => $totalItems,
@@ -108,7 +109,7 @@ class AmbassadorController extends Controller
     }
 
     /**
-     * List all users with shift time logs older than 9 hours.
+     * List all members with shift time logs older than 9 hours.
      *
      * @Route("/shifttimelog", name="ambassador_shifttimelog_list", methods={"GET","POST"})
      * @Security("has_role('ROLE_USER_MANAGER')")
@@ -122,9 +123,10 @@ class AmbassadorController extends Controller
             'dir' => 'DESC',
             'withdrawn' => 1,
             'frozen' => 1,
-            'compteurlt' => 0
+            'compteurlt' => 0,
+            'registration' => 2,
         ];
-        $disabledFields = ['withdrawn', 'compteurlt'];
+        $disabledFields = ['withdrawn', 'compteurlt', 'registration'];
 
         $form = $formHelper->createShiftTimeLogFilterForm($this->createFormBuilder(), $defaults, $disabledFields);
         $form->handleRequest($request);

--- a/src/AppBundle/Service/SearchUserFormHelper.php
+++ b/src/AppBundle/Service/SearchUserFormHelper.php
@@ -31,7 +31,7 @@ class SearchUserFormHelper {
         $formBuilder->add('withdrawn', ChoiceType::class, [
             'label' => $this->container->getParameter('member_withdrawn_icon') . ' fermé',
             'required' => false,
-            'disabled' => in_array("withdrawn", $disabledFields) ? true : false,
+            'disabled' => in_array('withdrawn', $disabledFields) ? true : false,
             'choices' => [
                 'fermé' => 2,
                 'ouvert' => 1,
@@ -95,6 +95,7 @@ class SearchUserFormHelper {
         $formBuilder->add('registration', ChoiceType::class, [
             'label' => $this->container->getParameter('member_registration_missing_icon') . ' adhéré',
             'required' => false,
+            'disabled' => in_array('registration', $disabledFields) ? true : false,
             'choices' => [
                 'adhéré' => 2,
                 'Non adhéré' => 1,
@@ -146,7 +147,7 @@ class SearchUserFormHelper {
             'html5' => false,
             'label' => 'avant le',
             'required' => false,
-            'disabled' => in_array("lastregistrationdatelt", $disabledFields) ? true : false,
+            'disabled' => in_array('lastregistrationdatelt', $disabledFields) ? true : false,
             'attr' => [
                 'class' => 'datepicker',
             ]
@@ -160,7 +161,7 @@ class SearchUserFormHelper {
         $formBuilder->add('compteurlt', NumberType::class, [
             'label' => 'max',
             'required' => false,
-            'disabled' => in_array("compteurlt", $disabledFields) ? true : false,
+            'disabled' => in_array('compteurlt', $disabledFields) ? true : false,
         ])
         ->add('compteurgt', NumberType::class, [
             'label' => 'min',
@@ -275,7 +276,7 @@ class SearchUserFormHelper {
     }
 
     public function createShiftTimeLogFilterForm($formBuilder, $defaults = [], $disabledFields = []) {
-        $form = $this->getSearchForm($formBuilder, "shifttimelog", $disabledFields);
+        $form = $this->getSearchForm($formBuilder, 'shifttimelog', $disabledFields);
         // set compteurlt default
         $options = $form->get('compteurlt')->getConfig()->getOptions();
         $options['required'] = true;
@@ -291,7 +292,7 @@ class SearchUserFormHelper {
     }
 
     public function createMembershipFilterForm($formBuilder, $defaults, $disabledFields = []) {
-        $form = $this->getSearchForm($formBuilder, "membership", $disabledFields);
+        $form = $this->getSearchForm($formBuilder, 'membership', $disabledFields);
         // set lastregistrationdatelt default
         $options = $form->get('lastregistrationdatelt')->getConfig()->getOptions();
         $options['required'] = true;

--- a/src/AppBundle/Service/SearchUserFormHelper.php
+++ b/src/AppBundle/Service/SearchUserFormHelper.php
@@ -90,8 +90,18 @@ class SearchUserFormHelper {
             $formBuilder->add('membernumberdiff', TextType::class, [
                 'label' => '# <>',
                 'required' => false
-            ])
-            ->add('registrationdate', TextType::class, [
+            ]);
+        }
+        $formBuilder->add('registration', ChoiceType::class, [
+            'label' => $this->container->getParameter('member_registration_missing_icon') . ' adhéré',
+            'required' => false,
+            'choices' => [
+                'adhéré' => 2,
+                'Non adhéré' => 1,
+            ]
+        ]);
+        if (!$type) {
+            $formBuilder->add('registrationdate', TextType::class, [
                 'label' => 'le',
                 'required' => false,
                 'attr' => [
@@ -411,6 +421,13 @@ class SearchUserFormHelper {
                 ->setParameter('beneficiary_count', $form->get('beneficiary_count')->getData()-1);
         }
 
+        if ($form->get('registration')->getData()) {
+            if ($form->get('registration')->getData() == 2) {
+                $qb = $qb->andWhere('r.date IS NOT NULL');
+            } else if ($form->get('registration')->getData() == 1) {
+                $qb = $qb->andWhere('r.date IS NULL');
+            }
+        }
         if ($form->get('registrationdate')->getData()) {
             $qb = $qb->andWhere('r.date LIKE :registrationdate')
                 ->setParameter('registrationdate', $form->get('registrationdate')->getData().'%');


### PR DESCRIPTION
### Quoi ?

- sur la page "liste des membres", pouvoir filtrer les membres "adhéré" ou "non adhéré"
- sur les pages "Relances créneaux" & "Relances ré-adhésion" : mettre le filtre "adhéré" par défaut (et read-only)

### Pourquoi ?

On n'avait pas de moyen de filtrer sur les membres sans adhésion

### Capture d'écran

![Screenshot from 2023-03-15 00-04-47](https://user-images.githubusercontent.com/7147385/225161398-6135c591-62e4-4f6d-871c-fcf36daf3d02.png)
