### PR TITLE
Événements : séparer index & liste

### DIFF
--- a/app/Resources/views/admin/event/_partial/table.html.twig
+++ b/app/Resources/views/admin/event/_partial/table.html.twig
@@ -1,0 +1,41 @@
+<table class="responsive-table">
+    <thead>
+        <tr>
+            <th>Événement</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Date</th>
+            <th>Procurations</th>
+            <th>Actions</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for event in events %}
+            <tr>
+                <td>{{ event.title }}</td>
+                <td>{{ event.kind }}</td>
+                <td class="center-align">
+                    {% if event.description is not empty %}
+                        <i class="material-icons" title="{{ event.description }}">playlist_add_check</i>
+                    {% endif %}
+                </td>
+                <td>
+                    {{ event.date | date_fr_full_with_time }}
+                    {% if event.end %}
+                        <span title="jusqu'à {{ event.end | date_fr_full_with_time }}">({{ event.duration }})</span>
+                    {% endif %}
+                </td>
+                <td>
+                    {% if event.needProxy %}
+                        <a href="{{ path("event_proxies_list",{'id':event.id}) }}"><i class="material-icons tiny">list</i>&nbsp;Procurations</a>
+                        <br />
+                        <a href="{{ path("event_signatures",{'id':event.id}) }}"><i class="material-icons tiny">print</i>&nbsp;Emargement</a>
+                    {% endif %}
+                </td>
+                <td>
+                    <a href="{{ path('event_edit', { 'id': event.id }) }}"><i class="material-icons">edit</i>Editer</a>
+                </td>
+            </tr>
+        {% endfor %}
+    </tbody>
+</table>

--- a/app/Resources/views/admin/event/edit.html.twig
+++ b/app/Resources/views/admin/event/edit.html.twig
@@ -5,7 +5,7 @@
 {% block breadcrumbs %}
 <a href="{{ path('homepage') }}"><i class="material-icons">home</i></a><i class="material-icons">chevron_right</i>
 <a href="{{ path('admin') }}"><i class="material-icons">build</i>&nbsp;Administration</a><i class="material-icons">chevron_right</i>
-<a href="{{ path('event_list') }}"><i class="material-icons">list</i>&nbsp;Liste des événements</a><i class="material-icons">chevron_right</i>
+<a href="{{ path('event_index') }}"><i class="material-icons">event</i>&nbsp;Événements</a><i class="material-icons">chevron_right</i>
 <i class="material-icons">edit</i>&nbsp;Editer
 {% endblock %}
 

--- a/app/Resources/views/admin/event/index.html.twig
+++ b/app/Resources/views/admin/event/index.html.twig
@@ -1,11 +1,11 @@
 {% extends 'layout.html.twig' %}
 
-{% block title %}Liste des événements - {{ site_name }}{% endblock %}
+{% block title %}Événements - {{ site_name }}{% endblock %}
 
 {% block breadcrumbs %}
 <a href="{{ path('homepage') }}"><i class="material-icons">home</i></a><i class="material-icons">chevron_right</i>
 <a href="{{ path('admin') }}"><i class="material-icons">build</i>&nbsp;Administration</a><i class="material-icons">chevron_right</i>
-<i class="material-icons">list</i>&nbsp;Liste des événements
+<i class="material-icons">event</i>&nbsp;Événements
 {% endblock %}
 
 {% block content %}
@@ -66,6 +66,7 @@
 {% if is_granted("ROLE_ADMIN") %}
     <br />
     <a href="{{ path("proxies_list") }}" class="btn"><i class="material-icons left">list</i>Toutes les procurations</a>
+    <br />
     <a href="{{ path('event_new') }}" class="btn"><i class="material-icons left">add</i>Ajouter un événement</a>
 {% endif %}
 {% endblock %}

--- a/app/Resources/views/admin/event/kind/new.html.twig
+++ b/app/Resources/views/admin/event/kind/new.html.twig
@@ -5,7 +5,7 @@
 {% block breadcrumbs %}
 <a href="{{ path('homepage') }}"><i class="material-icons">home</i></a><i class="material-icons">chevron_right</i>
 <a href="{{ path('admin') }}"><i class="material-icons">build</i>&nbsp;Administration</a><i class="material-icons">chevron_right</i>
