### PR TITLE
Événements : nouveau champ 'end'

### DIFF
--- a/app/DoctrineMigrations/Version20230417102556_event_end.php
+++ b/app/DoctrineMigrations/Version20230417102556_event_end.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20230417102556 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE event ADD end DATETIME DEFAULT NULL');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE event DROP end');
+    }
+}

--- a/app/Resources/views/admin/event/_partial/card.html.twig
+++ b/app/Resources/views/admin/event/_partial/card.html.twig
@@ -9,7 +9,12 @@
         {% if not event.img %}
             <span class="card-title"><i class="material-icons left">event</i>{{ event.title }}</span>
         {% endif %}
-        <i>{{ event.date | date_fr_full_with_time }}</i>
+        <i>
+            {{ event.date | date_fr_full_with_time }}
+            {% if event.end %}
+                <span title="jusqu'à {{ event.end | date_fr_full_with_time }}">({{ event.duration }})</span>
+            {% endif %}
+        </i>
         {{ event.description | markdown | raw }}
     </div>
     <div class="card-action">

--- a/app/Resources/views/admin/event/edit.html.twig
+++ b/app/Resources/views/admin/event/edit.html.twig
@@ -17,7 +17,12 @@
         {{ form_row(form.title) }}
     </div>
     <div class="row">
-        {{ form_row(form.date) }}
+        <div class="col s6">
+            {{ form_row(form.date) }}
+        </div>
+        <div class="col s6">
+            {{ form_row(form.end) }}
+        </div>
     </div>
     <div class="row">
         {{ form_row(form.description) }}

--- a/app/Resources/views/admin/event/edit.html.twig
+++ b/app/Resources/views/admin/event/edit.html.twig
@@ -14,27 +14,26 @@
 
     {{ form_start(form) }}
     <div class="row">
-        <div class="col s6">
+        {{ form_row(form.title) }}
+    </div>
+    <div class="row">
+        {{ form_row(form.date) }}
+    </div>
+    <div class="row">
+        {{ form_row(form.description) }}
+    </div>
+    <div class="row">
+        <div class="col s12">
             <div class="errors">
-                {{ form_errors(form.title) }}
+                {{ form_errors(form.imgFile) }}
             </div>
-            <div class="input-field">
-                {{ form_widget(form.title) }}
-                {{ form_label(form.title) }}
-            </div>
-        </div>
-        <div class="col s6">
-            <div class="errors">
-                {{ form_errors(form.date) }}
-            </div>
-            <div>
-                {{ form_label(form.date) }}
-            </div>
-            <div class="input-field">
-                {{ form_widget(form.date) }}
+            <div class="">
+                {{ form_widget(form.imgFile) }}
+                {{ form_label(form.imgFile) }}
             </div>
         </div>
     </div>
+    <h5>Nécessite un vote ?</h5>
     <div class="row">
         <div class="col s6">
             {{ form_errors(form.need_proxy) }}
@@ -53,29 +52,7 @@
     </div>
     <div class="row">
         <div class="col s6">
-            <div class="errors">
-                {{ form_errors(form.max_date_of_last_registration) }}
-            </div>
-            <div class="input-field">
-                {{ form_widget(form.max_date_of_last_registration) }}
-                {{ form_label(form.max_date_of_last_registration) }}
-            </div>
-        </div>
-    </div>
-    <div class="errors">
-        {{ form_errors(form.description) }}
-    </div>
-    {{ form_label(form.description) }}
-    {{ form_widget(form.description) }}
-    <div class="row">
-        <div class="col s12">
-            <div class="errors">
-                {{ form_errors(form.imgFile) }}
-            </div>
-            <div class="">
-                {{ form_widget(form.imgFile) }}
-                {{ form_label(form.imgFile) }}
-            </div>
+            {{ form_row(form.max_date_of_last_registration) }}
         </div>
     </div>
     <br />
@@ -103,4 +80,13 @@
         </div>
         {{ form_end(delete_form) }}
     {% endif %}
+{% endblock %}
+
+{% block stylesheets %}
+<style>
+    .vich-image {
+        max-height: 300px;
+        overflow: auto;
+    }
+</style>
 {% endblock %}

--- a/app/Resources/views/admin/event/edit.html.twig
+++ b/app/Resources/views/admin/event/edit.html.twig
@@ -13,6 +13,9 @@
 <h4>Editer un événement</h4>
 
 {{ form_start(form) }}
+<div class="errors">
+    {{ form_errors(form) }}
+</div>
 <div class="row">
     {{ form_row(form.title) }}
 </div>

