### PR TITLE
Créneau fixe : afficher le nombre de créneaux effectués

### DIFF
--- a/app/Resources/views/user/_partial/period_position_card.html.twig
+++ b/app/Resources/views/user/_partial/period_position_card.html.twig
@@ -2,6 +2,7 @@
     <div class="card-content">
         <span class="card-title">
             {{ period_position.period.getDayOfWeekString() }} de {{ period_position.period.start | date('H:i') }} à {{ period_position.period.end | date('H:i') }}
+            <br />
             <small>(Semaine {{ period_position.weekCycle }})</small>
         </span>
         <p>
@@ -14,6 +15,20 @@
             {% endif %}
         </p>
     </div>
+    {% if (show_actions ?? false) and is_granted("ROLE_SHIFT_MANAGER") %}
+        {% set period_position_shift_carried_out_count = period_position.getShiftCount(true) %}
+        {% set period_position_shift_not_carried_out_count = period_position.getShiftCount(false) %}
+        <div class="card-action">
+            <span class="chip green-text" title="{{ period_position_shift_carried_out_count }} créneaux effectués">
+                <i class="material-icons tiny">check</i>
+                {{ period_position_shift_carried_out_count }}
+            </span>
+            <span class="chip red-text" title="{{ period_position_shift_not_carried_out_count }} créneaux non effectués">
+                <i class="material-icons tiny">close</i>
+                {{ period_position_shift_not_carried_out_count }}
+            </span>
+        </div>
+    {% endif %}
     {% if (show_actions ?? false) and is_granted("ROLE_SHIFT_MANAGER") %}
         <div class="card-action">
             <a href="{{ path("period_edit", { 'id': period_position.period.id }) }}" class="waves-effect waves-light btn white black-text" target="_blank" title="Voir le créneau">

--- a/app/Resources/views/user/_partial/period_position_card.html.twig
+++ b/app/Resources/views/user/_partial/period_position_card.html.twig
@@ -16,8 +16,8 @@
         </p>
     </div>
     {% if (show_actions ?? false) and is_granted("ROLE_SHIFT_MANAGER") %}
-        {% set period_position_shift_carried_out_count = period_position.getShiftCount(true) %}
-        {% set period_position_shift_not_carried_out_count = period_position.getShiftCount(false) %}
+        {% set period_position_shift_carried_out_count = shift_service.getBeneficiaryShiftCount(period_position.shifter, period_position, true) %}
+        {% set period_position_shift_not_carried_out_count = shift_service.getBeneficiaryShiftCount(period_position.shifter, period_position, false) %}
         <div class="card-action">
             <span class="chip green-text" title="{{ period_position_shift_carried_out_count }} créneau{% if period_position_shift_carried_out_count > 1 %}x{% endif %} effectué{% if period_position_shift_carried_out_count > 1 %}s{% endif %}">
                 <i class="material-icons tiny">check</i>

--- a/app/Resources/views/user/_partial/period_position_card.html.twig
+++ b/app/Resources/views/user/_partial/period_position_card.html.twig
@@ -19,17 +19,15 @@
         {% set period_position_shift_carried_out_count = period_position.getShiftCount(true) %}
         {% set period_position_shift_not_carried_out_count = period_position.getShiftCount(false) %}
         <div class="card-action">
-            <span class="chip green-text" title="{{ period_position_shift_carried_out_count }} créneaux effectués">
+            <span class="chip green-text" title="{{ period_position_shift_carried_out_count }} créneau{% if period_position_shift_carried_out_count > 1 %}x{% endif %} effectué{% if period_position_shift_carried_out_count > 1 %}s{% endif %}">
                 <i class="material-icons tiny">check</i>
                 {{ period_position_shift_carried_out_count }}
             </span>
-            <span class="chip red-text" title="{{ period_position_shift_not_carried_out_count }} créneaux non effectués">
+            <span class="chip red-text" title="{{ period_position_shift_not_carried_out_count }} créneau{% if period_position_shift_not_carried_out_count > 1 %}x{% endif %} non effectué{% if period_position_shift_not_carried_out_count > 1 %}s{% endif %}">
                 <i class="material-icons tiny">close</i>
                 {{ period_position_shift_not_carried_out_count }}
             </span>
         </div>
