### PR TITLE
Admin : nouveau paramètre qui permet d'empêcher les membres de réserver leur propre créneau

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -104,6 +104,7 @@ parameters:
     reserve_new_shift_to_prior_shifter: true
     forbid_shift_overlap_time: 30
     max_time_at_end_of_shift: 0
+    forbid_own_shift_book_admin: false
     forbid_own_shift_free_admin: false
     forbid_own_shift_validate_admin: false
     display_name_shifters: false

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -107,6 +107,7 @@ parameters:
     forbid_own_shift_book_admin: false
     forbid_own_shift_free_admin: false
     forbid_own_shift_validate_admin: false
+    forbid_own_timelog_new_admin: false
     display_name_shifters: false
     max_nb_of_past_cycles_to_display: 3
     use_fly_and_fixed: false

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -43,6 +43,7 @@ services:
             - "%use_fly_and_fixed%"
     AppBundle\Controller\ShiftController:
         arguments:
+            - "%forbid_own_shift_book_admin%"
             - "%forbid_own_shift_free_admin%"
             - "%forbid_own_shift_validate_admin%"
             - "%use_fly_and_fixed%"

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -49,6 +49,9 @@ services:
             - "%use_fly_and_fixed%"
             - "%use_time_log_saving%"
             - "%time_log_saving_shift_free_min_time_in_advance_days%"
+    AppBundle\Controller\TimeLogController:
+        arguments:
+            - "%forbid_own_timelog_new_admin%"
     AppBundle\Helper\:
         resource: '../../src/AppBundle/Helper'
         arguments: ['@service_container']

--- a/src/AppBundle/Controller/ShiftController.php
+++ b/src/AppBundle/Controller/ShiftController.php
@@ -267,7 +267,7 @@ class ShiftController extends Controller
     public function freeShiftAction(Request $request, Shift $shift)
     {
         $session = new Session();
-        $current_app_user = $this->get('security.token_storage')->getToken()->getUser();
+        $current_user = $this->get('security.token_storage')->getToken()->getUser();
 
         $this->denyAccessUnlessGranted(ShiftVoter::FREE, $shift);
 
@@ -277,7 +277,7 @@ class ShiftController extends Controller
 
         if ($form->isSubmitted() && $form->isValid()) {
             // check if beneficiary can free this shift
-            $shift_can_be_freed = $this->get('shift_service')->canFreeShift($current_app_user->getBeneficiary(), $shift);
+            $shift_can_be_freed = $this->get('shift_service')->canFreeShift($current_user->getBeneficiary(), $shift);
             if (!$shift_can_be_freed['result']) {
                 $session->getFlashBag()->add("error", $shift_can_be_freed['message'] || "Impossible d'annuler ce créneau.");
                 return $this->redirectToRoute("homepage");
@@ -317,7 +317,7 @@ class ShiftController extends Controller
     public function freeShiftAdminAction(Request $request, Shift $shift)
     {
         $session = new Session();
-        $current_app_user = $this->get('security.token_storage')->getToken()->getUser();
+        $current_user = $this->get('security.token_storage')->getToken()->getUser();
 
         $this->denyAccessUnlessGranted(ShiftVoter::FREE, $shift);
 
@@ -325,7 +325,7 @@ class ShiftController extends Controller
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $shifter_is_current_user = $current_app_user->getBeneficiary() == $shift->getShifter();
+            $shifter_is_current_user = $current_user->getBeneficiary() == $shift->getShifter();
             $shift_can_be_freed = $this->get('shift_service')->canFreeShift($shift->getShifter(), $shift, true);
             // check if user is allowed to free shift
             if ($shifter_is_current_user && $this->forbid_own_shift_free_admin && !$this->get('security.authorization_checker')->isGranted('ROLE_ADMIN')) {
@@ -402,7 +402,7 @@ class ShiftController extends Controller
     public function validateShiftAction(Request $request, Shift $shift)
     {
         $session = new Session();
-        $current_app_user = $this->get('security.token_storage')->getToken()->getUser();
+        $current_user = $this->get('security.token_storage')->getToken()->getUser();
 
         $this->denyAccessUnlessGranted(ShiftVoter::VALIDATE, $shift);
 
@@ -412,7 +412,7 @@ class ShiftController extends Controller
         if ($form->isSubmitted() && $form->isValid()) {
             $validate = $form->get('validate')->getData() == 1;
             $current = $shift->getWasCarriedOut() == 1;
-            $shifter_is_current_user = $current_app_user->getBeneficiary() == $shift->getShifter();
+            $shifter_is_current_user = $current_user->getBeneficiary() == $shift->getShifter();
             // check if user is allowed to (in)validate shift
             if ($shifter_is_current_user && $this->forbid_own_shift_validate_admin && !$this->get('security.authorization_checker')->isGranted('ROLE_ADMIN')) {
                 $success = false;

--- a/src/AppBundle/Entity/User.php
+++ b/src/AppBundle/Entity/User.php
@@ -62,6 +62,15 @@ class User extends BaseUser
      */
     private $processUpdates;
 
+    public function __toString()
+    {
+        if (!$this->getBeneficiary())
+            return $this->getUsername();
+        else{
+            return (string)$this->getBeneficiary();
+        }
+    }
+
     public function getGroups()
     {
         if ($this->getBeneficiary()){
@@ -69,7 +78,6 @@ class User extends BaseUser
         }else{
             return new ArrayCollection();
         }
-
     }
 
     public function __get($property) {
@@ -103,15 +111,6 @@ class User extends BaseUser
             return $beneficiary->getLastname();
         else
             return '';
-    }
-
-    public function __toString()
-    {
-        if (!$this->getBeneficiary())
-            return $this->getUsername();
-        else{
-            return (string)$this->getBeneficiary();
-        }
     }
 
     public function getTmpToken($key = '')
@@ -276,7 +275,6 @@ class User extends BaseUser
         return $this->clients;
     }
 
-
     /**
      * Add annotation
      *
@@ -312,6 +310,14 @@ class User extends BaseUser
     }
 
     /**
+     * @param mixed $beneficiary
+     */
+    public function setBeneficiary($beneficiary)
+    {
+        $this->beneficiary = $beneficiary;
+    }
+
+    /**
      * @return Beneficiary
      */
     public function getBeneficiary()
@@ -320,11 +326,15 @@ class User extends BaseUser
     }
 
     /**
-     * @param mixed $beneficiary
+     * @return Membership
      */
-    public function setBeneficiary($beneficiary)
+    public function getMembership()
     {
-        $this->beneficiary = $beneficiary;
+        if ($this->getBeneficiary()) {
+            return $this->getBeneficiary()->getMembership();
+        } else {
+            return null;
+        }
     }
 
     /**


### PR DESCRIPTION
### Quoi ?

- nouveau paramètre `forbid_own_shift_book_admin`
- si vrai, alors les membres qui ont accès à l'interface admin (mais qui ne sont pas ROLE_ADMIN) ne pourront pas réserver leur propre créneaux (ils devront faire comme les autres membres et passer par `/booking`)