### PR TITLE
Afficher les réseaux sociaux dans le footer

### DIFF
--- a/app/DoctrineMigrations/Version20230405171203_social_network_displayed_footer.php
+++ b/app/DoctrineMigrations/Version20230405171203_social_network_displayed_footer.php
@@ -23,6 +23,7 @@ final class Version20230405171203 extends AbstractMigration
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE social_network ADD displayed_footer TINYINT(1) DEFAULT \'0\' NOT NULL');
+        $this->addSql('ALTER TABLE social_network CHANGE description description LONGTEXT DEFAULT NULL');
     }
 
     public function down(Schema $schema) : void
@@ -31,5 +32,6 @@ final class Version20230405171203 extends AbstractMigration
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE social_network DROP displayed_footer');
+        $this->addSql('ALTER TABLE social_network CHANGE description description LONGTEXT CHARACTER SET utf8mb4 NOT NULL COLLATE `utf8mb4_unicode_ci`');
     }
 }

--- a/app/DoctrineMigrations/Version20230405171203_social_network_displayed_footer.php
+++ b/app/DoctrineMigrations/Version20230405171203_social_network_displayed_footer.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20230405171203 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE social_network ADD displayed_footer TINYINT(1) DEFAULT \'0\' NOT NULL');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE social_network DROP displayed_footer');
+    }
+}

--- a/app/Resources/views/_partial/footer.html.twig
+++ b/app/Resources/views/_partial/footer.html.twig
@@ -2,6 +2,11 @@
     <div class="footer-copyright">
         <div class="container">
             © {{ "now" | date('Y') }} Copyright {{ project_name }}
+            {% for socialNetwork in socialNetworks %}
+                <a class="grey-text text-lighten-4 right" href="{{ socialNetwork.url }}">
+                    &nbsp;|&nbsp;{{ socialNetwork.name }}
+                </a>
+            {% endfor %}
             <a class="grey-text text-lighten-4 right" href="{{ project_url }}">{{ project_url_display }}</a>
         </div>
     </div>

--- a/app/Resources/views/admin/socialnetwork/_form.html.twig
+++ b/app/Resources/views/admin/socialnetwork/_form.html.twig
@@ -20,7 +20,7 @@
         </div>
     </div>
 </div>
-<div>
+<div class="row">
     <div class="col s12">
         <div class="errors">
             {{ form_errors(form.url) }}
@@ -30,4 +30,11 @@
             {{ form_label(form.url) }}
         </div>
     </div>
+</div>
+<div class="row">
+    {{ form_errors(form.displayed_footer) }}
+    <label>
+        {{ form_widget(form.displayed_footer) }}
+        <span>{{ form.displayed_footer.vars.label }}</span>
+    </label>
 </div>

--- a/app/Resources/views/admin/socialnetwork/edit.html.twig
+++ b/app/Resources/views/admin/socialnetwork/edit.html.twig
@@ -5,7 +5,7 @@
 {% block breadcrumbs %}
 <a href="{{ path('homepage') }}"><i class="material-icons">home</i></a><i class="material-icons">chevron_right</i>
 <a href="{{ path('admin') }}"><i class="material-icons">build</i>&nbsp;Administration</a><i class="material-icons">chevron_right</i>
-<a href="{{ path('service_list') }}"><i class="material-icons">public</i>&nbsp;Liste des réseaux sociaux</a><i class="material-icons">chevron_right</i>
+<a href="{{ path('admin_socialnetworks_list') }}"><i class="material-icons">public</i>&nbsp;Liste des réseaux sociaux</a><i class="material-icons">chevron_right</i>
 <i class="material-icons">edit</i>&nbsp;Editer
 {% endblock %}
 

--- a/app/Resources/views/admin/socialnetwork/list.html.twig
+++ b/app/Resources/views/admin/socialnetwork/list.html.twig
@@ -25,7 +25,11 @@
         {% for socialNetwork in socialNetworks %}
             <tr>
                 <td>{{ socialNetwork.name }}</td>
