### PR TITLE
Admin : nouveau paramètre qui permet d'empêcher les membres de s'ajouter des log de temps

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -107,6 +107,7 @@ parameters:
     forbid_own_shift_book_admin: false
     forbid_own_shift_free_admin: false
     forbid_own_shift_validate_admin: false
+    forbid_own_timelog_new_admin: false
     display_name_shifters: false
     max_nb_of_past_cycles_to_display: 3
     use_fly_and_fixed: false

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -49,6 +49,9 @@ services:
             - "%use_fly_and_fixed%"
             - "%use_time_log_saving%"
             - "%time_log_saving_shift_free_min_time_in_advance_days%"
+    AppBundle\Controller\TimeLogController:
+        arguments:
+            - "%forbid_own_timelog_new_admin%"
     AppBundle\Helper\:
         resource: '../../src/AppBundle/Helper'
         arguments: ['@service_container']

--- a/src/AppBundle/Entity/User.php
+++ b/src/AppBundle/Entity/User.php
@@ -62,6 +62,15 @@ class User extends BaseUser
      */
     private $processUpdates;
 
+    public function __toString()
+    {
+        if (!$this->getBeneficiary())
+            return $this->getUsername();
+        else{
+            return (string)$this->getBeneficiary();
+        }
+    }
+
     public function getGroups()
     {
         if ($this->getBeneficiary()){
@@ -69,7 +78,6 @@ class User extends BaseUser
         }else{
             return new ArrayCollection();
         }
-
     }
 
     public function __get($property) {
@@ -103,15 +111,6 @@ class User extends BaseUser
             return $beneficiary->getLastname();
         else
             return '';
-    }
-
-    public function __toString()
-    {
-        if (!$this->getBeneficiary())
-            return $this->getUsername();
-        else{
-            return (string)$this->getBeneficiary();
-        }
     }
 
     public function getTmpToken($key = '')
@@ -276,7 +275,6 @@ class User extends BaseUser
         return $this->clients;
     }
 
-
     /**
      * Add annotation
      *
@@ -312,6 +310,14 @@ class User extends BaseUser
     }
 
     /**
+     * @param mixed $beneficiary
+     */
+    public function setBeneficiary($beneficiary)
+    {
+        $this->beneficiary = $beneficiary;
+    }
+
+    /**
      * @return Beneficiary
      */
     public function getBeneficiary()
@@ -320,11 +326,15 @@ class User extends BaseUser
     }
 
     /**
-     * @param mixed $beneficiary
+     * @return Membership
      */
-    public function setBeneficiary($beneficiary)
+    public function getMembership()
     {
-        $this->beneficiary = $beneficiary;
+        if ($this->getBeneficiary()) {
+            return $this->getBeneficiary()->getMembership();
+        } else {
+            return null;
+        }
     }
 
     /**


### PR DESCRIPTION
### Quoi ?

- nouveau paramètre `forbid_own_timelog_new_admin`
- si vrai, alors les membres qui ont accès à l'interface admin (mais qui ne sont pas ROLE_ADMIN) ne pourront pas se rajouter de log de temps