-    {% endif %}
-    {% if (show_actions ?? false) and is_granted("ROLE_SHIFT_MANAGER") %}
         <div class="card-action">
             <a href="{{ path("period_edit", { 'id': period_position.period.id }) }}" class="waves-effect waves-light btn white black-text" target="_blank" title="Voir le créneau">
                 <i class="material-icons left orange-text">date_range</i>Voir le créneau

--- a/app/Resources/views/user/_partial/period_position_card.html.twig
+++ b/app/Resources/views/user/_partial/period_position_card.html.twig
@@ -18,6 +18,7 @@
     {% if (show_actions ?? false) and is_granted("ROLE_SHIFT_MANAGER") %}
         {% set period_position_shift_carried_out_count = shift_service.getBeneficiaryShiftCount(period_position.shifter, period_position, true) %}
         {% set period_position_shift_not_carried_out_count = shift_service.getBeneficiaryShiftCount(period_position.shifter, period_position, false) %}
+        {% set period_position_shift_freed_count = shift_service.getBeneficiaryShiftFreedCount(period_position.shifter, period_position) %}
         <div class="card-action">
             <span class="chip green-text" title="{{ period_position_shift_carried_out_count }} créneau{% if period_position_shift_carried_out_count > 1 %}x{% endif %} effectué{% if period_position_shift_carried_out_count > 1 %}s{% endif %}">
                 <i class="material-icons tiny">check</i>
@@ -26,6 +27,10 @@
             <span class="chip red-text" title="{{ period_position_shift_not_carried_out_count }} créneau{% if period_position_shift_not_carried_out_count > 1 %}x{% endif %} non effectué{% if period_position_shift_not_carried_out_count > 1 %}s{% endif %}">
                 <i class="material-icons tiny">close</i>
                 {{ period_position_shift_not_carried_out_count }}
+            </span>
+            <span class="chip red-text" title="{{ period_position_shift_freed_count }} créneau{% if period_position_shift_freed_count > 1 %}x{% endif %} annulé{% if period_position_shift_freed_count > 1 %}s{% endif %}">
+                <i class="material-icons tiny">delete_sweep</i>
+                {{ period_position_shift_freed_count }}
             </span>
         </div>
         <div class="card-action">

--- a/app/Resources/views/user/_partial/period_position_card.html.twig
+++ b/app/Resources/views/user/_partial/period_position_card.html.twig
@@ -16,8 +16,8 @@
         </p>
     </div>
     {% if (show_actions ?? false) and is_granted("ROLE_SHIFT_MANAGER") %}
-        {% set period_position_shift_carried_out_count = shift_service.getBeneficiaryShiftCount(period_position.shifter, period_position, true) %}
-        {% set period_position_shift_not_carried_out_count = shift_service.getBeneficiaryShiftCount(period_position.shifter, period_position, false) %}
+        {% set period_position_shift_carried_out_count = shift_service.getBeneficiaryShiftCount(period_position.shifter, period_position, true, true) %}
+        {% set period_position_shift_not_carried_out_count = shift_service.getBeneficiaryShiftCount(period_position.shifter, period_position, false, true) %}
         {% set period_position_shift_freed_count = shift_service.getBeneficiaryShiftFreedCount(period_position.shifter, period_position) %}
         <div class="card-action">
             <span class="chip green-text" title="{{ period_position_shift_carried_out_count }} créneau{% if period_position_shift_carried_out_count > 1 %}x{% endif %} effectué{% if period_position_shift_carried_out_count > 1 %}s{% endif %}">

--- a/src/AppBundle/Entity/PeriodPosition.php
+++ b/src/AppBundle/Entity/PeriodPosition.php
@@ -253,34 +253,11 @@ class PeriodPosition
      *
      * @return \Doctrine\Common\Collections\Collection
      */
