### PR TITLE
Créneau : nouveau champ Shift.createdBy

### DIFF
--- a/app/DoctrineMigrations/Version20230403195605_shift_created_by.php
+++ b/app/DoctrineMigrations/Version20230403195605_shift_created_by.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20230403195605 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE shift ADD created_by_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE shift ADD CONSTRAINT FK_A50B3B45B03A8386 FOREIGN KEY (created_by_id) REFERENCES fos_user (id)');
+        $this->addSql('CREATE INDEX IDX_A50B3B45B03A8386 ON shift (created_by_id)');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE shift DROP FOREIGN KEY FK_A50B3B45B03A8386');
+        $this->addSql('DROP INDEX IDX_A50B3B45B03A8386 ON shift');
+        $this->addSql('ALTER TABLE shift DROP created_by_id');
+    }
+}

--- a/app/Resources/views/admin/booking/_partial/bucket_modal.html.twig
+++ b/app/Resources/views/admin/booking/_partial/bucket_modal.html.twig
@@ -87,6 +87,12 @@ id = "modal-bucket"
                             {% endif %}
                         {{ form_end(shift_free_forms[shift.id]) }}
                     {% endif %}
+                    {% if shift.createdBy %}
+                        <p>
+                            Créneau créé le <i>{{ shift.createdAt | date_fr_full_with_time }}</i>
+                            par {% if shift.createdBy.beneficiary %}<a href="{{ path("member_show", { 'member_number': shift.createdBy.beneficiary.membership.memberNumber }) }}">{{ shift.createdBy.beneficiary }}</a>{% else %}{{ shift.createdBy }}{% endif %}.
+                        </p>
+                    {% endif %}
                 </div>
             </li>
         {% else %}
@@ -139,6 +145,12 @@ id = "modal-bucket"
                             </button>
                             {{ form_end(shift_delete_forms[shift.id]) }}
                         {% endif %}
+                    {% endif %}
+                    {% if shift.createdBy %}
+                        <p>
+                            Créneau créé le <i>{{ shift.createdAt | date_fr_full_with_time }}</i>
+                            par {% if shift.createdBy.beneficiary %}<a href="{{ path("member_show", { 'member_number': shift.createdBy.beneficiary.membership.memberNumber }) }}">{{ shift.createdBy.beneficiary }}</a>{% else %}{{ shift.createdBy }}{% endif %}.
+                        </p>
                     {% endif %}
                 </div>
             </li>

--- a/src/AppBundle/Command/ShiftGenerateCommand.php
+++ b/src/AppBundle/Command/ShiftGenerateCommand.php
@@ -79,7 +79,6 @@ class ShiftGenerateCommand extends ContainerAwareCommand
                 $shift->setEnd($end);
 
                 foreach ($period->getPositions() as $position) {
-
                     // Semaine #A-B-C-D
                     // Ignorer les periodes en dehors du cycle semaine
                     $weekCycleIndex = ($date->format('W') - 1) % 4; //0 = (1-1)%4 (first week) through 51

--- a/src/AppBundle/Controller/BookingController.php
+++ b/src/AppBundle/Controller/BookingController.php
@@ -363,7 +363,6 @@ class BookingController extends Controller
      * When the user click on the 'edit' button on the bucket popup.
      *
      * @Route("/bucket/{id}/edit", name="bucket_edit", methods={"GET", "POST"})
-     * @Route("/bucket/{id}/edit", name="bucket_edit")
      * @Security("has_role('ROLE_SHIFT_MANAGER')")
      */
     public function editBucketAction(Request $request,Shift $shift)

--- a/src/AppBundle/Controller/ShiftController.php
+++ b/src/AppBundle/Controller/ShiftController.php
@@ -52,6 +52,7 @@ class ShiftController extends Controller
     public function newAction(Request $request)
     {
         $session = new Session();
+        $current_user = $this->get('security.token_storage')->getToken()->getUser();
 
         $em = $this->getDoctrine()->getManager();
         $job = $em->getRepository(Job::class)->findOneBy(array());
@@ -67,13 +68,16 @@ class ShiftController extends Controller
 
         if ($form->isSubmitted() && $form->isValid()) {
             $number = $form->get('number')->getData();
-            while (1 < $number) {
+            while ($number > 1) {
                 $s = clone($shift);
+                $s->setCreatedBy($current_user);
                 $em->persist($s);
                 $number --;
             }
+            $shift->setCreatedBy($current_user);
             $em->persist($shift);
             $em->flush();
+
             $success = true;
             $message = 'Le créneau a bien été créé !';
         } else {

--- a/src/AppBundle/Entity/Shift.php
+++ b/src/AppBundle/Entity/Shift.php
@@ -120,6 +120,12 @@ class Shift
      */
     private $createdAt;
 
+    /**
+     * @ORM\ManyToOne(targetEntity="User")
+     * @ORM\JoinColumn(name="created_by_id", referencedColumnName="id")
+     */
+    private $createdBy;
+
     public function __construct()
     {
         $this->wasCarriedOut = false;
@@ -481,10 +487,6 @@ class Shift
         return $this->lastShifter;
     }
 
-    public function getTmpToken($key = ''){
-        return md5($this->getId().$this->getStart()->format('d/m/Y').$this->getEnd()->format('d/m/Y').$key);
-    }
-
     /**
      * Add timeLog
      *
@@ -538,14 +540,16 @@ class Shift
     /**
      * @return bool
      */
-    public function isFixe(): ?bool {
+    public function isFixe(): ?bool
+    {
         return $this->fixe;
     }
 
     /**
      * @param bool $fixe
      */
-    public function setFixe(?bool $fixe): void {
+    public function setFixe(?bool $fixe): void
+    {
         $this->fixe = $fixe;
     }
 
@@ -574,6 +578,30 @@ class Shift
     }
 
     /**
+     * Set createdBy.
+     *
+     * @param \AppBundle\Entity\User $createBy
+     *
+     * @return Shift
+     */
+    public function setCreatedBy(\AppBundle\Entity\User $createdBy = null)
+    {
+        $this->createdBy = $createdBy;
+
+        return $this;
+    }
+
+    /**
+     * Get createdBy.
+     *
+     * @return \AppBundle\Entity\User
+     */
+    public function getCreatedBy()
+    {
+        return $this->createdBy;
+    }
+
+    /**
      * Return true if this is the first ever shift by the shifter
      *
      * @return bool
@@ -587,5 +615,13 @@ class Shift
             }
         }
         return false;
+    }
+
+    /**
+     * Generate token from key
+     */
+    public function getTmpToken($key = '')
+    {
+        return md5($this->getId().$this->getStart()->format('d/m/Y').$this->getEnd()->format('d/m/Y').$key);
     }
 }


### PR DESCRIPTION
### Quoi ?

Nouveau champ `Shift.createdBy`

### Pourquoi ?

Pour savoir quel utilisateur a créé des créneaux ad-hoc

### Capture d'écran

|Admin > Créneaux > Bucket modal||
|---|---|
|Créneau créé automatiquement (aucun changement)|![Screenshot from 2023-04-04 10-40-28](https://user-images.githubusercontent.com/7147385/229737076-46f0487a-b6f2-475a-a553-4bdf4cfd675c.png)|
|Créneau créé manuellement|![Screenshot from 2023-04-04 10-38-50](https://user-images.githubusercontent.com/7147385/229736747-08ac24c8-9775-4756-bf13-c0570fb6027f.png)|