-<a href="{{ path('event_list') }}"><i class="material-icons">list</i>&nbsp;Liste des types d'événements</a><i class="material-icons">chevron_right</i>
+<a href="{{ path('event_index') }}"><i class="material-icons">list</i>&nbsp;Liste des types d'événements</a><i class="material-icons">chevron_right</i>
 <i class="material-icons">add</i>&nbsp;Ajouter
 {% endblock %}
 

--- a/app/Resources/views/admin/event/list.html.twig
+++ b/app/Resources/views/admin/event/list.html.twig
@@ -5,27 +5,17 @@
 {% block breadcrumbs %}
 <a href="{{ path('homepage') }}"><i class="material-icons">home</i></a><i class="material-icons">chevron_right</i>
 <a href="{{ path('admin') }}"><i class="material-icons">build</i>&nbsp;Administration</a><i class="material-icons">chevron_right</i>
-<i class="material-icons">event</i>&nbsp;Événements
+<a href="{{ path('event_index') }}"><i class="material-icons">event</i>&nbsp;Événements</a><i class="material-icons">chevron_right</i>
+<i class="material-icons">list</i>&nbsp;Liste des événements
 {% endblock %}
 
 {% block content %}
-<h4>Événements à venir ({{ eventsFuture | length }})</h4>
+<h4>Liste des événements ({{ events | length }})</h4>
 
-<div class="row">
-    {% for event in eventsFuture %}
-        <div class="col s12 m6">
-            {% include "admin/event/_partial/card.html.twig" with { event: event } %}
-        </div>
-    {% endfor %}
-</div>
-
-<h4>Événements passés (10 plus récents)</h4>
-
-{% include "admin/event/_partial/table.html.twig" with { events: eventsPast } %}
+{% include "admin/event/_partial/table.html.twig" with { events: events } %}
 
 {% if is_granted("ROLE_ADMIN") %}
     <br />
-    <a href="{{ path("event_list") }}" class="btn"><i class="material-icons left">list</i>Tous les événements</a>
     <a href="{{ path("proxies_list") }}" class="btn"><i class="material-icons left">list</i>Toutes les procurations</a>
     <br />
     <a href="{{ path('event_new') }}" class="btn"><i class="material-icons left">add</i>Ajouter un événement</a>

--- a/app/Resources/views/admin/event/list.html.twig
+++ b/app/Resources/views/admin/event/list.html.twig
@@ -12,6 +12,28 @@
 {% block content %}
 <h4>Liste des événements ({{ events | length }})</h4>
 
