### PR TITLE
Admin : nouveau paramètre qui permet d'empêcher les membres de (in)valider leur propre créneau

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -105,6 +105,7 @@ parameters:
     forbid_shift_overlap_time: 30
     max_time_at_end_of_shift: 0
     forbid_own_shift_free_admin: false
+    forbid_own_shift_validate: false
     display_name_shifters: false
     max_nb_of_past_cycles_to_display: 3
     use_fly_and_fixed: false

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -105,7 +105,7 @@ parameters:
     forbid_shift_overlap_time: 30
     max_time_at_end_of_shift: 0
     forbid_own_shift_free_admin: false
-    forbid_own_shift_validate: false
+    forbid_own_shift_validate_admin: false
     display_name_shifters: false
     max_nb_of_past_cycles_to_display: 3
     use_fly_and_fixed: false

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -44,7 +44,7 @@ services:
     AppBundle\Controller\ShiftController:
         arguments:
             - "%forbid_own_shift_free_admin%"
-            - "%forbid_own_shift_validate%"
+            - "%forbid_own_shift_validate_admin%"
             - "%use_fly_and_fixed%"
             - "%use_time_log_saving%"
             - "%time_log_saving_shift_free_min_time_in_advance_days%"

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -44,6 +44,7 @@ services:
     AppBundle\Controller\ShiftController:
         arguments:
             - "%forbid_own_shift_free_admin%"
+            - "%forbid_own_shift_validate%"
             - "%use_fly_and_fixed%"
             - "%use_time_log_saving%"
             - "%time_log_saving_shift_free_min_time_in_advance_days%"

--- a/src/AppBundle/Controller/BookingController.php
+++ b/src/AppBundle/Controller/BookingController.php
@@ -341,7 +341,7 @@ class BookingController extends Controller
             $shiftBookForms[$shift->getId()] = $this->createShiftBookAdminForm($shift)->createView();
             $shiftDeleteForms[$shift->getId()] = $this->createShiftDeleteForm($shift)->createView();
             $shiftFreeForms[$shift->getId()] = $this->createShiftFreeAdminForm($shift)->createView();
-            $shiftValidateInvalidateForms[$shift->getId()] = $this->createShiftValidateInvalidateForm($shift)->createView();
+            $shiftValidateInvalidateForms[$shift->getId()] = $this->createShiftValidateInvalidateAdminForm($shift)->createView();
         }
         $bucketShiftAddForm = $this->createBucketShiftAddForm($bucket);
         $bucketDeleteform = $this->createBucketDeleteForm($bucket);
@@ -635,16 +635,16 @@ class BookingController extends Controller
 
     /**
      * Creates a form to validate / invalidate a shift entity.
-     * // TODO: how to avoid having same createShiftValidateInvalidateForm in ShiftController ?
+     * // TODO: how to avoid having same createShiftValidateInvalidateAdminForm in ShiftController ?
      *
      * @param Shift $shift The shift entity
      *
      * @return \Symfony\Component\Form\Form The form
      */
-    private function createShiftValidateInvalidateForm(Shift $shift)
+    private function createShiftValidateInvalidateAdminForm(Shift $shift)
     {
         return $this->get('form.factory')->createNamedBuilder('shift_validate_invalidate_forms_' . $shift->getId())
-            ->setAction($this->generateUrl('shift_validate', array('id' => $shift->getId())))
+            ->setAction($this->generateUrl('shift_validate_admin', array('id' => $shift->getId())))
             ->add('validate', HiddenType::class, [
                 'data' => ($shift->getWasCarriedOut() ? 0 : 1),
             ])

--- a/src/AppBundle/Controller/CardReaderController.php
+++ b/src/AppBundle/Controller/CardReaderController.php
@@ -58,6 +58,7 @@ class CardReaderController extends Controller
         if (!$card) {
             $session->getFlashBag()->add("error", "Oups, ce badge n'est pas actif ou n'existe pas");
         } else {
+            // find corresponding beneficiary
             $beneficiary = $card->getBeneficiary();
             $membership = $beneficiary->getMembership();
             $cycle_end = $this->get('membership_service')->getEndOfCycle($membership, 0);
@@ -69,6 +70,7 @@ class CardReaderController extends Controller
                 }
                 $dispatcher->dispatch(SwipeCardEvent::SWIPE_CARD_SCANNED, new SwipeCardEvent($card, $counter));
             }
