### PR TITLE
Compte épargne : répare la logique de validation  

### DIFF
--- a/src/AppBundle/EventListener/TimeLogEventListener.php
+++ b/src/AppBundle/EventListener/TimeLogEventListener.php
@@ -245,7 +245,7 @@ class TimeLogEventListener
         $this->em->flush();
 
         if ($this->use_time_log_saving) {
-            $this->em->refresh($member);
+            $this->em->refresh($member);  // added to prevent getShiftTimeCount() from returning a cached (old) value
             $counter_now = $member->getShiftTimeCount();
             $extra_counter_time = $counter_now - $this->due_duration_by_cycle; // + max_time_at_end_of_shift ??
 

--- a/src/AppBundle/EventListener/TimeLogEventListener.php
+++ b/src/AppBundle/EventListener/TimeLogEventListener.php
@@ -245,6 +245,7 @@ class TimeLogEventListener
         $this->em->flush();
 
         if ($this->use_time_log_saving) {
+            $this->em->refresh($member);
             $counter_now = $member->getShiftTimeCount();
             $extra_counter_time = $counter_now - $this->due_duration_by_cycle; // + max_time_at_end_of_shift ??
 


### PR DESCRIPTION
### Quoi ?

Suite à #768, la validation d'un créneau bascule le temps "en trop" vers le compteur épargne.

Mais pour une histoire de "cache" (?), cela n'arrivait pas.

On utilise donc `em->refresh()` pour récupérer la bonne valeur du compteur temps du membre.