-    public function getShifts($wasCarriedOut = null)
+    public function getShifts()
     {
         $shifts = $this->shifts;
 
-        if ($wasCarriedOut == true) {
-            $shifts = $shifts->filter(function (Shift $shift) {
-                return ($shift->getWasCarriedOut());
-            });
-        }
-        elseif ($wasCarriedOut == false) {
-            $shifts = $shifts->filter(function (Shift $shift) {
-                return ($shift->getIsPast() && !$shift->getWasCarriedOut());
-            });
-        }
-
         return $shifts;
-    }
-
-    /**
-     * Get shift count
-     *
-     * @return int
-     */
-    public function getShiftCount($wasCarriedOut = null)
-    {
-        $shifts = $this->getShifts($wasCarriedOut);
-
-        return $shifts->count();
     }
 
     /**

--- a/src/AppBundle/Entity/PeriodPosition.php
+++ b/src/AppBundle/Entity/PeriodPosition.php
@@ -61,6 +61,11 @@ class PeriodPosition
     private $bookedTime;
 
     /**
+     * @ORM\OneToMany(targetEntity="Shift", mappedBy="position", cascade={"persist"})
+     */
+    private $shifts;
+
+    /**
      * @var \DateTime
      *
      * @ORM\Column(name="created_at", type="datetime")
@@ -241,6 +246,41 @@ class PeriodPosition
     public function getBookedTime()
     {
         return $this->bookedTime;
+    }
+
+    /**
+     * Get shifts
+     *
+     * @return \Doctrine\Common\Collections\Collection
+     */
+    public function getShifts($wasCarriedOut = null)
+    {
+        $shifts = $this->shifts;
+
+        if ($wasCarriedOut == true) {
+            $shifts = $shifts->filter(function (Shift $shift) {
+                return ($shift->getWasCarriedOut());
+            });
+        }
+        elseif ($wasCarriedOut == false) {
+            $shifts = $shifts->filter(function (Shift $shift) {
+                return ($shift->getIsPast() && !$shift->getWasCarriedOut());
+            });
+        }
+
+        return $shifts;
+    }
+
+    /**
+     * Get shift count
+     *
+     * @return int
+     */
+    public function getShiftCount($wasCarriedOut = null)
+    {
+        $shifts = $this->getShifts($wasCarriedOut);
+
+        return $shifts->count();
     }
 
     /**

--- a/src/AppBundle/Entity/Shift.php
+++ b/src/AppBundle/Entity/Shift.php
@@ -84,7 +84,7 @@ class Shift
 
     /**
      * One Shift may have been created from One PeriodPosition.
-     * @ORM\ManyToOne(targetEntity="PeriodPosition")
+     * @ORM\ManyToOne(targetEntity="PeriodPosition", inversedBy="shifts")
      * @ORM\JoinColumn(name="position_id", referencedColumnName="id", onDelete="SET NULL")
      */
     private $position;

--- a/src/AppBundle/Repository/ShiftFreeLogRepository.php
+++ b/src/AppBundle/Repository/ShiftFreeLogRepository.php
@@ -2,6 +2,9 @@
 
 namespace AppBundle\Repository;
 
+use AppBundle\Entity\Beneficiary;
+use AppBundle\Entity\PeriodPosition;
+
 /**
  * ShiftFreeLogRepository
  *
@@ -10,4 +13,27 @@ namespace AppBundle\Repository;
  */
 class ShiftFreeLogRepository extends \Doctrine\ORM\EntityRepository
 {
+    /**
+     * Get number of freed shifts for a given beneficiary, with possible filter on PeriodPosition
+     * @param Beneficiary $beneficiary
+     * @param PeriodPosition $position
+     */
+    public function getBeneficiaryShiftFreedCount(Beneficiary $beneficiary, PeriodPosition $position = null)
+    {
+        $qb = $this->createQueryBuilder('sfl')
+            ->select('count(sfl.id)')
+            ->where('sfl.beneficiary = :beneficiary')
+            ->setParameter('beneficiary', $beneficiary);
+
+        if ($position != null) {
+            $qb = $qb->andwhere('sfl.fixe = 1')
+                ->leftJoin('sfl.shift', 's')
+                ->andwhere('s.position = :position')
+                ->setParameter('position', $position);
+        }
+
+        return $qb
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
 }

--- a/src/AppBundle/Repository/ShiftRepository.php
+++ b/src/AppBundle/Repository/ShiftRepository.php
@@ -424,12 +424,13 @@ class ShiftRepository extends \Doctrine\ORM\EntityRepository
     }
 
     /**
-     * Get number of shifts for a given beneficiary, with possible filters on PeriodPosition & wasCarriedOut
+     * Get number of shifts for a given beneficiary, with possible filters on PeriodPosition, wasCarriedOut & endBeforeNow
      * @param Beneficiary $beneficiary
      * @param PeriodPosition $position
      * @param bool $wasCarriedOut
+     * @param bool $endBeforeNow
      */
