### PR TITLE
Semaine type : ajout des champs createdAt

### DIFF
--- a/app/DoctrineMigrations/Version20230322214532_period_created_at.php
+++ b/app/DoctrineMigrations/Version20230322214532_period_created_at.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20230322214532 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE period ADD created_at DATETIME NOT NULL');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE period DROP created_at');
+    }
+}

--- a/app/DoctrineMigrations/Version20230322215143_period_position_created_at.php
+++ b/app/DoctrineMigrations/Version20230322215143_period_position_created_at.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20230322215143 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE period_position ADD created_at DATETIME NOT NULL');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE period_position DROP created_at');
+    }
+}

--- a/src/AppBundle/Entity/Period.php
+++ b/src/AppBundle/Entity/Period.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Mapping\OrderBy;
  * Period
  *
  * @ORM\Table(name="period")
+ * @ORM\HasLifecycleCallbacks()
  * @ORM\Entity(repositoryClass="AppBundle\Repository\PeriodRepository")
  */
 class Period
@@ -51,10 +52,17 @@ class Period
     private $job;
 
     /**
-     * One Period have Many Positions.
+     * One Period has Many Positions.
      * @ORM\OneToMany(targetEntity="PeriodPosition", mappedBy="period", cascade={"persist", "remove"}), orphanRemoval=true)
      */
     private $positions;
+
+    /**
+     * @var \DateTime
+     *
+     * @ORM\Column(name="created_at", type="datetime")
+     */
+    private $createdAt;
 
     /**
      * Constructor
@@ -62,6 +70,14 @@ class Period
     public function __construct()
     {
         $this->positions = new \Doctrine\Common\Collections\ArrayCollection();
+    }
+
+    /**
+     * @ORM\PrePersist
+     */
+    public function setCreatedAtValue()
+    {
+        $this->createdAt = new \DateTime();
     }
 
     /**
@@ -214,6 +230,16 @@ class Period
     public function getPositions()
     {
         return $this->positions;
+    }
+
+    /**
+     * Get createdAt
+     *
+     * @return \DateTime
+     */
+    public function getCreatedAt()
+    {
+        return $this->createdAt;
     }
 
     /**

--- a/src/AppBundle/Entity/PeriodPosition.php
+++ b/src/AppBundle/Entity/PeriodPosition.php
@@ -8,6 +8,7 @@ use Doctrine\ORM\Mapping as ORM;
  * PeriodRoom
  *
  * @ORM\Table(name="period_position")
+ * @ORM\HasLifecycleCallbacks()
  * @ORM\Entity(repositoryClass="AppBundle\Repository\PeriodPositionRepository")
  */
 class PeriodPosition
@@ -35,6 +36,12 @@ class PeriodPosition
     private $period;
 
     /**
+     * @var string
+     * @ORM\Column(name="week_cycle", type="string", length=1, nullable=false)
+     */
+    private $weekCycle;
+
+    /**
      * @ORM\ManyToOne(targetEntity="Beneficiary")
      * @ORM\JoinColumn(name="shifter_id", referencedColumnName="id")
      */
@@ -47,17 +54,18 @@ class PeriodPosition
     private $booker;
 
     /**
-     * @var string
-     * @ORM\Column(name="week_cycle", type="string", length=1, nullable=false)
-     */
-    private $weekCycle;
-
-    /**
      * @var \DateTime
      *
      * @ORM\Column(name="booked_time", type="datetime", nullable=true)
      */
     private $bookedTime;
+
+    /**
+     * @var \DateTime
+     *
+     * @ORM\Column(name="created_at", type="datetime")
+     */
+    private $createdAt;
 
     /**
      * Constructor
@@ -72,6 +80,14 @@ class PeriodPosition
             return $this->getFormation()->getName();
         else
             return "Membre";
+    }
+
+    /**
+     * @ORM\PrePersist
+     */
+    public function setCreatedAtValue()
+    {
+        $this->createdAt = new \DateTime();
     }
 
     /**
@@ -225,6 +241,16 @@ class PeriodPosition
     public function getBookedTime()
     {
         return $this->bookedTime;
+    }
+
+    /**
+     * Get createdAt
+     *
+     * @return \DateTime
+     */
+    public function getCreatedAt()
+    {
+        return $this->createdAt;
     }
 
     /**


### PR DESCRIPTION
### Quoi ?

- ajout du champ `Period.createdAt`
- ajout du champ `PeriodPosition.createdAt`

### Pourquoi ?

Pour généraliser l'usage des timestamps "createdAt" sur chaque modèle