### PR TITLE
Compte épargne : homogénéiser les droits d'annulation d'un créneau (entre membre & admin)

### DIFF
--- a/app/Resources/views/booking/_partial/home_shift_card.html.twig
+++ b/app/Resources/views/booking/_partial/home_shift_card.html.twig
@@ -16,9 +16,9 @@
             {% include "user/_partial/shift_card_validation_status.html.twig" with { shift: shift } %}
         {% endif %}
     {% else %}
-        {% if shift_service.canFreeShift(beneficiary, shift) or shift.isUpcoming %}
+        {% if shift_service.canFreeShift(beneficiary, shift)['result'] or shift.isUpcoming %}
             <div class="card-action">
-                {% if shift_service.canFreeShift(beneficiary, shift) %}
+                {% if shift_service.canFreeShift(beneficiary, shift)['result'] %}
                     <a href="#free{{ shift.id }}" class="modal-trigger btn-flat red white-text" title="Annuler">Annuler</a>
                 {% endif %}
                 {% if shift.isUpcoming %}

--- a/app/Resources/views/user/_partial/shift_card.html.twig
+++ b/app/Resources/views/user/_partial/shift_card.html.twig
@@ -1,3 +1,7 @@
+{% set beneficiary = app.user.beneficiary %}
+{% set member = beneficiary.membership %}
+{% set shift_member = shift.shifter.membership %}
+
 <div class="card center {% if (shift.isCurrent) %}deep-purple white-text{% elseif (shift.isPast) %}grey lighten-2{% else %}cyan darken-4 white-text{% endif %}">
     <div class="card-content">
         {% include "user/_partial/shift_card_header.html.twig" with { shift: shift } %}
@@ -43,6 +47,24 @@
                     {{ form_errors(shift_free_forms[shift.id].reason) }}
                     {{ form_widget(shift_free_forms[shift.id].reason) }}
                 </div>
+                {% if use_time_log_saving %}
+                    <div class="card-panel blue lighten-3">
+                        <i class="material-icons left">info</i>
+                        {% if time_log_saving_shift_free_min_time_in_advance_days and shift.isBefore(time_log_saving_shift_free_min_time_in_advance_days|trans ~ ' days') %}
+                            Ce créneau a lieu dans <strong>moins de {{ time_log_saving_shift_free_min_time_in_advance_days }} jours</strong>.
+                            <br />
+                            Ce créneau ne sera donc pas comptabilisé, et son compteur épargne ne sera pas utilisé.
+                        {% elseif shift.duration > shift_member.savingTimeCount %}
+                            Ce membre <strong>n'a pas assez de temps sur son compteur épargne</strong> (durée du créneau : <strong>{{ shift.duration | duration_from_minutes }}</strong> ; compteur épargne : <strong>{{ member.savingTimeCount | duration_from_minutes }}</strong>).
+                            <br />
+                            Ce créneau ne sera donc pas comptabilisé, et son compteur épargne ne sera pas utilisé.
+                        {% else %}
+                            Grâce au compteur épargne du membre, ce créneau sera comptabilisé !
+                            <br />
+                            En échange, <strong>{{ shift.duration | duration_from_minutes }}</strong> seront décrémentés du compteur épargne (<strong>{{ member.savingTimeCount | duration_from_minutes }}</strong>) du membre.
+                        {% endif %}
+                    </div>
+                {% endif %}
             </div>
             <div class="modal-footer">
                 <a href="#!" class="modal-action modal-close waves-effect waves-green btn-flat grey-text">Annuler</a>

--- a/src/AppBundle/Controller/ShiftController.php
+++ b/src/AppBundle/Controller/ShiftController.php
@@ -267,21 +267,6 @@ class ShiftController extends Controller
                 return $this->redirectToRoute("homepage");
             }
 