-    public function getBeneficiaryShiftCount(Beneficiary $beneficiary, PeriodPosition $position = null, $wasCarriedOut = null)
+    public function getBeneficiaryShiftCount(Beneficiary $beneficiary, PeriodPosition $position = null, $wasCarriedOut = null, $endBeforeNow = false)
     {
         $qb = $this->createQueryBuilder('s')
             ->select('count(s.id)')
@@ -446,6 +447,11 @@ class ShiftRepository extends \Doctrine\ORM\EntityRepository
         }
         elseif ($wasCarriedOut == false) {
             $qb = $qb->andwhere('s.wasCarriedOut = 0');
+        }
+
+        if ($endBeforeNow == true) {
+            $qb = $qb->andwhere('s.end < :now')
+                ->setParameter('now', new \Datetime('now'));
         }
 
         return $qb

--- a/src/AppBundle/Repository/ShiftRepository.php
+++ b/src/AppBundle/Repository/ShiftRepository.php
@@ -438,7 +438,7 @@ class ShiftRepository extends \Doctrine\ORM\EntityRepository
 
         if ($position != null) {
             $qb = $qb->andwhere('s.position = :position')
-            ->setParameter('position', $position);
+                ->setParameter('position', $position);
         }
 
         if ($wasCarriedOut == true) {

--- a/src/AppBundle/Repository/ShiftRepository.php
+++ b/src/AppBundle/Repository/ShiftRepository.php
@@ -3,8 +3,9 @@
 namespace AppBundle\Repository;
 
 use AppBundle\Entity\Beneficiary;
-use AppBundle\Entity\Membership;
 use AppBundle\Entity\Job;
+use AppBundle\Entity\Membership;
+use AppBundle\Entity\PeriodPosition;
 use AppBundle\Entity\Shift;
 use Doctrine\Common\Collections\ArrayCollection;
 use \Datetime;
@@ -420,5 +421,35 @@ class ShiftRepository extends \Doctrine\ORM\EntityRepository
             ->getResult();
 
         return new ArrayCollection($result);
+    }
+
+    /**
+     * Get number of shifts for a given beneficiary, with possible filters on PeriodPosition & wasCarriedOut
+     * @param Beneficiary $beneficiary
+     * @param PeriodPosition $position
+     * @param bool $wasCarriedOut
+     */
+    public function getBeneficiaryShiftCount(Beneficiary $beneficiary, PeriodPosition $position = null, $wasCarriedOut = null)
+    {
+        $qb = $this->createQueryBuilder('s')
+            ->select('count(s.id)')
+            ->where('s.shifter = :beneficiary')
+            ->setParameter('beneficiary', $beneficiary);
+
+        if ($position != null) {
+            $qb = $qb->andwhere('s.position = :position')
+            ->setParameter('position', $position);
+        }
+
+        if ($wasCarriedOut == true) {
+            $qb = $qb->andwhere('s.wasCarriedOut = 1');
+        }
+        elseif ($wasCarriedOut == false) {
+            $qb = $qb->andwhere('s.wasCarriedOut = 0');
+        }
+
+        return $qb
+            ->getQuery()
+            ->getSingleScalarResult();
     }
 }