--- a/app/Resources/views/admin/event/edit.html.twig
+++ b/app/Resources/views/admin/event/edit.html.twig
@@ -10,81 +10,81 @@
 {% endblock %}
 
 {% block content %}
-    <h4>Editer un événement</h4>
+<h4>Editer un événement</h4>
 
-    {{ form_start(form) }}
-    <div class="row">
-        {{ form_row(form.title) }}
+{{ form_start(form) }}
+<div class="row">
+    {{ form_row(form.title) }}
+</div>
+<div class="row">
+    <div class="col s6">
+        {{ form_row(form.date) }}
     </div>
-    <div class="row">
-        <div class="col s6">
-            {{ form_row(form.date) }}
-        </div>
-        <div class="col s6">
-            {{ form_row(form.end) }}
-        </div>
+    <div class="col s6">
+        {{ form_row(form.end) }}
     </div>
-    <div class="row">
-        {{ form_row(form.description) }}
-    </div>
-    <div class="row">
-        <div class="col s12">
-            <div class="errors">
-                {{ form_errors(form.imgFile) }}
-            </div>
-            <div class="">
-                {{ form_widget(form.imgFile) }}
-                {{ form_label(form.imgFile) }}
-            </div>
+</div>
+<div class="row">
+    {{ form_row(form.description) }}
+</div>
+<div class="row">
+    <div class="col s12">
+        <div class="errors">
+            {{ form_errors(form.imgFile) }}
         </div>
-    </div>
-    <h5>Nécessite un vote ?</h5>
-    <div class="row">
-        <div class="col s6">
-            {{ form_errors(form.need_proxy) }}
-            <label>
-                {{ form_widget(form.need_proxy) }}
-                <span>{{ form.need_proxy.vars.label }}</span>
-            </label>
-        </div>
-        <div class="col s6">
-            {{ form_errors(form.anonymous_proxy) }}
-            <label>
-                {{ form_widget(form.anonymous_proxy) }}
-                <span>{{ form.anonymous_proxy.vars.label }}</span>
-            </label>
+        <div class="">
+            {{ form_widget(form.imgFile) }}
+            {{ form_label(form.imgFile) }}
         </div>
     </div>
-    <div class="row">
-        <div class="col s6">
-            {{ form_row(form.max_date_of_last_registration) }}
-        </div>
+</div>
+<h5>Nécessite un vote ?</h5>
+<div class="row">
+    <div class="col s6">
+        {{ form_errors(form.need_proxy) }}
+        <label>
+            {{ form_widget(form.need_proxy) }}
+            <span>{{ form.need_proxy.vars.label }}</span>
+        </label>
     </div>
-    <br />
-    <div>
-        <button type="submit" class="btn waves-effect waves-light"><i class="material-icons left">save</i>Enregistrer</button>
+    <div class="col s6">
+        {{ form_errors(form.anonymous_proxy) }}
+        <label>
+            {{ form_widget(form.anonymous_proxy) }}
+            <span>{{ form.anonymous_proxy.vars.label }}</span>
+        </label>
     </div>
-    {{ form_end(form) }}
+</div>
+<div class="row">
+    <div class="col s6">
+        {{ form_row(form.max_date_of_last_registration) }}
+    </div>
+</div>
+<br />
+<div>
+    <button type="submit" class="btn waves-effect waves-light"><i class="material-icons left">save</i>Enregistrer</button>
+</div>
+{{ form_end(form) }}
 
-    {% if is_granted("ROLE_ADMIN") %}
-        {% if event.needProxy %}
-            <ul>
-                <li>
-                    <a href="{{ path("event_proxies_list",{'id':event.id}) }}"><i class="material-icons">list</i>Procurations</a>
-                </li>
-                <li>
-                    <a href="{{ path("event_signatures",{'id':event.id}) }}"><i class="material-icons">list</i>Emargement</a>
-                </li>
-            </ul>
-        {% endif %}
-
-        {{ form_start(delete_form) }}
-        {{ form_widget(delete_form) }}
-        <div>
-            <button type="submit" class="btn waves-effect waves-light red">Supprimer</button>
-        </div>
-        {{ form_end(delete_form) }}
+{% if is_granted("ROLE_ADMIN") %}
+    {% if event.needProxy %}
+        <ul>
+            <li>
+                <a href="{{ path("event_proxies_list",{'id':event.id}) }}"><i class="material-icons">list</i>Procurations</a>
+            </li>
+            <li>
+                <a href="{{ path("event_signatures",{'id':event.id}) }}"><i class="material-icons">list</i>Emargement</a>
+            </li>
+        </ul>
     {% endif %}