-                <td>{{ socialNetwork.description }}</td>
+                <td class="center-align">
+                    {% if socialNetwork.description is not empty %}
+                        <i class="material-icons" title="{{ socialNetwork.description }}">playlist_add_check</i>
+                    {% endif %}
+                </td>
                 <td>
                     <a href="{{ socialNetwork.url }}">{{ socialNetwork.url }}</a>
                 </td>

--- a/app/Resources/views/admin/socialnetwork/list.html.twig
+++ b/app/Resources/views/admin/socialnetwork/list.html.twig
@@ -17,6 +17,7 @@
                 <th>Réseau social</th>
                 <th>Description</th>
                 <th>Url</th>
+                <th>Affiché dans le footer ?</th>
                 <th>Actions</th>
             </tr>
         </thead>
@@ -29,7 +30,16 @@
                     <a href="{{ socialNetwork.url }}">{{ socialNetwork.url }}</a>
                 </td>
                 <td>
-                    <a href="{{ path("admin_socialnetwork_edit", { 'id': socialNetwork.id }) }}"><i class="material-icons">edit</i>editer</a>
+                    {% if socialNetwork.displayedFooter %}
+                        <i class="material-icons">check</i>
+                    {% else %}
+                        <i class="material-icons">close</i>
+                    {% endif %}
+                </td>
+                <td>
+                    <a href="{{ path("admin_socialnetwork_edit", { 'id': socialNetwork.id }) }}">
+                        <i class="material-icons">edit</i>editer
+                    </a>
                 </td>
             </tr>
         {% endfor %}
@@ -37,5 +47,7 @@
     </table>
 
     <br />
-    <a href="{{ path('admin_socialnetwork_new') }}" class="btn"><i class="material-icons left">add</i>Ajouter un réseau social</a>
+    <a href="{{ path('admin_socialnetwork_new') }}" class="btn">
+        <i class="material-icons left">add</i>Ajouter un réseau social
+    </a>
 {% endblock %}

--- a/app/Resources/views/admin/socialnetwork/new.html.twig
+++ b/app/Resources/views/admin/socialnetwork/new.html.twig
@@ -5,7 +5,7 @@
 {% block breadcrumbs %}
 <a href="{{ path('homepage') }}"><i class="material-icons">home</i></a><i class="material-icons">chevron_right</i>
 <a href="{{ path('admin') }}"><i class="material-icons">build</i>&nbsp;Administration</a><i class="material-icons">chevron_right</i>
-<a href="{{ path('admin_socialnetwork_new') }}"><i class="material-icons">public</i>&nbsp;Liste des réseaux sociaux</a><i class="material-icons">chevron_right</i>
+<a href="{{ path('admin_socialnetwork_list') }}"><i class="material-icons">public</i>&nbsp;Liste des réseaux sociaux</a><i class="material-icons">chevron_right</i>
 <i class="material-icons">add</i>&nbsp;Ajouter
 {% endblock %}
 

--- a/app/Resources/views/layout.html.twig
+++ b/app/Resources/views/layout.html.twig
@@ -70,7 +70,7 @@
             {% endblock %}
         </main>
 
-        {% include "_partial/footer.html.twig" %}
+        {{ render(controller("AppBundle:Default:footer")) }}
 
         <script src="{{ asset('bundles/app/js/jquery-3.6.min.js') }}"></script>
         <script src="{{ asset('bundles/app/materialize/js/materialize-1.2.1.min.js') }}"></script>

--- a/src/AppBundle/Controller/DefaultController.php
+++ b/src/AppBundle/Controller/DefaultController.php
@@ -109,6 +109,17 @@ class DefaultController extends Controller
         ]);
     }
 
