### PR TITLE
Ajout d'une version annonyme de la semaine type (V2)

### DIFF
--- a/app/Resources/views/admin/index.html.twig
+++ b/app/Resources/views/admin/index.html.twig
@@ -56,7 +56,7 @@
                 <a href="{{ path("shift_new") }}" class="waves-effect waves-light btn orange">
                     <i class="material-icons left">add</i>créer un créneau ponctuel
                 </a>
-                <a href="{{ path("period") }}" class="waves-effect waves-light btn orange">
+                <a href="{{ path("period_index") }}" class="waves-effect waves-light btn orange">
                     <i class="material-icons left">date_range</i>la semaine type
                 </a>
             {% endif %}

--- a/app/Resources/views/admin/index.html.twig
+++ b/app/Resources/views/admin/index.html.twig
@@ -56,7 +56,7 @@
                 <a href="{{ path("shift_new") }}" class="waves-effect waves-light btn orange">
                     <i class="material-icons left">add</i>créer un créneau ponctuel
                 </a>
-                <a href="{{ path("period_index") }}" class="waves-effect waves-light btn orange">
+                <a href="{{ path("period_admin") }}" class="waves-effect waves-light btn orange">
                     <i class="material-icons left">date_range</i>la semaine type
                 </a>
             {% endif %}