+
+    {{ form_start(delete_form) }}
+    {{ form_widget(delete_form) }}
+    <div>
+        <button type="submit" class="btn waves-effect waves-light red">Supprimer</button>
+    </div>
+    {{ form_end(delete_form) }}
+{% endif %}
 {% endblock %}
 
 {% block stylesheets %}

--- a/app/Resources/views/admin/event/list.html.twig
+++ b/app/Resources/views/admin/event/list.html.twig
@@ -40,7 +40,12 @@
                         <i class="material-icons" title="{{ event.description }}">playlist_add_check</i>
                     {% endif %}
                 </td>
-                <td>{{ event.date | date_fr_full_with_time }}</td>
+                <td>
+                    {{ event.date | date_fr_full_with_time }}
+                    {% if event.end %}
+                        <span title="jusqu'à {{ event.end | date_fr_full_with_time }}">({{ event.duration }})</span>
+                    {% endif %}
+                </td>
                 <td>
                     {% if event.needProxy %}
                         <a href="{{ path("event_proxies_list",{'id':event.id}) }}"><i class="material-icons tiny">list</i>&nbsp;Procurations</a>

--- a/app/Resources/views/admin/event/new.html.twig
+++ b/app/Resources/views/admin/event/new.html.twig
@@ -10,13 +10,32 @@
 {% endblock %}
 
 {% block content %}
-    <h4>Nouvel événement</h4>
+<h4>Nouvel événement</h4>
 
-    {{ form_start(form) }}
-    {{ form_widget(form) }}
-    <br />
-    <div>
-        <button type="submit" class="btn waves-effect waves-light">Créer</button>
+{{ form_start(form) }}
+<div class="errors">
+    {{ form_errors(form) }}
+</div>
+<div class="row">
+    <div class="col s6">
+        {{ form_row(form.title) }}
     </div>
-    {{ form_end(form) }}
+</div>
+<div class="row">
+    <div class="col s6">
+        {{ form_row(form.date) }}
+    </div>
+    <div class="col s6">
+        {{ form_row(form.end) }}
+    </div>
+</div>
+<div class="row">
+    {{ form_row(form.description) }}
+</div>
+<div class="row">
+    {{ form_row(form.imgFile) }}
+</div>
+<a href="{{ path('event_list') }}" class="waves-effect waves-light btn red white-text" title="Annuler">Annuler</a>
+<button type="submit" class="btn waves-effect waves-light"><i class="material-icons left">save</i>Créer</button>
+{{ form_end(form) }}
 {% endblock %}

--- a/app/Resources/views/admin/membershipshiftexemption/edit.html.twig
+++ b/app/Resources/views/admin/membershipshiftexemption/edit.html.twig
@@ -13,7 +13,9 @@
     <h4>Editer une exemption de bénévolat</h4>
 
     {{ form_start(edit_form) }}
-    {{ form_errors(edit_form) }}
+    <div class="errors">
+        {{ form_errors(form) }}
+    </div>
     <div class="row">
         <div class="col s6">
             <label for="beneficiaries">Bénéficiaires</label>

--- a/app/Resources/views/admin/user/import.html.twig
+++ b/app/Resources/views/admin/user/import.html.twig
@@ -19,7 +19,9 @@
 
         <div class="col s8 offset-s2">
             {{ form_start(form) }}
-            {{ form_errors(form) }}
+            <div class="errors">
+                {{ form_errors(form) }}
+            </div>
             <div class="row">
                 <div class="col s7">
                     <div class="file-field input-field">
@@ -40,7 +42,6 @@
                     <button type="submit" class="btn"><i class="material-icons left">file_upload</i>Importer</button>
                 </div>
             </div>
-
             {{ form_end(form) }}
         </div>
         <div class="col s12">

--- a/app/Resources/views/beneficiary/find_member_number.html.twig
+++ b/app/Resources/views/beneficiary/find_member_number.html.twig
@@ -15,7 +15,9 @@
             <h3 class="header center">Recherche numéro d'adhérent</h3>
             {% if form %}
                 {{ form_start(form) }}
-                {{ form_errors(form) }}
+                    <div class="errors">
+                        {{ form_errors(form) }}
+                    </div>
                     <div class="row center">
                         <div class="input-field col s6">
                             {{ form_widget(form.firstname) }}

--- a/app/Resources/views/user/tools/find_me.html.twig
+++ b/app/Resources/views/user/tools/find_me.html.twig
@@ -6,7 +6,9 @@
             <br><br>
             <h2 class="header center orange-text">Première connexion</h2>
             {{ form_start(form) }}
-            {{ form_errors(form) }}
+                <div class="errors">
+                    {{ form_errors(form) }}
+                </div>
                 <div class="row">
                     <div class="input-field col s6">
                         {{ form_widget(form.member_number) }}