+    public function footerAction()
+    {
+        $em = $this->getDoctrine()->getManager();
+
+        $socialNetworks = $em->getRepository('AppBundle:SocialNetwork')->findAllDisplayedFooter();
+
+        return $this->render('_partial/footer.html.twig', [
+            'socialNetworks' => $socialNetworks,
+        ]);
+    }
+
     /**
      * @Route("/schedule", name="schedule", methods={"GET","POST"})
      * @Security("is_granted('IS_AUTHENTICATED_REMEMBERED', user)")

--- a/src/AppBundle/Entity/SocialNetwork.php
+++ b/src/AppBundle/Entity/SocialNetwork.php
@@ -44,6 +44,13 @@ class SocialNetwork
     private $url;
 
     /**
+     * @var bool
+     * 
+     * @ORM\Column(name="displayed_footer", type="boolean", options={"default" : 0}, nullable=false)
+     */
+    private $displayedFooter;
+
+    /**
      * @var \DateTime
      * 
      * @ORM\Column(name="created_at", type="datetime")
@@ -138,6 +145,30 @@ class SocialNetwork
     public function getUrl()
     {
         return $this->url;
+    }
+
+    /**
+     * Set displayedFooter.
+     *
+     * @param bool|null $displayedFooter
+     *
+     * @return SocialNetwork
+     */
+    public function setDisplayedFooter($displayedFooter = null)
+    {
+        $this->displayedFooter = $displayedFooter;
+
+        return $this;
+    }
+
+    /**
+     * Get displayedFooter.
+     *
+     * @return bool|null
+     */
+    public function getDisplayedFooter()
+    {
+        return $this->displayedFooter;
     }
 
     /**

--- a/src/AppBundle/Entity/SocialNetwork.php
+++ b/src/AppBundle/Entity/SocialNetwork.php
@@ -32,7 +32,7 @@ class SocialNetwork
     /**
      * @var string
      *
-     * @ORM\Column(name="description", type="text")
+     * @ORM\Column(name="description", type="text", nullable=true)
      */
     private $description;
 

--- a/src/AppBundle/Form/SocialNetworkType.php
+++ b/src/AppBundle/Form/SocialNetworkType.php
@@ -43,7 +43,8 @@ class SocialNetworkType extends AbstractType
 
             $form->add('name', TextType::class, array('label' => 'nom', 'required' => true))
                 ->add('description', TextType::class, array('label' => 'Description', 'required' => false))
-                ->add('url', TextType::class, array('label' => 'Adresse web', 'required' => false));
+                ->add('url', TextType::class, array('label' => 'Adresse web', 'required' => false))
+                ->add('displayed_footer', CheckboxType::class, array('required' => false, 'label' => 'Afficher dans le footer', 'attr' => array('class' => 'filled-in')));
         });
     }
     

--- a/src/AppBundle/Repository/SocialNetworkRepository.php
+++ b/src/AppBundle/Repository/SocialNetworkRepository.php
@@ -10,4 +10,13 @@ namespace AppBundle\Repository;
  */
 class SocialNetworkRepository extends \Doctrine\ORM\EntityRepository
 {
+    public function findAllDisplayedFooter()
+    {
+        $qb = $this->createQueryBuilder('sn')
+            ->where('sn.displayedFooter = 1');
+
+        return $qb
+            ->getQuery()
+            ->getResult();
+    }
 }


### PR DESCRIPTION
Suite de #803

### Quoi ?

- nouveau champ `SocialNetwork.displayedFooter`
- ajouter le champ dans la liste des réseaux sociaux + formulaire de création / modification
- afficher les réseaux sociaux dans le footer (à condition que `displayedFooter = true`)

Autres modifications : 
- amélioré la gestion du champ description (nullable, ne pas afficher tout le contenu dans la vue "liste")

### Captures d'écran

|Avant|Après|
|---|---|
|![Screenshot from 2022-11-25 21-50-08](https://user-images.githubusercontent.com/7147385/204054209-59b39f81-0af7-461e-ba65-18a19ce50e83.png)|![Screenshot from 2022-11-25 21-49-46](https://user-images.githubusercontent.com/7147385/204054197-55e1c21b-3fdb-4572-ae35-7c83e8ba02db.png)|