-            if ($this->use_time_log_saving) {
-                $member = $shift->getShifter()->getMembership();
-                $member_saving_now = $member->getSavingTimeCount();
-                // the saving account must have the necessary amount
-                if ($shift->getDuration() > $member_saving_now) {
-                    $session->getFlashBag()->add("warning", "Impossible de libérer le créneau car la capacité de votre compteur épargne est trop faible.");
-                    return $this->redirectToRoute("homepage");
-                }
-                // check if there is a time_in_advance rule
-                if (isset($this->time_log_saving_shift_free_min_time_in_advance_days) && $shift->isBefore($this->time_log_saving_shift_free_min_time_in_advance_days . ' days')) {
-                    $session->getFlashBag()->add("warning", "Impossible de libérer le créneau car il a lieu dans moins de " . $this->time_log_saving_shift_free_min_time_in_advance_days . " jours.");
-                    return $this->redirectToRoute("homepage");
-                }
-            }
-
             // store shift beneficiary & reason (before shift free())
             $beneficiary = $shift->getShifter();
             $fixe = $shift->isFixe();

--- a/src/AppBundle/Controller/ShiftController.php
+++ b/src/AppBundle/Controller/ShiftController.php
@@ -251,7 +251,6 @@ class ShiftController extends Controller
     {
         $session = new Session();
         $current_app_user = $this->get('security.token_storage')->getToken()->getUser();
-        $beneficiary = $current_app_user->getBeneficiary();
 
         $this->denyAccessUnlessGranted(ShiftVoter::FREE, $shift);
 
@@ -261,7 +260,7 @@ class ShiftController extends Controller
 
         if ($form->isSubmitted() && $form->isValid()) {
             // check if beneficiary can free this shift
-            $shift_can_be_freed = $this->get('shift_service')->canFreeShift($beneficiary, $shift);
+            $shift_can_be_freed = $this->get('shift_service')->canFreeShift($current_app_user->getBeneficiary(), $shift);
             if (!$shift_can_be_freed['result']) {
                 $session->getFlashBag()->add("error", $shift_can_be_freed['message'] || "Impossible d'annuler ce créneau.");
                 return $this->redirectToRoute("homepage");
@@ -300,6 +299,9 @@ class ShiftController extends Controller
      */
     public function freeShiftAdminAction(Request $request, Shift $shift)
     {
+        $session = new Session();
+        $current_app_user = $this->get('security.token_storage')->getToken()->getUser();
+
         $this->denyAccessUnlessGranted(ShiftVoter::FREE, $shift);
 
         $form = $this->createShiftFreeAdminForm($shift);
@@ -361,7 +363,6 @@ class ShiftController extends Controller
                 return new JsonResponse(array('message'=>$message), 400);
             }
         } else {
-            $session = new Session();
             $session->getFlashBag()->add($success ? 'success' : 'error', $message);
             $referer = $request->headers->get('referer');
             return new RedirectResponse($referer);

--- a/src/AppBundle/Service/ShiftService.php
+++ b/src/AppBundle/Service/ShiftService.php
@@ -302,13 +302,15 @@ class ShiftService
         // - check if there is a min time in advance rule
         // - check if the shifter has enough time on its time log saving account
         if ($this->use_time_log_saving) {
+            $member = $shift->getShifter()->getMembership();
+            $member_saving_now = $member->getSavingTimeCount();
             if ($this->time_log_saving_shift_free_min_time_in_advance_days) {
                 if ($shift->isBefore($this->time_log_saving_shift_free_min_time_in_advance_days . ' days')) {
                     $result = false;
                     $message = "Impossible de libérer un créneau si peu de temps en avance (minumum " . $this->time_log_saving_shift_free_min_time_in_advance_days . " jours).";
                 }
             }
-            if ($shift->getDuration() > $shift->getShifter()->getMembership()->getSavingTimeCount()) {
+            if ($shift->getDuration() > $member_saving_now) {
                 $result = false;
                 $message = "Impossible de libérer le créneau car sa durée dépasse la capacité du compteur épargne du membre.";
             }


### PR DESCRIPTION
### Quoi ?

- ShiftController : simplifications
- amélioration de ShiftService.canBookShift (créé dans #787) : 
  - renvoyer un array (result true / false ; message) pour pouvoir l'afficher ensuite dans le controlleur
  - comportement différent si venant d'une action admin (moins de règles)
- Admin : rajouter des messages d'informations dans la modale de libération d'un créneau