+            // validate ongoing beneficiary shift(s)
             $shifts = $em->getRepository('AppBundle:Shift')->getOnGoingShifts($beneficiary);
             $dispatcher = $this->get('event_dispatcher');
             foreach ($shifts as $shift) {

--- a/src/AppBundle/Controller/CardReaderController.php
+++ b/src/AppBundle/Controller/CardReaderController.php
@@ -70,7 +70,7 @@ class CardReaderController extends Controller
                 }
                 $dispatcher->dispatch(SwipeCardEvent::SWIPE_CARD_SCANNED, new SwipeCardEvent($card, $counter));
             }
-            // validate ongoing beneficiary shift(s)
+            // validate beneficiary ongoing shift(s)
             $shifts = $em->getRepository('AppBundle:Shift')->getOnGoingShifts($beneficiary);
             $dispatcher = $this->get('event_dispatcher');
             foreach ($shifts as $shift) {

--- a/src/AppBundle/Controller/MembershipController.php
+++ b/src/AppBundle/Controller/MembershipController.php
@@ -171,7 +171,7 @@ class MembershipController extends Controller
         foreach ($shifts_by_cycle as $shifts) {
             foreach ($shifts as $shift) {
                 $shiftFreeForms[$shift->getId()] = $this->createShiftFreeAdminForm($shift)->createView();
-                $shiftValidateInvalidateForms[$shift->getId()] = $this->createShiftValidateInvalidateForm($shift)->createView();
+                $shiftValidateInvalidateForms[$shift->getId()] = $this->createShiftValidateInvalidateAdminForm($shift)->createView();
             }
         }
 
@@ -1198,16 +1198,16 @@ class MembershipController extends Controller
 
     /**
      * Creates a form to validate / invalidate a shift entity.
-     * // TODO: how to avoid having same createShiftValidateInvalidateForm in ShiftController ?
+     * // TODO: how to avoid having same createShiftValidateInvalidateAdminForm in ShiftController ?
      *
      * @param Shift $shift The shift entity
      *
      * @return \Symfony\Component\Form\Form The form
      */
-    private function createShiftValidateInvalidateForm(Shift $shift)
+    private function createShiftValidateInvalidateAdminForm(Shift $shift)
     {
         return $this->get('form.factory')->createNamedBuilder('shift_validate_invalidate_forms_' . $shift->getId())
-            ->setAction($this->generateUrl('shift_validate', array('id' => $shift->getId())))
+            ->setAction($this->generateUrl('shift_validate_admin', array('id' => $shift->getId())))
             ->add('validate', HiddenType::class, [
                 'data' => ($shift->getWasCarriedOut() ? 0 : 1),
             ])

--- a/src/AppBundle/Controller/ShiftController.php
+++ b/src/AppBundle/Controller/ShiftController.php
@@ -35,15 +35,15 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 class ShiftController extends Controller
 {
     private $forbid_own_shift_free_admin;
-    private $forbid_own_shift_validate;
+    private $forbid_own_shift_validate_admin;
     private $use_fly_and_fixed;
     private $use_time_log_saving;
     private $time_log_saving_shift_free_min_time_in_advance_days;
 
-    public function __construct(bool $forbid_own_shift_free_admin, bool $forbid_own_shift_validate, bool $use_fly_and_fixed, bool $use_time_log_saving, $time_log_saving_shift_free_min_time_in_advance_days)
+    public function __construct(bool $forbid_own_shift_free_admin, bool $forbid_own_shift_validate_admin, bool $use_fly_and_fixed, bool $use_time_log_saving, $time_log_saving_shift_free_min_time_in_advance_days)
     {
         $this->forbid_own_shift_free_admin = $forbid_own_shift_free_admin;
-        $this->forbid_own_shift_validate = $forbid_own_shift_validate;
+        $this->forbid_own_shift_validate_admin = $forbid_own_shift_validate_admin;
         $this->use_fly_and_fixed = $use_fly_and_fixed;
         $this->use_time_log_saving = $use_time_log_saving;
         $this->time_log_saving_shift_free_min_time_in_advance_days = $time_log_saving_shift_free_min_time_in_advance_days;
@@ -383,7 +383,7 @@ class ShiftController extends Controller
     /**
      * validate / invalidate a shift.
      *
-     * @Route("/{id}/validate", name="shift_validate", methods={"POST"})
+     * @Route("/{id}/validate_admin", name="shift_validate_admin", methods={"POST"})
      * @Security("has_role('ROLE_SHIFT_MANAGER')")
      */
     public function validateShiftAction(Request $request, Shift $shift)
@@ -393,13 +393,13 @@ class ShiftController extends Controller
 
         $this->denyAccessUnlessGranted(ShiftVoter::VALIDATE, $shift);
 
-        $form = $this->createShiftValidateInvalidateForm($shift);
+        $form = $this->createShiftValidateInvalidateAdminForm($shift);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
             $shifter_is_current_user = $current_app_user->getBeneficiary() == $shift->getShifter();
             // check if user is allowed to (in)validate shift
-            if ($shifter_is_current_user && $this->forbid_own_shift_validate && !$this->get('security.authorization_checker')->isGranted('ROLE_ADMIN')) {
+            if ($shifter_is_current_user && $this->forbid_own_shift_validate_admin && !$this->get('security.authorization_checker')->isGranted('ROLE_ADMIN')) {
                 $success = false;
                 $message = "Vous ne pouvez pas (in)valider votre propre créneau.";
             }
@@ -673,10 +673,10 @@ class ShiftController extends Controller
      *
      * @return \Symfony\Component\Form\Form The form
      */
-    private function createShiftValidateInvalidateForm(Shift $shift)
+    private function createShiftValidateInvalidateAdminForm(Shift $shift)
     {
         $form = $this->get('form.factory')->createNamedBuilder('shift_validate_invalidate_forms_' . $shift->getId())
-            ->setAction($this->generateUrl('shift_validate', array('id' => $shift->getId())))
+            ->setAction($this->generateUrl('shift_validate_admin', array('id' => $shift->getId())))
             ->add('validate', HiddenType::class, [
                 'data'  => ($shift->getWasCarriedOut() ? 0 : 1),
             ])

--- a/src/AppBundle/Controller/ShiftController.php
+++ b/src/AppBundle/Controller/ShiftController.php
@@ -314,7 +314,7 @@ class ShiftController extends Controller
         if ($form->isSubmitted() && $form->isValid()) {
             $shifter_is_current_user = $current_app_user->getBeneficiary() == $shift->getShifter();
             $shift_can_be_freed = $this->get('shift_service')->canFreeShift($shift->getShifter(), $shift, true);
-            // check if admin user is allowed to free shift
+            // check if user is allowed to free shift
             if ($shifter_is_current_user && $this->forbid_own_shift_free_admin && !$this->get('security.authorization_checker')->isGranted('ROLE_ADMIN')) {
                 $success = false;
                 $message = "Vous ne pouvez pas annuler votre propre créneau.";
@@ -384,6 +384,7 @@ class ShiftController extends Controller
      * validate / invalidate a shift.
      *
      * @Route("/{id}/validate", name="shift_validate", methods={"POST"})
+     * @Security("has_role('ROLE_SHIFT_MANAGER')")
      */
     public function validateShiftAction(Request $request, Shift $shift)
     {
@@ -397,7 +398,7 @@ class ShiftController extends Controller
 
         if ($form->isSubmitted() && $form->isValid()) {
             $shifter_is_current_user = $current_app_user->getBeneficiary() == $shift->getShifter();
-            // check if admin user is allowed to (in)validate shift
+            // check if user is allowed to (in)validate shift
             if ($shifter_is_current_user && $this->forbid_own_shift_validate && !$this->get('security.authorization_checker')->isGranted('ROLE_ADMIN')) {
                 $success = false;
                 $message = "Vous ne pouvez pas (in)valider votre propre créneau.";


### PR DESCRIPTION
Suite de https://github.com/elefan-grenoble/gestion-compte/pull/796

### Quoi ?

- nouveau paramètre `forbid_own_shift_validate_admin`
- si vrai, alors les membres qui ont accès à l'interface admin (mais qui ne sont pas ROLE_ADMIN) ne pourront pas (in)valider leur propre créneaux

Modifications annexes : 
- j'en ai profité pour renommer la route `shift_validate` en `shift_validate_admin` (vu que ce n'est seulement possible via l'admin)
- et j'ai rajouté une securité sur la route

### Pourquoi ?

Pour restreindre le nombre de membres qui peuvent s'auto-valider leur créneaux