--- a/app/Resources/views/widget/generate.html.twig
+++ b/app/Resources/views/widget/generate.html.twig
@@ -15,7 +15,6 @@
     <div class="errors">
         {{ form_errors(form) }}
     </div>
-
     <div class="row">
         <div class="col s12">
             {{ form_label(form.job) }}
@@ -61,7 +60,6 @@
             </div>
         </div>
     </div>
-
     {{ form_widget(form.generate, {'attr': {'class': 'btn waves-effect waves-light'}}) }}
     {{ form_end(form) }}
 

--- a/src/AppBundle/Entity/Event.php
+++ b/src/AppBundle/Entity/Event.php
@@ -500,8 +500,14 @@ class Event
             }
             # scale = "hours"
             $duration = "";
+            if ($diff->y) {
+                $duration = $duration . $diff->y . ' an' . ($diff->y > 1 ? 's' : '');
+            }
+            if ($diff->m) {
+                $duration = $duration . ($duration ? ' ' : '') . $diff->m . ' mois';
+            }
             if ($diff->d) {
-                $duration = $duration . $diff->d . ' jour' . ($diff->d > 1 ? 's' : '');
+                $duration = $duration . ($duration ? ' ' : '') . $diff->d . ' jour' . ($diff->d > 1 ? 's' : '');
             }
             if ($diff->h) {
                 $duration = $duration . ($duration ? ' ' : '') . $diff->h . 'h';

--- a/src/AppBundle/Entity/Event.php
+++ b/src/AppBundle/Entity/Event.php
@@ -270,6 +270,17 @@ class Event
     }
 
     /**
+     * @Assert\IsTrue(message="La date de début doit être avant celle de fin")
+     */
+    public function isStartBeforeEnd()
+    {
+        if ($this->end) {
+            return $this->date < $this->end;
+        }
+        return true;
+    }
+
+    /**
      * Add proxy
      *
      * @param \AppBundle\Entity\Proxy $proxy

--- a/src/AppBundle/Entity/Event.php
+++ b/src/AppBundle/Entity/Event.php
@@ -82,6 +82,14 @@ class Event
     /**
      * @var \DateTime
      *
+     * @Assert\DateTime()
+     * @ORM\Column(name="end", type="datetime", nullable=true)
+     */
+    private $end;
+
+    /**
+     * @var \DateTime
+     *
      * @ORM\Column(name="max_date_of_last_registration", type="datetime", nullable=true)
      */
     private $max_date_of_last_registration;
@@ -213,6 +221,30 @@ class Event
     public function setDate($date)
     {
         $this->date = $date;
+
+        return $this;
+    }
+
+    /**
+     * Get end
+     *
+     * @return \DateTime
+     */
+    public function getEnd()
+    {
+        return $this->end;
+    }
+
+    /**
+     * Set end
+     *
+     * @param \DateTime $date
+     *
+     * @return Event
+     */
+    public function setEnd($end)
+    {
+        $this->end = $end;
 
         return $this;
     }
@@ -457,5 +489,28 @@ class Event
     public function getUpdatedAt()
     {
         return $this->updatedAt;
+    }
+
+    public function getDuration($scale = 'hours')
+    {
+        if ($this->end) {
+            $diff = date_diff($this->date, $this->end);
+            if ($scale == 'minutes') {
+                return ($diff->h * 60 + $diff->i) . ' min';  # "180 min"
+            }
+            # scale = "hours"
+            $duration = "";
+            if ($diff->d) {
+                $duration = $duration . $diff->d . ' jour' . ($diff->d > 1 ? 's' : '');
+            }
+            if ($diff->h) {
+                $duration = $duration . ($duration ? ' ' : '') . $diff->h . 'h';
+            }
+            if ($diff->i) {
+                $duration = $duration . ($duration ? ' ' : '') . $diff->i . ' min';
+            }
+            return $duration;
+        }
+        return null;
     }
 }