--- a/app/Resources/views/admin/period/index.html.twig
+++ b/app/Resources/views/admin/period/index.html.twig
@@ -1,4 +1,23 @@
+{#
+    twig template for Controller/PeriodController.php/adminIndexAction()
+    for the route: /period/admin
+    It display a page with all the avaible periods (a.k.a the "Semaine type")
+    (and also display the periods reserved for a members if use_fly_and_fixed==true)
+#}
+
 {% extends 'layout.html.twig' %}
+
+{# generate a form input, used for the filters #}
+{% macro form_input(input_obj, hidden=false) %}
+    <div class="input-field col m3">
+        {% if hidden %}
+            {{ form_widget(input_obj, { 'attr': {'class': 'hide'} }) }}
+        {% else %}
+            {{ form_widget(input_obj) }}
+            {{ form_label(input_obj) }}
+        {% endif %}
+    </div>
+{% endmacro %}
 
 {% block title %}Semaine type - {{ site_name }}{% endblock %}
 
@@ -39,92 +58,6 @@
     </style>
 {% endblock %}
 
-{% block macro %}
-    {# generate a form input, used for the filters #}
-    {% macro form_input(input_obj, hidden=false) %}
-        <div class="input-field col m3">
-            {% if hidden %}
-                {{ form_widget(input_obj, { 'attr': {'class': 'hide'} }) }}
-            {% else %}
-                {{ form_widget(input_obj) }}
-                {{ form_label(input_obj) }}
-            {% endif %}
-        </div>
-    {% endmacro %}
-
-    {# generate one line with the icon and the shifter id+name and if needed a warning icon #}
-    {% macro position_shifter_display(position) %}
-        {% set shifter = position.shifter %}
-        {% set formation = position.formation??"Sans formation" %}
-
-        {% if shifter %}
-            {# sombody is registered for this periodposition #}
-            {% set warning = beneficiary_service.hasWarningStatus(shifter) %}
-            <a href="{{ path('member_show', { 'member_number': shifter.membership.memberNumber }) }}" target="_blank"
-               class="black-text tooltipped editable-box truncate" data-position="bottom" data-tooltip="{{ shifter | print_with_number_and_status_icon | raw }} &#013;&#010; ({{ formation }})">
-                {% if warning %}
-                    <i class="red-text material-icons warning-animation">warning</i>
-                {% else %}
-                    <i class="material-icons">person</i>
-                {% endif %}
-                {{ shifter.getFirstname() }} {{ shifter.getLastname() | first }}
-            </a>
-        {% else %}
-            <div class="tooltipped truncate black-text" data-position="bottom" data-tooltip="{{ formation }}">
-                <i class="material-icons">person</i>
-                <strong><i>libre</i></strong>
-            </div>
-        {% endif %}
-    {% endmacro position_shifter_display %}
-
-    {# generate a card for all positions in a period
-     # period: a period object
-     # week_filter: a string with the week to keep or null if no filter
-    #}
-    {% macro period_card(period, week_filter) %}
-        <div class="card {{ period.job? period.job.color : "blue" }} lighten-2 hoverable" style="padding: 15px;">
-
-            {# Card header #}
-            <a href="{{ path("period_edit",{'id': period.id}) }}" class="black-text">
-                <div class="black-text editable-box">
-                    {% if period.job %}
-                        <b>{{ period.job.name }}</b>
-                        <br>
-                        {{ period.start | date('H:i') }}-{{ period.end | date('H:i') }}
-                    {% else %}
-                        {{ period.start | date('H:i') }}-{{ period.end | date('H:i') }}
-                        <br>
-                    {% endif %}
-                </div>
-            </a>
-            {# if display by job/training #}
-            <div id="training" style="margin-top:1em;">
-                {% for week, positions in period.groupedpositionsperweekcycle(week_filter) %}
-                    <h6>Semaine {{ week }}</h6>
-                    {% for training, nb_shifters in positions %}
-                        <i class="material-icons">person</i>{{ nb_shifters }} x {{ training }}
-                        <br/>
-                    {% endfor %}
-                {% endfor %}
-            </div>
-
-            {# if display by member name #}
-            {% if use_fly_and_fixed %}
-                <div id="shifter" style="margin-top:1em;">
-                    {% for week, positions in period.positionsperweekcycle %}
-                        {% if (week in week_filter) or not week_filter %}
-                            <h6>Semaine {{ week }}</h6>
-                            {% for position in positions %}
-                                {{ _self.position_shifter_display(position) }}
-                            {% endfor %}
-                        {% endif %}
-                    {% endfor %}
-                </div>
-            {% endif %}
-        </div>
-    {% endmacro %}
-{% endblock macro %}
-
 {% block breadcrumbs %}
 <a href="{{ path('homepage') }}"><i class="material-icons">home</i></a><i class="material-icons">chevron_right</i>
 <a href="{{ path('admin') }}"><i class="material-icons">build</i>&nbsp;Administration</a><i class="material-icons">chevron_right</i>
@@ -142,8 +75,8 @@
 
             {# Header section -------------------------------------------------- #}
             <ul class="collapsible">
-                {# Filters  ---------------------------------- #}
                 <li>
+                    {# Filters ----------------------------------- #}
                     <div class="collapsible-header">
                         <i class="material-icons">tune</i>Filtres
                     </div>
@@ -170,7 +103,8 @@
                         <div class="row">
                             <a href="{{ path("period_new") }}"
                                class="btn col m4 waves-effect waves-light tooltipped"
-                               data-position="bottom" data-tooltip="Créer un groupe de créneaux type à une heure et un jour donné">
+                               data-position="bottom"
+                               data-tooltip="Créer un groupe de créneaux type à une heure et un jour donné">
                                 <i class="material-icons left">note_add</i>Nouveau créneau type
                             </a>
                         </div>
@@ -179,15 +113,18 @@
                             <div class="row">
                                 <a href="{{ path("period_copy") }}"
                                    class="btn col m4 waves-effect waves-light tooltipped"
-                                   data-position="bottom" data-tooltip="Dupliquer des créneaux types d'un jour vers un autre">
+                                   data-position="bottom"
+                                   data-tooltip="Dupliquer des créneaux types d'un jour vers un autre">
                                     <i class="material-icons left">content_copy</i>Dupliquer des créneaux
                                 </a>
                             </div>
                             <div class="row">
                                 <a href="{{ path("shifts_generation") }}"
                                    class="btn col m4 waves-effect waves-light tooltipped"
-                                   data-position="bottom" data-tooltip="Générer automatiquement des créneaux à partir de la semaine type">
-                                    <i class="material-icons left">date_range</i> <i class="material-icons left">build</i>Générer des créneaux
+                                   data-position="bottom"
+                                   data-tooltip="Générer automatiquement des créneaux à partir de la semaine type">
+                                    <i class="material-icons left">date_range</i> <i
+                                            class="material-icons left">build</i>Générer des créneaux
                                 </a>
                             </div>
                         {% endif %}
@@ -195,77 +132,80 @@
                         {% if use_fly_and_fixed %}
                             <div class="row">
                                 <a id="shifter" style="display: None;" onClick="showShifters()"
-                                class="btn col m4 waves-effect waves-light purple tooltipped"
-                                data-position="bottom" data-tooltip="Afficher le nom des membres inscrits en créneaux fixes">
+                                   class="btn col m4 waves-effect waves-light purple tooltipped"
+                                   data-position="bottom"
+                                   data-tooltip="Afficher le nom des membres inscrits en créneaux fixes">
                                     <i class="material-icons left">accessibility</i>Afficher les membres
                                 </a>
                                 <a id="training" onClick="showTraining()"
-                                class="btn col m4 waves-effect waves-light purple tooltipped"
-                                data-position="bottom" data-tooltip="Afficher la formation demandée pour étre inscrit à un créneau">
+                                   class="btn col m4 waves-effect waves-light purple tooltipped"
+                                   data-position="bottom"
+                                   data-tooltip="Afficher la formation demandée pour être inscrit à un créneau">
                                     <i class="material-icons left">accessibility</i>Afficher les formations
                                 </a>
                             </div>
                         {% endif %}
                     </div>
                 </li>
-                {% if use_fly_and_fixed %}
+                <li>
                     {# Légende ----------------------------------- #}
-                    <li>
-                        <div class="collapsible-header">
-                            <i class="material-icons">help_outline</i>Légende
-                        </div>
-                        <div class="collapsible-body">
+                    <div class="collapsible-header">
+                        <i class="material-icons">help_outline</i>Légende
+                    </div>
+                    <div class="collapsible-body">
+                        {% if use_fly_and_fixed %}
+                            {# Légende ----------------------------------- #}
                             <table class="responsive-table striped">
                                 <thead>
-                                    <tr>
-                                        <th>Texte</th>
-                                        <th>Explication</th>
-                                    </tr>
+                                <tr>
+                                    <th>Texte</th>
+                                    <th>Explication</th>
+                                </tr>
                                 </thead>
                                 <tbody>
-                                    <tr>
-                                        <td>
-                                            <i class="material-icons">person</i>&nbsp;<strong><i>libre</i></strong>
-                                        </td>
-                                        <td>
-                                            Un créneau fixe libre
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td>
-                                            <i class="material-icons">person</i>&nbsp;Prénom N
-                                        </td>
-                                        <td>
-                                            Un créneau fixe avec un bénéficiaire d'inscrit
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td>
-                                            <i class="red-text material-icons warning-animation">warning</i>&nbsp;Prénom N
-                                        </td>
-                                        <td>
-                                            Un créneau fixe avec un bénéficiaire dans un état "anormal"
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td>
-                                            Etats "anormaux"
-                                        </td>
-                                        <td>
-                                            <ul>
-                                                <li>{{ member_withdrawn_icon }} Membre clôturé</li>
-                                                <li>{{ member_frozen_icon }} Membre gelé</li>
-                                                <li>{{ member_exempted_icon }} Membre exempté de créneaux</li>
-                                                <li>{{ member_registration_missing_icon }} Membre avec une adhésion expirée</li>
-                                                <li>{{ beneficiary_flying_icon }} Bénéficiaire avec un statut "volant"</li>
-                                            </ul>
-                                        </td>
-                                    </tr>
+                                <tr>
+                                    <td>
+                                        <i class="material-icons">person</i>&nbsp;<strong><i>libre</i></strong>
+                                    </td>
+                                    <td>
+                                        Un créneau fixe libre
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <i class="material-icons">person</i>&nbsp;Prénom N
+                                    </td>
+                                    <td>
+                                        Un créneau fixe avec un bénéficiaire d'inscrit
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <i class="red-text material-icons warning-animation">warning</i>&nbsp;Prénom N
+                                    </td>
+                                    <td>
+                                        Un créneau fixe avec un bénéficiaire dans un état "anormal"
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        Etats "anormaux"
+                                    </td>
+                                    <td>
+                                        <ul>
+                                            <li>{{ member_withdrawn_icon }} Membre clôturé</li>
+                                            <li>{{ member_frozen_icon }} Membre gelé</li>
+                                            <li>{{ member_exempted_icon }} Membre exempté de créneaux</li>
+                                            <li>{{ member_registration_missing_icon }} Membre avec une adhésion expirée</li>
+                                            <li>{{ beneficiary_flying_icon }} Bénéficiaire avec un statut "volant"</li>
+                                        </ul>
+                                    </td>
+                                </tr>
                                 </tbody>
                             </table>
-                        </div>
-                    </li>
-                {% endif %}
+                        {% endif %}
+                    </div>
+                </li>
             </ul>
         </div>
     </div>
@@ -292,7 +232,8 @@
                                         or (filling_filter == "full" and period.isFull(week_filter))
                                         or (filling_filter == "partial" and period.isPartial(week_filter))
                                         or (beneficiary_filter and period.hasShifter(beneficiary_filter) | length > 0) %}
-                                        {{ _self.period_card(period, week_filter) }}
+                                        {% include 'period/_partial/period_card.html.twig'
+                                                with {'period':period, 'week_filter':week_filter, 'anonymized':false} %}
                                     {% endif %}
                                 {% endfor %}
                             </td>

--- a/app/Resources/views/default/index.html.twig
+++ b/app/Resources/views/default/index.html.twig
@@ -127,6 +127,9 @@
                     <i class="material-icons left">schedule</i>Planning
                 </a>
                 <br />
+                <a href="{{ path("period") }}" class="waves-effect waves-light btn teal darken-1">
+                    <i class="material-icons left">schedule</i>Semaine type
+                </a>
                 <br />
                 {% if profile_display_task_list %}
                     <a href="{{ path("tasks_list") }}" class="waves-effect waves-light btn blue-grey">
@@ -138,6 +141,7 @@
                     <i class="material-icons left" >info</i>Les nouveautés
                     <span class="bubble_counter red white-text" style="display:none;">{{ app.user.beneficiary | last_shift_date | count_updates_list_from_date }}</span>
                 </a>
+
                 <script>
                     defer(function () {
                         var cookie_data = myCookieInit({'last_processupdates_check' : "{{ app.user.beneficiary | last_shift_date | date_w3c }}".replace('+','_')});
@@ -167,7 +171,7 @@
             </div>
             {% if app.user.beneficiary.ownedCommissions | length %}
                 <div class="homebox">
-                    <h5><span class="white">Mes commissions</h5>
+                    <h5><span class="white">Mes commissions</span></h5>
                     {% for commission in app.user.beneficiary.ownedCommissions %}
                         <a href="{{ path("commission_edit",{'id': commission.id }) }}" class="waves-effect waves-light btn blue-grey">
                             Gérer la commission {{ commission.name }}

--- a/app/Resources/views/default/index.html.twig
+++ b/app/Resources/views/default/index.html.twig
@@ -128,7 +128,7 @@
                 </a>
                 <br />
                 <a href="{{ path("period") }}" class="waves-effect waves-light btn teal darken-1">
-                    <i class="material-icons left">schedule</i>Semaine type
+                    <i class="material-icons left">date_range</i>Semaine type
                 </a>
                 <br />
                 {% if profile_display_task_list %}

--- a/app/Resources/views/period/_partial/period_card.html.twig
+++ b/app/Resources/views/period/_partial/period_card.html.twig
@@ -1,0 +1,64 @@
+{# Generate a card for all positions in a period
+# period: a Entity/Period object to be display
+# week_filter: a string with the week to keep or null if no filter
+# anonymized: if true will not display the shifter name
+
+# will use the editable-box css class if anonymized is false
+#}
+
+{# generate a form input, used for the filters #}
+{% macro period_title(period) %}
+    {% if period.job %}
+        <b>{{ period.job.name }}</b>
+        <br>
+        {{ period.start | date('H:i') }}-{{ period.end | date('H:i') }}
+    {% else %}
+        {{ period.start | date('H:i') }}-{{ period.end | date('H:i') }}
+        <br>
+    {% endif %}
+{% endmacro %}
+
+
+<div class="card {{ period.job? period.job.color : "blue" }} lighten-2 hoverable" style="padding: 15px;">
+
+    {# Card header #}
+    {%  if anonymized %}
+        <div>
+            {{ _self.period_title(period) }}
+        </div>
+
+    {% else %}
+        <a href="{{ path("period_edit",{'id': period.id}) }}" class="black-text">
+            <div class="black-text editable-box">
+                {{ _self.period_title(period) }}
+            </div>
+        </a>
+    {% endif %}
+
+
+    {# if display by job/training #}
+    <div id="training" style="margin-top:1em;">
+        {% for week, positions in period.groupedpositionsperweekcycle(week_filter) %}
+            <h6>Semaine {{ week }}</h6>
+            {% for training, nb_shifters in positions %}
+                <i class="material-icons">person</i>{{ nb_shifters }} x {{ training }}
+                <br/>
+            {% endfor %}
+        {% endfor %}
+    </div>
+
+    {# if display by member name #}
+    {% if use_fly_and_fixed %}
+        <div id="shifter" style="margin-top:1em;">
+            {% for week, positions in period.positionsperweekcycle %}
+                {% if (week in week_filter) or not week_filter %}
+                    <h6>Semaine {{ week }}</h6>
+                    {% for position in positions %}
+                        {% include 'period/_partial/position_shifter_display.html.twig'
+                            with {'position':position, 'anonymized':anonymized} %}
+                    {% endfor %}
+                {% endif %}
+            {% endfor %}
+        </div>
+    {% endif %}
+</div>

--- a/app/Resources/views/period/_partial/position_shifter_display.html.twig
+++ b/app/Resources/views/period/_partial/position_shifter_display.html.twig
@@ -1,0 +1,41 @@
+{# generate one line with the icon and the shifter id+name and if needed a warning icon
+# position: an Entity/PeriodPosition object to be display in a period
+# anonymized: if true will not display the shifter name
+#}
+
+{% set shifter = position.shifter %}
+{% set formation = position.formation??"Sans formation" %}
+
+{% if shifter %}
+    {# sombody is registered for this PeriodPosition #}
+
+    {%  if anonymized %}
+        {# sombody is registered for this periodposition #}
+        {% set warning = beneficiary_service.hasWarningStatus(shifter) %}
+        <div class="tooltipped truncate black-text" data-position="bottom" data-tooltip="Formation : {{ formation }}">
+            <i class="material-icons">person</i>
+            <strong><i>Réservé</i></strong>
+        </div>
+    {% else %}
+
+        {% set warning = beneficiary_service.hasWarningStatus(shifter) %}
+
+        <a href="{{ path('member_show', { 'member_number': shifter.membership.memberNumber }) }}" target="_blank"
+           class="black-text tooltipped editable-box truncate" data-position="bottom"
+           data-tooltip="{{ shifter | print_with_number_and_status_icon | raw }} &#013;&#010; ({{ formation }})">
+            {% if warning %}
+                <i class="red-text material-icons warning-animation">warning</i>
+            {% else %}
+                <i class="material-icons">person</i>
+            {% endif %}
+            {{ shifter.getFirstname() }} {{ shifter.getLastname() | first }}
+        </a>
+    {% endif %}
+{% else %}
+    {# free PeriodPosition #}
+    <div class="tooltipped truncate black-text" data-position="bottom" data-tooltip="{{ formation }}">
+        <i class="material-icons">person</i>
+        <strong><i>Libre</i></strong>
+    </div>
+
+{% endif %}

--- a/app/Resources/views/period/_partial/position_shifter_display.html.twig
+++ b/app/Resources/views/period/_partial/position_shifter_display.html.twig
@@ -14,7 +14,7 @@
         {% set warning = beneficiary_service.hasWarningStatus(shifter) %}
         <div class="tooltipped truncate black-text" data-position="bottom" data-tooltip="Formation : {{ formation }}">
             <i class="material-icons">person</i>
-            <strong><i>Réservé</i></strong>
+            Réservé
         </div>
     {% else %}
 

--- a/app/Resources/views/period/index.html.twig
+++ b/app/Resources/views/period/index.html.twig
@@ -1,0 +1,158 @@
+{#
+twig template for Controller/PeriodController.php/indexAction()
+for the route: /period/
+It display a page with all the avaible periods (a.k.a the "Semaine type")
+(and also display the periods reserved for a members if use_fly_and_fixed==true but without any names)
+#}
+
+{% extends 'layout.html.twig' %}
+
+{# generate a form input, used for the filters #}
+{% macro form_input(input_obj, hidden=false) %}
+    <div class="input-field col m3">
+        {% if hidden %}
+            {{ form_widget(input_obj, { 'attr': {'class': 'hide'} }) }}
+        {% else %}
+            {{ form_widget(input_obj) }}
+            {{ form_label(input_obj) }}
+        {% endif %}
+    </div>
+{% endmacro %}
+
+{% block title %}Semaine type - {{ site_name }}{% endblock %}
+
+{% block stylesheets %}
+    <link rel="stylesheet" href="{{ asset('bundles/app/css/custom_animation.css') }}?060820191303">
+    <style>
+        .card .material-icons {
+            display: inline-flex;
+            vertical-align: top;
+        }
+    </style>
+{% endblock %}
+
+{% block breadcrumbs %}
+    <a href="{{ path('homepage') }}"><i class="material-icons">home</i></a><i class="material-icons">chevron_right</i>
+    <i class="material-icons">date_range</i>&nbsp;Semaine type
+{% endblock breadcrumbs %}
+
+{% block container %}
+    <div class="container">
+        <div class="section">
+
+            {# Title Section --------------------------------------------------- #}
+            <div class="row center">
+                <h4 class="header">Semaine type</h4>
+            </div>
+
+            {# Header section -------------------------------------------------- #}
+            <ul class="collapsible">
+                <li>
+                    {# Filters ----------------------------------- #}
+                    <div class="collapsible-header">
+                        <i class="material-icons">tune</i>Filtres
+                    </div>
+                    <div class="collapsible-body">
+                        {{ form_start(filter_form) }}
+                        <div class="row">
+                            {{ _self.form_input(filter_form.job) }}
+                            {{ _self.form_input(filter_form.week) }}
+                            {{ _self.form_input(filter_form.filling, not use_fly_and_fixed) }}
+                        </div>
+                        <div class="row">
+                            {{ form_widget(filter_form.filter, { 'attr': {'class': 'btn col m3'} }) }}
+                            {{ form_end(filter_form) }}
+                        </div>
+                        {% if use_fly_and_fixed %}
+                        <div class="row">
+                            <a id="shifter" style="display: None;" onClick="showShifters()"
+                               class="btn col m3 waves-effect waves-light purple tooltipped"
+                               data-position="bottom"
+                               data-tooltip="Afficher le nom des membres inscrits en créneaux fixes">
+                                <i class="material-icons left">accessibility</i>Afficher les membres
+                            </a>
+                            <a id="training" onClick="showTraining()"
+                               class="btn col m3 waves-effect waves-light purple tooltipped"
+                               data-position="bottom"
+                               data-tooltip="Afficher la formation demandée pour être inscrit à un créneau">
+                                <i class="material-icons left">accessibility</i>Afficher les formations
+                            </a>
+                        </div>
+                        {% endif %}
+                    </div>
+                </li>
+            </ul>
+        </div>
+    </div>
+
+    {# Table with all the periods in a schedule --------- #}
+    <div class="container" style="width: 90%; max-width: 1880px;">
+        <div class="section">
+            <table>
+                <thead>
+                <tr>
+                    {% for key,day in days_of_week %}
+                        <th>{{ day }}</th>
+                    {% endfor %}
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                    {% for key,day in days_of_week %}
+                        <td>
+                            {% for period in periods_by_day[key] %}
+                                {% if (filling_filter == null)
+                                    or (filling_filter == "empty" and period.isEmpty(week_filter))
+                                    or (filling_filter == "full" and period.isFull(week_filter))
+                                    or (filling_filter == "partial" and period.isPartial(week_filter)) %}
+                                    {% include 'period/_partial/period_card.html.twig'
+                                        with {'period':period, 'week_filter':week_filter, 'anonymized':true} %}
+                                {% endif %}
+                            {% endfor %}
+                        </td>
+                    {% endfor %}
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+{% endblock container %}
+
+{% block javascripts %}
+    {% if use_fly_and_fixed %}
+        <script>
+            $(document).ready(function ($) {
+                    showShifters();
+                }
+            )
+
+            /**
+             * when user click on the showShifters
+             * ("Afficher les membres") bottom
+             */
+            function showShifters() {
+                $('div[id="training"]').hide();
+                $('div[id="shifter"]').show();
+                $('a[id="training"]').show();
+                $('a[id="shifter"]').hide();
+            }
+
+            /**
+             * when user click on the showTraining
+             * ("Afficher les formations") bottom
+             */
+            function showTraining() {
+                $('div[id="training"]').show();
+                $('div[id="shifter"]').hide();
+                $('a[id="training"]').hide();
+                $('a[id="shifter"]').show();
+            }
+
+            function truncate(str, maxlength) {
+                return (str.length > maxlength) ?
+                    str.slice(0, maxlength - 1) + '…' : str;
+            }
+
+        </script>
+    {% endif %}
+{% endblock javascripts %}

--- a/src/AppBundle/Controller/PeriodController.php
+++ b/src/AppBundle/Controller/PeriodController.php
@@ -175,7 +175,7 @@ class PeriodController extends Controller
     /**
      * Display all the periods in a schedule (available and reserved)
      *
-     * @Route("/admin", name="period_index", methods={"GET","POST"})
+     * @Route("/admin", name="period_admin", methods={"GET","POST"})
      * @Security("has_role('ROLE_SHIFT_MANAGER')")
      */
     public function adminIndexAction(Request $request, EntityManagerInterface $em): Response


### PR DESCRIPTION
Pour faire suite à la PR #772 et en lien avec #751, il y a deux pages distinctes, une version anonyme et une version admin. La version anonyme ne montre ni les nom ni les cas "problématiques", mais a tjs les autres filtres (sauf bénéficiaire évidement).

![image](https://user-images.githubusercontent.com/31699829/225364351-9f9eb3aa-3e2b-419a-a4ac-9f2a51669b3e.png)

J'ai déplacer une partie des macro twig dans des "_partial" et j'ai essayer de ne pas avoir trop de code en doublon, mais le compromis n'est pas forcement evident à trouver...

Pour y accéder, il y a un nouveau bouton à coté de celui pour le planning :
![image](https://user-images.githubusercontent.com/31699829/225362752-262db0e4-d6e7-437b-9426-e56e26d27f7b.png)

Pour les routes /period va vers la version anonyme et /period/admin vers la version d'avant. C'est copier sur le fonctionnement de booking. Il faudra peut être homogénéiser les routes pck certaines sont en /xxx/admin et d'autre en /admin/xxx mais de ce que je comprend des routes et des controllers /xxx/admin et plus logique  (xxx étant le root du controller). De meme /period/new devrait peut être devenir /period/admin/new (?).

