### PR TITLE
Cleanup : améliorer l'affichage des adhésions

### DIFF
--- a/app/Resources/views/member/_partial/recorded_registrations.html.twig
+++ b/app/Resources/views/member/_partial/recorded_registrations.html.twig
@@ -1,9 +1,10 @@
 {% if member.mainBeneficiary and member.mainBeneficiary.user.recordedRegistrations | length %}
-<h6>Recorded registrations</h6>
-<ul class="collapsible">
+<h6>Adhésions enregistrées</h6>
+<ul class="collapsible" style="cursor: default;">
     {% for registration in member.mainBeneficiary.user.recordedRegistrations %}
         <li>
-            <div class="collapsible-header">{% if registration.mode == constant('TYPE_CREDIT_CARD', registration) %}
+            <div class="collapsible-header" style="cursor: default;">
+                {% if registration.mode == constant('TYPE_CREDIT_CARD', registration) %}
                     <i class="material-icons tiny">credit_card</i>
                 {% else %}
                     <i class="material-icons tiny">attach_money</i>
@@ -11,21 +12,20 @@
                 {{ registration.date | date('d F Y') }} {{ registration.date | date('H:i') }} {{ registration.amount }}
                 {% if registration.mode == constant('TYPE_CREDIT_CARD', registration) %}
                     € en CARTE CREDIT
-                {% elseif registration.mode ==  constant('TYPE_LOCAL', registration) %}
+                {% elseif registration.mode == constant('TYPE_LOCAL', registration) %}
                     {{ local_currency_name }}
-                {% elseif registration.mode ==  constant('TYPE_CASH', registration) %}
+                {% elseif registration.mode == constant('TYPE_CASH', registration) %}
                     € en ESPECE
-                {% elseif registration.mode ==  constant('TYPE_CHECK', registration) %}
+                {% elseif registration.mode == constant('TYPE_CHECK', registration) %}
                     € en CHEQUE
                 {% endif %}
                 {% if registration.membership %}
-                pour #<a
-                        href="{{ path("member_new_registration",{"member_number":registration.membership.memberNumber}) }}">{{ registration.membership.memberNumber }}</a>&nbsp;
-                {% if registration.membership.mainBeneficiary %}
-                    {{ registration.membership.mainBeneficiary.firstname }} {{ registration.membership.mainBeneficiary.lastname }}
+                    pour #<a href="{{ path("member_new_registration",{"member_number":registration.membership.memberNumber}) }}">{{ registration.membership.memberNumber }}</a>&nbsp;
+                    {% if registration.membership.mainBeneficiary %}
+                        {{ registration.membership.mainBeneficiary.firstname }} {{ registration.membership.mainBeneficiary.lastname }}
+                    {% endif %}
                 {% endif %}
             </div>
-            {% endif %}
         </li>
     {% endfor %}
 </ul>

--- a/app/Resources/views/member/show.html.twig
+++ b/app/Resources/views/member/show.html.twig
@@ -79,7 +79,8 @@
                 <ul class="collapsible">
                     {% for registration in member.registrations %}
                         <li>
-                            <div class="collapsible-header">{% if registration.mode == constant('TYPE_CREDIT_CARD', registration) or registration.mode == constant('TYPE_HELLOASSO', registration) %}
+                            <div class="collapsible-header" style="cursor: default;">
+                                {% if registration.mode == constant('TYPE_CREDIT_CARD', registration) or registration.mode == constant('TYPE_HELLOASSO', registration) %}
                                     <i class="material-icons tiny">credit_card</i>
                                 {% else %}
                                     <i class="material-icons tiny">attach_money</i>

--- a/app/Resources/views/registrations/list.html.twig
+++ b/app/Resources/views/registrations/list.html.twig
@@ -87,7 +87,7 @@
             <li>
                 <div class="collapsible-header {% if registration.membership is defined and registration.membership and (registration.membership.registrations | length) > 1 %}teal{% elseif registration.type == constant('TYPE_ANONYMOUS', registration) %}orange{% else %}indigo{% endif %} lighten-4">
                     {% if registration.amount is not null %}
-                        {% if registration.mode == constant('TYPE_CREDIT_CARD', R) or  registration.mode == constant('TYPE_HELLOASSO', R)  %}
+                        {% if registration.mode == constant('TYPE_CREDIT_CARD', R) or registration.mode == constant('TYPE_HELLOASSO', R)  %}
                             <i class="material-icons tiny">credit_card</i>
                         {% else %}
                             <i class="material-icons tiny">attach_money</i>
@@ -100,18 +100,13 @@
                         Bénéficiaire rattaché
                     {% endif %}
                     {% if registration.registrar %}
-                        par&nbsp;
-                        {% if registration.registrar.beneficiary %}
-                            <a href="{{ path("member_show", { "member_number": registration.registrar.beneficiary.membership.memberNumber }) }}" target="_blank">{{ registration.registrar.beneficiary }}</a>
-                        {% else %}
-                            {{ registration.registrar.username }}
-                        {% endif %}
+                        par {% include "admin/member/_partial/member_or_user_link.html.twig" with { user: registration.registrar, target_blank: true } %}
                         &nbsp;&agrave;&nbsp;
                         {{ registration.date | date('H:i') }}
                     {% endif %}
                     {% if registration.membership %}
-                        pour <a href="{{ path("member_show",{ "member_number": registration.membership.memberNumber }) }}" target="_blank">{{ registration.membership }}</a>&nbsp;
-                        {% if(registration.membership.registrations | length) > 1 %}
+                        pour <a href="{{ path("member_show",{ "member_number": registration.membership.memberNumber }) }}" target="_blank">{{ registration.membership.memberNumberWithBeneficiaryListString }}</a>&nbsp;
+                        {% if (registration.membership.registrations | length) > 1 %}
                             (Ré-adhésion) effective le {{ registration.startDate | date('d F Y') }}
                         {% endif %}
                     {% else %}


### PR DESCRIPTION
### Quoi ?

Quelques améliorations sur les adhésions : 
- enlever le cursor "clic" sur les sections non cliquables
- utiliser le nouveau template `member_or_user_link`
- afficher le nom complet du membre en utilisant `memberNumberWithBeneficiaryListString`