+{# Filter form  --------- #}
+<ul class="collapsible">
+    <li>
+        <div class="collapsible-header">
+            <i class="material-icons">tune</i>Filtres
+        </div>
+        <div class="collapsible-body">
+            {{ form_start(filter_form) }}
+            <div class="row">
+                <div class="col s6">
+                    <div class="input-field">
+                        {{ form_widget(filter_form.kind) }}
+                        {{ form_label(filter_form.kind) }}
+                    </div>
+                </div>
+            </div>
+            {{ form_widget(filter_form.submit) }}
+            {{ form_end(filter_form) }}
+        </div>
+    </li>
+</ul>
+
 {% include "admin/event/_partial/table.html.twig" with { events: events } %}
 
 {% if is_granted("ROLE_ADMIN") %}

--- a/app/Resources/views/admin/event/new.html.twig
+++ b/app/Resources/views/admin/event/new.html.twig
@@ -5,7 +5,7 @@
 {% block breadcrumbs %}
 <a href="{{ path('homepage') }}"><i class="material-icons">home</i></a><i class="material-icons">chevron_right</i>
 <a href="{{ path('admin') }}"><i class="material-icons">build</i>&nbsp;Administration</a><i class="material-icons">chevron_right</i>
-<a href="{{ path('event_list') }}"><i class="material-icons">list</i>&nbsp;Liste des événements</a><i class="material-icons">chevron_right</i>
+<a href="{{ path('event_index') }}"><i class="material-icons">event</i>&nbsp;Événements</a><i class="material-icons">chevron_right</i>
 <i class="material-icons">add</i>&nbsp;Ajouter
 {% endblock %}
 
@@ -38,7 +38,7 @@
 <div class="row">
     {{ form_row(form.imgFile) }}
 </div>
-<a href="{{ path('event_list') }}" class="waves-effect waves-light btn red white-text" title="Annuler">Annuler</a>
+<a href="{{ path('event_index') }}" class="waves-effect waves-light btn red white-text" title="Annuler">Annuler</a>
 <button type="submit" class="btn waves-effect waves-light"><i class="material-icons left">save</i>Créer</button>
 {{ form_end(form) }}
 {% endblock %}

--- a/app/Resources/views/admin/event/proxy/edit.html.twig
+++ b/app/Resources/views/admin/event/proxy/edit.html.twig
@@ -5,7 +5,7 @@
 {% block breadcrumbs %}
 <a href="{{ path('homepage') }}"><i class="material-icons">home</i></a><i class="material-icons">chevron_right</i>
 <a href="{{ path('admin') }}"><i class="material-icons">build</i>&nbsp;Administration</a><i class="material-icons">chevron_right</i>
-<a href="{{ path('event_list') }}"><i class="material-icons">list</i>&nbsp;Liste des événements</a><i class="material-icons">chevron_right</i>
+<a href="{{ path('event_index') }}"><i class="material-icons">event</i>&nbsp;Événements</a><i class="material-icons">chevron_right</i>
 <i class="material-icons">edit</i>&nbsp;Editer une procuration
 {% endblock %}
 

--- a/app/Resources/views/admin/event/proxy/list.html.twig
+++ b/app/Resources/views/admin/event/proxy/list.html.twig
@@ -5,7 +5,7 @@
 {% block breadcrumbs %}
 <a href="{{ path('homepage') }}"><i class="material-icons">home</i></a><i class="material-icons">chevron_right</i>
 <a href="{{ path('admin') }}"><i class="material-icons">build</i>&nbsp;Administration</a><i class="material-icons">chevron_right</i>
-<a href="{{ path('event_list') }}"><i class="material-icons">list</i>&nbsp;Liste des événements</a><i class="material-icons">chevron_right</i>
+<a href="{{ path('event_index') }}"><i class="material-icons">event</i>&nbsp;Événements</a><i class="material-icons">chevron_right</i>
 {% if event %}
     <i class="material-icons">event</i>&nbsp;{{ event.title }}<i class="material-icons">chevron_right</i>
 {% endif %}

--- a/app/Resources/views/admin/event/proxy/list.html.twig
+++ b/app/Resources/views/admin/event/proxy/list.html.twig
@@ -9,11 +9,11 @@
 {% if event %}
     <i class="material-icons">event</i>&nbsp;{{ event.title }}<i class="material-icons">chevron_right</i>
 {% endif %}
-<i class="material-icons">list</i>&nbsp;Procurations
+<i class="material-icons">list</i>&nbsp;Liste des procurations
 {% endblock %}
 
 {% block content %}
-    <h4>Liste des procurations en cours <small>({{ proxies | length }})</small></h4>
+    <h4>Liste des procurations <small>({{ proxies | length }})</small></h4>
 
     {% if max_event_proxy_per_member > 0 %}
         <blockquote class="red-text">

--- a/app/Resources/views/admin/index.html.twig
+++ b/app/Resources/views/admin/index.html.twig
@@ -74,7 +74,7 @@
                 <a href="{{ path("process_update_list") }}" class="waves-effect waves-light btn lime darken-1">
                     <i class="material-icons left">assignment</i>Gérer les nouveautés
                 </a>
-                <a href="{{ path("event_list") }}" class="waves-effect waves-light btn teal">
+                <a href="{{ path("event_index") }}" class="waves-effect waves-light btn teal">
                     <i class="material-icons left">event</i>Événements
                 </a>
                 {% if is_granted("ROLE_ADMIN") %}

--- a/src/AppBundle/Controller/EventController.php
+++ b/src/AppBundle/Controller/EventController.php
@@ -24,19 +24,19 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 class EventController extends Controller
 {
     /**
-     * Lists all events.
+     * Event home page
      *
-     * @Route("/", name="event_list", methods={"GET"})
+     * @Route("/", name="event_index", methods={"GET"})
      * @Security("has_role('ROLE_PROCESS_MANAGER')")
      */
-    public function listAction(Request $request)
+    public function indexAction(Request $request)
     {
         $em = $this->getDoctrine()->getManager();
 
         $eventsFuture = $em->getRepository('AppBundle:Event')->findFutures();
         $eventsPast = $em->getRepository('AppBundle:Event')->findPast();
 
-        return $this->render('admin/event/list.html.twig', array(
+        return $this->render('admin/event/index.html.twig', array(
             'eventsFuture' => $eventsFuture,
             'eventsPast' => $eventsPast,
         ));
@@ -89,7 +89,7 @@ class EventController extends Controller
             $em->flush();
 
             $session->getFlashBag()->add('success', 'L\'événement a bien été édité !');
-            return $this->redirectToRoute('event_list');
+            return $this->redirectToRoute('event_index');
         }
 
         return $this->render('admin/event/edit.html.twig', array(
@@ -120,7 +120,7 @@ class EventController extends Controller
             $session->getFlashBag()->add('success', 'L\'événement a bien été supprimé !');
         }
 
-        return $this->redirectToRoute('event_list');
+        return $this->redirectToRoute('event_index');
     }
 
     /**

--- a/src/AppBundle/Controller/EventController.php
+++ b/src/AppBundle/Controller/EventController.php
@@ -34,11 +34,28 @@ class EventController extends Controller
         $em = $this->getDoctrine()->getManager();
 
         $eventsFuture = $em->getRepository('AppBundle:Event')->findFutures();
-        $eventsPast = $em->getRepository('AppBundle:Event')->findPast();
+        $eventsPast = $em->getRepository('AppBundle:Event')->findPast(10);  # only the 10 last
 
         return $this->render('admin/event/index.html.twig', array(
             'eventsFuture' => $eventsFuture,
             'eventsPast' => $eventsPast,
+        ));
+    }
+
+    /**
+     * Event list
+     *
+     * @Route("/list", name="event_list", methods={"GET"})
+     * @Security("has_role('ROLE_PROCESS_MANAGER')")
+     */
+    public function listAction(Request $request)
+    {
+        $em = $this->getDoctrine()->getManager();
+
+        $events = $em->getRepository('AppBundle:Event')->findAll();
+
+        return $this->render('admin/event/list.html.twig', array(
+            'events' => $events,
         ));
     }
 

--- a/src/AppBundle/Repository/EventRepository.php
+++ b/src/AppBundle/Repository/EventRepository.php
@@ -10,10 +10,15 @@ namespace AppBundle\Repository;
  */
 class EventRepository extends \Doctrine\ORM\EntityRepository
 {
+    public function findAll()
+    {
+        return $this->findBy(array(), array('date' => 'DESC'));
+    }
+
     public function findFutures(\DateTime $max = null)
     {
         $qb = $this->createQueryBuilder('e')
-            ->where("e.date > :now")
+            ->where('e.date > :now')
             ->setParameter('now', new \Datetime('now'));
 
         if ($max) {
@@ -22,19 +27,24 @@ class EventRepository extends \Doctrine\ORM\EntityRepository
                 ->setParameter('max', $max);
         }
 
-        $qb->orderBy("e.date", 'ASC');
+        $qb->orderBy('e.date', 'ASC');
 
         return $qb
             ->getQuery()
             ->getResult();
     }
 
-    public function findPast()
+    public function findPast(int $limit = null)
     {
         $qb = $this->createQueryBuilder('e')
-            ->where("e.date < :now")
-            ->setParameter('now', new \Datetime('now'))
-            ->orderBy("e.date", 'DESC');
+            ->where('e.date < :now')
+            ->setParameter('now', new \Datetime('now'));
+
+        if ($limit) {
+            $qb->setMaxResults($limit);
+        }
+
+        $qb->orderBy('e.date', 'DESC');
 
         return $qb
             ->getQuery()


### PR DESCRIPTION
### Quoi ?

Créer une page avec la liste complète de tous les événements : 
- renommé `event_list` en `event_index` (sert de "home" page)
- nouvelle page `event_list` avec tous les événements (bouton "Tous les événements" sur la page index)
- filtre basique sur la page liste
- template pour une liste d'événements (utilisée dans index & liste)

### Capture d'écran

![image](https://user-images.githubusercontent.com/7147385/232887354-0a28d66a-c8aa-4556-b8e5-4df236edf126.png)