--- a/src/AppBundle/Service/ShiftService.php
+++ b/src/AppBundle/Service/ShiftService.php
@@ -568,17 +568,19 @@ class ShiftService
     }
 
     /**
-     * Get number of shifts for a given beneficiary, with possible filters on PeriodPosition & wasCarriedOut
+     * Get number of shifts for a given beneficiary, with possible filters on PeriodPosition, wasCarriedOut & endBeforeNow
      * @param Beneficiary $beneficiary
      * @param PeriodPosition $position
      * @param bool $wasCarriedOut
+     * @param bool $endBeforeNow
      */
-    public function getBeneficiaryShiftCount(Beneficiary $beneficiary, PeriodPosition $position = null, $wasCarriedOut = null)
+    public function getBeneficiaryShiftCount(Beneficiary $beneficiary, PeriodPosition $position = null, $wasCarriedOut = null, $endBeforeNow = false)
     {
         return $this->em->getRepository('AppBundle:Shift')->getBeneficiaryShiftCount(
             $beneficiary,
             $position,
-            $wasCarriedOut
+            $wasCarriedOut,
+            $endBeforeNow
         );
     }
 

--- a/src/AppBundle/Service/ShiftService.php
+++ b/src/AppBundle/Service/ShiftService.php
@@ -4,6 +4,7 @@ namespace AppBundle\Service;
 
 use AppBundle\Entity\Beneficiary;
 use AppBundle\Entity\Membership;
+use AppBundle\Entity\PeriodPosition;
 use AppBundle\Entity\Registration;
 use AppBundle\Entity\Shift;
 use AppBundle\Entity\ShiftBucket;
@@ -556,10 +557,28 @@ class ShiftService
      */
     public function isBeneficiaryHasShifts(Beneficiary $beneficiary, \Datetime $start_after, \Datetime $start_before, \Datetime $end_after)
     {
-        return !$this->em->getRepository('AppBundle:Shift')->findShiftsForBeneficiary($beneficiary,
-                $start_after,
-                null,
-                $start_before,
-                $end_after)->isEmpty();
+        $beneficiaryShifts = $this->em->getRepository('AppBundle:Shift')->findShiftsForBeneficiary(
+            $beneficiary,
+            $start_after,
+            null,
+            $start_before,
+            $end_after
+        );
+        return !$beneficiaryShifts->isEmpty();
+    }
+
+    /**
+     * Get number of shifts for a given beneficiary, with possible filters on PeriodPosition & wasCarriedOut
+     * @param Beneficiary $beneficiary
+     * @param PeriodPosition $position
+     * @param bool $wasCarriedOut
+     */
+    public function getBeneficiaryShiftCount(Beneficiary $beneficiary, PeriodPosition $position = null, $wasCarriedOut = null)
+    {
+        return $this->em->getRepository('AppBundle:Shift')->getBeneficiaryShiftCount(
+            $beneficiary,
+            $position,
+            $wasCarriedOut
+        );
     }
 }

--- a/src/AppBundle/Service/ShiftService.php
+++ b/src/AppBundle/Service/ShiftService.php
@@ -581,4 +581,17 @@ class ShiftService
             $wasCarriedOut
         );
     }
+
+    /**
+     * Get number of freed shifts for a given beneficiary, with possible filter on PeriodPosition
+     * @param Beneficiary $beneficiary
+     * @param PeriodPosition $position
+     */
+    public function getBeneficiaryShiftFreedCount(Beneficiary $beneficiary, PeriodPosition $position = null)
+    {
+        return $this->em->getRepository('AppBundle:ShiftFreeLog')->getBeneficiaryShiftFreedCount(
+            $beneficiary,
+            $position
+        );
+    }
 }


### PR DESCRIPTION
### Quoi ?

Sur la page admin d'un membre, indiquer pour chacun de ses créneau fixe le nombre de créneaux correspondants
- effectués
- non effectués
- annulés

Reste à faire : 
- afficher aussi cette info aux membres ?

### Capture d'écran

|Page|Avant|Après|
|---|---|---|
|Admin > page membre|![Screenshot from 2023-04-05 18-58-27](https://user-images.githubusercontent.com/7147385/230151378-ed65e2bb-10a4-4e59-bb0a-ee7725d0b953.png)|![image](https://user-images.githubusercontent.com/7147385/233481848-3b5bd521-8291-4c21-b092-ab6e0bdb1910.png)|