--- a/src/AppBundle/Entity/Event.php
+++ b/src/AppBundle/Entity/Event.php
@@ -226,6 +226,26 @@ class Event
     }
 
     /**
+     * Get date
+     *
+     * @return \DateTime
+     */
+    public function getDate()
+    {
+        return $this->date;
+    }
+
+    /**
+     * Get time
+     *
+     * @return \DateTime
+     */
+    public function getTime()
+    {
+        return $this->date;
+    }
+
+    /**
      * Get end
      *
      * @return \DateTime
@@ -247,26 +267,6 @@ class Event
         $this->end = $end;
 
         return $this;
-    }
-
-    /**
-     * Get date
-     *
-     * @return \DateTime
-     */
-    public function getDate()
-    {
-        return $this->date;
-    }
-
-    /**
-     * Get time
-     *
-     * @return \DateTime
-     */
-    public function getTime()
-    {
-        return $this->date;
     }
 
     /**

--- a/src/AppBundle/Form/EventType.php
+++ b/src/AppBundle/Form/EventType.php
@@ -46,25 +46,35 @@ class EventType extends AbstractType
             $form = $event->getForm();
             $userData = $event->getData();
 
-            $form->add('title', TextType::class,array('label' => 'Titre'))
-                ->add('date', DateTimeType::class,array(
+            $form->add('title', TextType::class, array('label' => 'Titre'))
+                ->add('date', DateTimeType::class, array(
                     'required' => true,
                     'input'  => 'datetime',
                     'date_widget' => 'single_text',
                     'time_widget' => 'single_text',
-                    'label' => 'Date & heure',
+                    'label' => 'Date & heure de début',
                     'attr' => array(
                         'class' => 'datepicker'
                     )
                 ))
-                ->add('description',MarkdownEditorType::class,array('label'=>'Description', 'required' => false));
-            $form->add('imgFile', VichImageType::class, array(
+                ->add('end', DateTimeType::class, array(
+                    'required' => false,
+                    'input'  => 'datetime',
+                    'date_widget' => 'single_text',
+                    'time_widget' => 'single_text',
+                    'label' => 'Date & heure de fin (optionnel)',
+                    'attr' => array(
+                        'class' => 'datepicker'
+                    )
+                ))
+                ->add('description', MarkdownEditorType::class, array('label' => 'Description', 'required' => false))
+                ->add('imgFile', VichImageType::class, array(
                 'required' => false,
                 'allow_delete' => true,
                 'download_link' => true,
             ));
 
-            if ($userData && $userData->getId()){
+            if ($userData && $userData->getId()) {
                 $form->add('need_proxy', CheckboxType::class, array(
                     'required' => false,
                     'label' => 'Utilise des procurations (AG, ...)',
@@ -81,10 +91,7 @@ class EventType extends AbstractType
                     'attr' => array('class' => 'datepicker')
                 ));
             }
-
         });
-
-
     }
     
     /**
@@ -104,6 +111,4 @@ class EventType extends AbstractType
     {
         return 'appbundle_event';
     }
-
-
 }

--- a/src/AppBundle/Form/EventType.php
+++ b/src/AppBundle/Form/EventType.php
@@ -69,10 +69,10 @@ class EventType extends AbstractType
                 ))
                 ->add('description', MarkdownEditorType::class, array('label' => 'Description', 'required' => false))
                 ->add('imgFile', VichImageType::class, array(
-                'required' => false,
-                'allow_delete' => true,
-                'download_link' => true,
-            ));
+                    'required' => false,
+                    'allow_delete' => true,
+                    'download_link' => true,
+                ));
 
             if ($userData && $userData->getId()) {
                 $form->add('need_proxy', CheckboxType::class, array(

--- a/src/AppBundle/Form/SocialNetworkType.php
+++ b/src/AppBundle/Form/SocialNetworkType.php
@@ -13,7 +13,6 @@ use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
-use Vich\UploaderBundle\Form\Type\VichImageType;
 
 class SocialNetworkType extends AbstractType
 {


### PR DESCRIPTION
### Quoi ?

- Nouveau champ `Event.end` (facultatif)
  - ajouté le champ au formulaire de création d'événement
  - afficher la durée de l'événement si le champ est rempli
- Améliorations d'affichage sur le formulaire de modification d'un événement : 
  - descendu les champs "procuration" + mis dans une section "nécessite un vote ?"
  - éviter que l'image prennent trop de places

### Information supplémentaire

- il faudrait aussi renommer `Event.date` en `Event.start`, mais j'ai peur de tout casser...
- il faudrait aussi rajouter des check pour s'assurer que end > start

### Capture d'écran

|Avant|Après|
|---|---|
|![image](https://user-images.githubusercontent.com/7147385/232464712-9dd83f2a-fa5c-4653-9d05-6f911852abdb.png)|![image](https://user-images.githubusercontent.com/7147385/232466616-0edefc04-e34b-413f-9344-f448c07f1545.png)|
|![image](https://user-images.githubusercontent.com/7147385/232512810-e57d4fef-83d5-4fe3-a1bd-96532bd5a3bc.png)|![Screenshot from 2023-04-17 16-16-41](https://user-images.githubusercontent.com/7147385/232512866-24b1afdb-b8ba-4542-8927-3d058c0c10fc.png)|



