### PR TITLE
Cleanup : homogénéiser la pagination

### DIFF
--- a/app/Resources/views/admin/helloasso/browser.html.twig
+++ b/app/Resources/views/admin/helloasso/browser.html.twig
@@ -15,9 +15,9 @@
     {% if campaigns is defined and campaigns | length %}
         <div class="row">
             {% for campaign in campaigns %}
-            <div class="col s12 m6 l6 xl4">
-                {% include "admin/helloasso/_partial/campaign.html.twig" with { campaign: campaign } %}
-            </div>
+                <div class="col s12 m6 l6 xl4">
+                    {% include "admin/helloasso/_partial/campaign.html.twig" with { campaign: campaign } %}
+                </div>
             {% endfor %}
         </div>
     {% elseif campaigns is defined and campaigns is not null %}
@@ -67,14 +67,17 @@
                     <td>{{ payment.payer_country }}</td>
                     <td>{{ payment.payer_email }}</td>
                     <td>{{ payment.status }}</td>
-                    <td><ul>{% for key,action in payment.actions %}
+                    <td>
+                        <ul>
+                            {% for key,action in payment.actions %}
                                 <li>#{{ action.id }} {{ action.amount }}€ ({{ action.type }})</li>
-                        {% endfor %}</ul>
+                            {% endfor %}
+                        </ul>
                     </td>
                     <td>
                         <form action="{{ path("helloasso_manual_paiement_add",{paiementId : payment.id }) }}" method="post">
                             <input type="hidden" name="paiementId" value="{{ payment.id }}">
-                            <button class="btn red" type="submit" ><i class="material-icons">save</i></button>
+                            <button class="btn red" type="submit"><i class="material-icons">save</i></button>
                         </form>
                     </td>
                 </tr>
@@ -83,16 +86,16 @@
             </tbody>
         </table>
         <ul class="pagination">
-            <li class="{% if(page==1) %}disabled{% else %}waves-effect{% endif %}">
-                <a href="{% if(page==1) %}#!{% else %}{{ path("helloasso_browser",{campaign:campaign.id,'page':page-1}) }}{% endif %}">
+            <li class="{% if(current_page==1) %}disabled{% else %}waves-effect{% endif %}">
+                <a href="{% if(current_page==1) %}#!{% else %}{{ path("helloasso_browser",{campaign:campaign.id,'page':current_page-1}) }}{% endif %}">
                     <i class="material-icons">chevron_left</i>
                 </a>
             </li>
-            {% for i in range(1,nb_of_pages) %}
-                <li class="{% if(page==i) %}active{% else %}waves-effect{% endif %}"><a href="{{ path("helloasso_browser",{campaign:campaign.id,'page':i}) }}">{{ i }}</a></li>
+            {% for i in range(1, page_count) %}
+                <li class="{% if(current_page==i) %}active{% else %}waves-effect{% endif %}"><a href="{{ path("helloasso_browser",{campaign:campaign.id,'page':i}) }}">{{ i }}</a></li>
             {% endfor %}
-            <li class="{% if(page==nb_of_pages) %}disabled{% else %}waves-effect{% endif %}">
-                <a href="{% if(page==nb_of_pages) %}#!{% else %}{{ path("helloasso_browser",{campaign:campaign.id,'page':page+1}) }}{% endif %}">
+            <li class="{% if(current_page==page_count) %}disabled{% else %}waves-effect{% endif %}">
+                <a href="{% if(current_page==page_count) %}#!{% else %}{{ path("helloasso_browser",{campaign:campaign.id,'page':current_page+1}) }}{% endif %}">
                     <i class="material-icons">chevron_right</i>
                 </a>
             </li>

--- a/app/Resources/views/admin/helloasso/payments.html.twig
+++ b/app/Resources/views/admin/helloasso/payments.html.twig
@@ -51,23 +51,24 @@
                                 <i class="material-icons">delete</i>
                             </button>
                             {{ form_end(delete_forms[payment.id]) }}
-                        {% endif %}</td>
+                        {% endif %}
+                    </td>
                 </tr>
             {% endfor %}
         </tbody>
     </table>
 
     <ul class="pagination">
-        <li class="{% if(page==1) %}disabled{% else %}waves-effect{% endif %}">
-            <a href="{% if(page==1) %}#!{% else %}{{ path("helloasso_payments",{'page':page-1}) }}{% endif %}">
+        <li class="{% if(current_page==1) %}disabled{% else %}waves-effect{% endif %}">
+            <a href="{% if(current_page==1) %}#!{% else %}{{ path("helloasso_payments",{'page':current_page-1}) }}{% endif %}">
                 <i class="material-icons">chevron_left</i>
             </a>
         </li>
-        {% for i in range(1,nb_of_pages) %}
-        <li class="{% if(page==i) %}active{% else %}waves-effect{% endif %}"><a href="{{ path("helloasso_payments",{'page':i}) }}">{{ i }}</a></li>
+        {% for i in range(1, page_count) %}
+            <li class="{% if(current_page==i) %}active{% else %}waves-effect{% endif %}"><a href="{{ path("helloasso_payments",{'page':i}) }}">{{ i }}</a></li>
         {% endfor %}
-        <li class="{% if(page==nb_of_pages) %}disabled{% else %}waves-effect{% endif %}">
-            <a href="{% if(page==nb_of_pages) %}#!{% else %}{{ path("helloasso_payments",{'page':page+1}) }}{% endif %}">
+        <li class="{% if(current_page==page_count) %}disabled{% else %}waves-effect{% endif %}">
+            <a href="{% if(current_page==page_count) %}#!{% else %}{{ path("helloasso_payments",{'page':current_page+1}) }}{% endif %}">
                 <i class="material-icons">chevron_right</i>
             </a>
         </li>

--- a/app/Resources/views/admin/membershipshiftexemption/index.html.twig
+++ b/app/Resources/views/admin/membershipshiftexemption/index.html.twig
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block content %}
-    <h4>Liste des membres exempté.e.s de bénévolat ({{ membershipShiftExemptions | length }})</h4>
+    <h4>Liste des membres exempté.e.s de bénévolat ({{ result_count }})</h4>
 
     {# Filter form  --------- #}
     <ul class="collapsible">
@@ -103,15 +103,17 @@
 
     <ul class="pagination">
         <li class="{% if(current_page==1) %}disabled{% else %}waves-effect{% endif %}">
-            <a href="{% if(current_page==1) %}#!{% else %}{{ path("admin_membershipshiftexemption_index",{'page':current_page-1}) }}{% endif %}">
+            <a href="{% if(current_page==1) %}#!{% else %}{{ path("admin_membershipshiftexemption_index", {'page':current_page-1}) }}{% endif %}" data-page="{{ current_page-1 }}">
                 <i class="material-icons">chevron_left</i>
             </a>
         </li>
-        {% for i in range(1,max_page) %}
-            <li class="{% if(current_page==i) %}active{% else %}waves-effect{% endif %}"><a href="{{ path("admin_membershipshiftexemption_index",{'page':i}) }}">{{ i }}</a></li>
+        {% for i in range(1, page_count) %}
+            <li class="{% if(current_page==i) %}active{% else %}waves-effect{% endif %}">
+                <a href="#" data-page="{{ i }}">{{ i }}</a>
+            </li>
         {% endfor %}
-        <li class="{% if(current_page==max_page) %}disabled{% else %}waves-effect{% endif %}">
-            <a href="{% if(current_page==max_page) %}#!{% else %}{{ path("admin_membershipshiftexemption_index",{'page':current_page+1}) }}{% endif %}">
+        <li class="{% if(current_page==page_count) %}disabled{% else %}waves-effect{% endif %}">
+            <a href="{% if(current_page==page_count) %}#!{% else %}{{ path("admin_membershipshiftexemption_index", {'page':current_page+1}) }}{% endif %}" data-page="{{ current_page+1 }}">
                 <i class="material-icons">chevron_right</i>
             </a>
         </li>
@@ -124,4 +126,16 @@
             </a>
         </li>
     </ul>
+{% endblock %}
+
+{% block javascripts %}
+<script>
+    jQuery(function() {
+        $('.pagination li:not(.disabled) a').click(function(e) {
+            e.preventDefault();
+            $('#form_page').val($(this).data('page'));
+            $('form[name=form]').submit();
+        });
+    });
+</script>
 {% endblock %}

--- a/app/Resources/views/admin/shiftfreelog/index.html.twig
+++ b/app/Resources/views/admin/shiftfreelog/index.html.twig
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block content %}
-    <h4>Historique des annulations de créneaux ({{ shiftFreeLogs | length }})</h4>
+    <h4>Historique des annulations de créneaux ({{ result_count }})</h4>
 
     {# Filter form  --------- #}
     <ul class="collapsible">
@@ -58,6 +58,7 @@
                     </div>
                 </div>
                 {{ form_widget(filter_form.submit) }}
+                {{ form_row(filter_form.page) }}
                 {{ form_row(filter_form._token) }}
                 {{ form_end(filter_form, {'render_rest': false}) }}
             </div>
@@ -118,18 +119,31 @@
 
     <ul class="pagination">
         <li class="{% if(current_page==1) %}disabled{% else %}waves-effect{% endif %}">
-            <a href="{% if(current_page==1) %}#!{% else %}{{ path("admin_shiftfreelog_index",{'page':current_page-1}) }}{% endif %}">
+            <a href="{% if(current_page==1) %}#!{% else %}{{ path("admin_shiftfreelog_index", {'page':current_page-1}) }}{% endif %}" data-page="{{ current_page-1 }}">
                 <i class="material-icons">chevron_left</i>
             </a>
         </li>
-        {% for i in range(1,pages_count) %}
-        <li class="{% if(current_page==i) %}active{% else %}waves-effect{% endif %}"><a href="{{ path("admin_shiftfreelog_index",{'page':i}) }}">{{ i }}</a></li>
+        {% for i in range(1, page_count) %}
+            <li class="{% if(current_page==i) %}active{% else %}waves-effect{% endif %}">
+                <a href="#" data-page="{{ i }}">{{ i }}</a>
+            </li>
         {% endfor %}
-        <li class="{% if(current_page==pages_count) %}disabled{% else %}waves-effect{% endif %}">
-            <a href="{% if(current_page==pages_count) %}#!{% else %}{{ path("admin_shiftfreelog_index",{'page':current_page+1}) }}{% endif %}">
+        <li class="{% if(current_page==page_count) %}disabled{% else %}waves-effect{% endif %}">
+            <a href="{% if(current_page==page_count) %}#!{% else %}{{ path("admin_shiftfreelog_index", {'page':current_page+1}) }}{% endif %}" data-page="{{ current_page+1 }}">
                 <i class="material-icons">chevron_right</i>
             </a>
         </li>
     </ul>
+{% endblock %}
 
+{% block javascripts %}
+<script>
+    jQuery(function() {
+        $('.pagination li:not(.disabled) a').click(function(e) {
+            e.preventDefault();
+            $('#form_page').val($(this).data('page'));
+            $('form[name=form]').submit();
+        });
+    });
+</script>
 {% endblock %}

--- a/app/Resources/views/admin/user/list.html.twig
+++ b/app/Resources/views/admin/user/list.html.twig
@@ -10,7 +10,7 @@
 
 {% block content %}
     <div class="row center">
-        <h4 class="header">Liste des membres ({{ nb_of_result }})</h4>
+        <h4 class="header">Liste des membres ({{ result_count }})</h4>
     </div>
 
     <ul class="collapsible">
@@ -311,52 +311,52 @@
     </table>
 <div class="container">
     <div class="section">
-    {% if nb_of_pages > 1 %}
+    {% if page_count > 1 %}
     <ul class="pagination">
-        <li class="{% if(page==1) %}disabled{% else %}waves-effect{% endif %}">
-            <a href="{% if(page==1) %}#!{% else %}{{ path("user_index",{'page':page-1}) }}{% endif %}" data-page="{{ page-1 }}">
+        <li class="{% if(current_page==1) %}disabled{% else %}waves-effect{% endif %}">
+            <a href="{% if(current_page==1) %}#!{% else %}{{ path("user_index", {'page':current_page-1}) }}{% endif %}" data-page="{{ current_page-1 }}">
                 <i class="material-icons">chevron_left</i>
             </a>
         </li>
-        {% if nb_of_pages < 10 %}
-            {% for i in range(1,nb_of_pages) %}
-                <li class="{% if(page==i) %}active{% else %}waves-effect{% endif %}"><a href="#" data-page="{{ i }}">{{ i }}</a></li>
+        {% if page_count < 10 %}
+            {% for i in range(1, page_count) %}
+                <li class="{% if(current_page==i) %}active{% else %}waves-effect{% endif %}"><a href="#" data-page="{{ i }}">{{ i }}</a></li>
             {% endfor %}
         {% else %}
-            {% if page <= 3 %}
-                {% for i in range(1,page+1) %}
-                    <li class="{% if(page==i) %}active{% else %}waves-effect{% endif %}"><a href="#" data-page="{{ i }}">{{ i }}</a></li>
+            {% if current_page <= 3 %}
+                {% for i in range(1, current_page+1) %}
+                    <li class="{% if(current_page==i) %}active{% else %}waves-effect{% endif %}"><a href="#" data-page="{{ i }}">{{ i }}</a></li>
                 {% endfor %}
                 <li>...</li>
-                {% for i in range(nb_of_pages-1,nb_of_pages) %}
-                    <li class="{% if(page==i) %}active{% else %}waves-effect{% endif %}"><a href="#" data-page="{{ i }}">{{ i }}</a></li>
+                {% for i in range(page_count-1, page_count) %}
+                    <li class="{% if(current_page==i) %}active{% else %}waves-effect{% endif %}"><a href="#" data-page="{{ i }}">{{ i }}</a></li>
                 {% endfor %}
             {% else %}
-                {% if nb_of_pages - page <= 3 %}
-                    {% for i in range(1,2) %}
-                        <li class="{% if(page==i) %}active{% else %}waves-effect{% endif %}"><a href="#" data-page="{{ i }}">{{ i }}</a></li>
+                {% if page_count - current_page <= 3 %}
+                    {% for i in range(1, 2) %}
+                        <li class="{% if(current_page==i) %}active{% else %}waves-effect{% endif %}"><a href="#" data-page="{{ i }}">{{ i }}</a></li>
                     {% endfor %}
                     <li>...</li>
-                    {% for i in range(page-1,nb_of_pages) %}
-                        <li class="{% if(page==i) %}active{% else %}waves-effect{% endif %}"><a href="#" data-page="{{ i }}">{{ i }}</a></li>
+                    {% for i in range(current_page-1, page_count) %}
+                        <li class="{% if(current_page==i) %}active{% else %}waves-effect{% endif %}"><a href="#" data-page="{{ i }}">{{ i }}</a></li>
                     {% endfor %}
                 {% else %}
-                    {% for i in range(1,2) %}
-                    <li class="{% if(page==i) %}active{% else %}waves-effect{% endif %}"><a href="#" data-page="{{ i }}">{{ i }}</a></li>
+                    {% for i in range(1, 2) %}
+                    <li class="{% if(current_page==i) %}active{% else %}waves-effect{% endif %}"><a href="#" data-page="{{ i }}">{{ i }}</a></li>
                     {% endfor %}
                     <li>...</li>
-                    {% for i in range(page-1,page+1) %}
-                        <li class="{% if(page==i) %}active{% else %}waves-effect{% endif %}"><a href="#" data-page="{{ i }}">{{ i }}</a></li>
+                    {% for i in range(current_page-1, current_page+1) %}
+                        <li class="{% if(current_page==i) %}active{% else %}waves-effect{% endif %}"><a href="#" data-page="{{ i }}">{{ i }}</a></li>
                     {% endfor %}
                     <li>...</li>
-                    {% for i in range(nb_of_pages-1,nb_of_pages) %}
-                        <li class="{% if(page==i) %}active{% else %}waves-effect{% endif %}"><a href="#" data-page="{{ i }}">{{ i }}</a></li>
+                    {% for i in range(page_count-1, page_count) %}
+                        <li class="{% if(current_page==i) %}active{% else %}waves-effect{% endif %}"><a href="#" data-page="{{ i }}">{{ i }}</a></li>
                     {% endfor %}
                 {% endif %}
             {% endif %}
         {% endif %}
-        <li class="{% if(page==nb_of_pages) %}disabled{% else %}waves-effect{% endif %}">
-            <a href="{% if(page==nb_of_pages) %}#!{% else %}{{ path("user_index",{'page':page+1}) }}{% endif %}" data-page="{{ page+1}}">
+        <li class="{% if(current_page==page_count) %}disabled{% else %}waves-effect{% endif %}">
+            <a href="{% if(current_page==page_count) %}#!{% else %}{{ path("user_index", {'page':current_page+1}) }}{% endif %}" data-page="{{ current_page+1 }}">
                 <i class="material-icons">chevron_right</i>
             </a>
         </li>

--- a/app/Resources/views/ambassador/phone/list.html.twig
+++ b/app/Resources/views/ambassador/phone/list.html.twig
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block content %}
-    <h4>Liste des membres en retard {{ reason }} ({{ nb_of_result }})</h4>
+    <h4>Liste des membres en retard {{ reason }} ({{ result_count }})</h4>
 
     <ul class="collapsible">
         <li>
@@ -193,20 +193,20 @@
         </tbody>
     </table>
 
-    {% if nb_of_pages > 1 %}
+    {% if page_count > 1 %}
         <ul class="pagination">
-            <li class="{% if(page==1) %}disabled{% else %}waves-effect{% endif %}">
-                <a href="#" data-page="{{ page-1 }}">
+            <li class="{% if(current_page==1) %}disabled{% else %}waves-effect{% endif %}">
+                <a href="#" data-page="{{ current_page-1 }}">
                     <i class="material-icons">chevron_left</i>
                 </a>
             </li>
-            {% for i in range(1,nb_of_pages) %}
-                <li class="{% if(page==i) %}active{% else %}waves-effect{% endif %}">
+            {% for i in range(1, page_count) %}
+                <li class="{% if(current_page==i) %}active{% else %}waves-effect{% endif %}">
                     <a href="#" data-page="{{ i }}">{{ i }}</a>
                 </li>
             {% endfor %}
-            <li class="{% if(page==nb_of_pages) %}disabled{% else %}waves-effect{% endif %}">
-                <a href="#" data-page="{{ page+1 }}">
+            <li class="{% if(current_page==page_count) %}disabled{% else %}waves-effect{% endif %}">
+                <a href="#" data-page="{{ current_page+1 }}">
                     <i class="material-icons">chevron_right</i>
                 </a>
             </li>

--- a/app/Resources/views/registrations/list.html.twig
+++ b/app/Resources/views/registrations/list.html.twig
@@ -160,32 +160,32 @@
         <br>
         <ul class="pagination">
             {% if to is not null %}
-                <li class="{% if(page==1) %}disabled{% else %}waves-effect{% endif %}">
-                    <a href="{% if(page==1) %}#!{% else %}{{ path("registrations",{'page':page-1,'from':(from | date('Y-m-d')),'to':(to | date('Y-m-d'))}) }}{% endif %}">
+                <li class="{% if(current_page==1) %}disabled{% else %}waves-effect{% endif %}">
+                    <a href="{% if(current_page==1) %}#!{% else %}{{ path("registrations",{'page':current_page-1,'from':(from | date('Y-m-d')),'to':(to | date('Y-m-d'))}) }}{% endif %}">
                         <i class="material-icons">chevron_left</i>
                     </a>
                 </li>
-                {% for i in range(1,nb_of_pages) %}
-                    <li class="{% if(page==i) %}active{% else %}waves-effect{% endif %}"><a
+                {% for i in range(1, page_count) %}
+                    <li class="{% if(current_page==i) %}active{% else %}waves-effect{% endif %}"><a
                                 href="{{ path("registrations",{'page':i,'from':(from | date('Y-m-d')),'to':(to | date('Y-m-d'))}) }}">{{ i }}</a></li>
                 {% endfor %}
-                <li class="{% if(page==nb_of_pages) %}disabled{% else %}waves-effect{% endif %}">
-                    <a href="{% if(page==nb_of_pages) %}#!{% else %}{{ path("registrations",{'page':page+1,'from':(from | date('Y-m-d')),'to':(to | date('Y-m-d'))}) }}{% endif %}">
+                <li class="{% if(page==page_count) %}disabled{% else %}waves-effect{% endif %}">
+                    <a href="{% if(page==page_count) %}#!{% else %}{{ path("registrations",{'page':current_page+1,'from':(from | date('Y-m-d')),'to':(to | date('Y-m-d'))}) }}{% endif %}">
                         <i class="material-icons">chevron_right</i>
                     </a>
                 </li>
             {% else %}
-                <li class="{% if(page==1) %}disabled{% else %}waves-effect{% endif %}">
-                    <a href="{% if(page==1) %}#!{% else %}{{ path("registrations",{'page':page-1,'from':(from | date('Y-m-d'))}) }}{% endif %}">
+                <li class="{% if(current_page==1) %}disabled{% else %}waves-effect{% endif %}">
+                    <a href="{% if(current_page==1) %}#!{% else %}{{ path("registrations",{'page':current_page-1,'from':(from | date('Y-m-d'))}) }}{% endif %}">
                         <i class="material-icons">chevron_left</i>
                     </a>
                 </li>
-                {% for i in range(1,nb_of_pages) %}
-                    <li class="{% if(page==i) %}active{% else %}waves-effect{% endif %}"><a
+                {% for i in range(1, page_count) %}
+                    <li class="{% if(current_page==i) %}active{% else %}waves-effect{% endif %}"><a
                                 href="{{ path("registrations",{'page':i,'from':(from | date('Y-m-d'))}) }}">{{ i }}</a></li>
                 {% endfor %}
-                <li class="{% if(page==nb_of_pages) %}disabled{% else %}waves-effect{% endif %}">
-                    <a href="{% if(page==nb_of_pages) %}#!{% else %}{{ path("registrations",{'page':page+1,'from':(from | date('Y-m-d'))}) }}{% endif %}">
+                <li class="{% if(current_page==page_count) %}disabled{% else %}waves-effect{% endif %}">
+                    <a href="{% if(current_page==page_count) %}#!{% else %}{{ path("registrations",{'page':current_page+1,'from':(from | date('Y-m-d'))}) }}{% endif %}">
                         <i class="material-icons">chevron_right</i>
                     </a>
                 </li>

--- a/src/AppBundle/Controller/AdminController.php
+++ b/src/AppBundle/Controller/AdminController.php
@@ -130,9 +130,9 @@ class AdminController extends Controller
         } else {
             $limitPerPage = 25;
             $paginator = new Paginator($qb);
-            $totalItems = count($paginator);
-            $pagesCount = ($totalItems == 0) ? 1 : ceil($totalItems / $limitPerPage);
-            $currentPage = ($currentPage > $pagesCount) ? $pagesCount : $currentPage;
+            $resultCount = count($paginator);
+            $pageCount = ($resultCount == 0) ? 1 : ceil($resultCount / $limitPerPage);
+            $currentPage = ($currentPage > $pageCount) ? $pageCount : $currentPage;
 
             $paginator
                 ->getQuery()
@@ -143,9 +143,9 @@ class AdminController extends Controller
         return $this->render('admin/user/list.html.twig', array(
             'members' => $paginator,
             'form' => $form->createView(),
-            'nb_of_result' => $totalItems,
-            'page' => $currentPage,
-            'nb_of_pages' => $pagesCount
+            'result_count' => $resultCount,
+            'current_page' => $currentPage,
+            'page_count' => $pageCount
         ));
     }
 

--- a/src/AppBundle/Controller/AmbassadorController.php
+++ b/src/AppBundle/Controller/AmbassadorController.php
@@ -20,7 +20,7 @@ use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Validator\Constraints\DateTime;
 
 /**
- * Task controller.
+ * Ambassador controller.
  *
  * @Route("ambassador")
  */
@@ -77,9 +77,9 @@ class AmbassadorController extends Controller
         $limitPerPage = 25;
         $qb = $qb->orderBy($sort, $order);
         $paginator = new Paginator($qb);
-        $totalItems = count($paginator);
-        $pagesCount = ($totalItems == 0) ? 1 : ceil($totalItems / $limitPerPage);
-        $currentPage = ($currentPage > $pagesCount) ? $pagesCount : $currentPage;
+        $resultCount = count($paginator);
+        $pageCount = ($resultCount == 0) ? 1 : ceil($resultCount / $limitPerPage);
+        $currentPage = ($currentPage > $pageCount) ? $pageCount : $currentPage;
 
         $paginator
             ->getQuery()
@@ -90,9 +90,9 @@ class AmbassadorController extends Controller
             'reason' => "adhésion",
             'members' => $paginator,
             'form' => $form->createView(),
-            'nb_of_result' => $totalItems,
-            'page' => $currentPage,
-            'nb_of_pages' => $pagesCount
+            'result_count' => $resultCount,
+            'current_page' => $currentPage,
+            'page_count' => $pageCount
         ));
     }
 
@@ -149,9 +149,9 @@ class AmbassadorController extends Controller
         $limitPerPage = 25;
         $qb = $qb->orderBy($sort, $order);
         $paginator = new Paginator($qb);
-        $totalItems = count($paginator);
-        $pagesCount = ($totalItems == 0) ? 1 : ceil($totalItems / $limitPerPage);
-        $currentPage = ($currentPage > $pagesCount) ? $pagesCount : $currentPage;
+        $resultCount = count($paginator);
+        $pageCount = ($resultCount == 0) ? 1 : ceil($resultCount / $limitPerPage);
+        $currentPage = ($currentPage > $pageCount) ? $pageCount : $currentPage;
 
         $paginator
             ->getQuery()
@@ -162,9 +162,9 @@ class AmbassadorController extends Controller
             'reason' => "de ré-adhésion",
             'members' => $paginator,
             'form' => $form->createView(),
-            'nb_of_result' => $totalItems,
-            'page' => $currentPage,
-            'nb_of_pages' => $pagesCount
+            'result_count' => $resultCount,
+            'current_page' => $currentPage,
+            'page_count' => $pageCount
         ));
     }
 
@@ -216,9 +216,9 @@ class AmbassadorController extends Controller
         $limitPerPage = 25;
         $qb = $qb->orderBy($sort, $order);
         $paginator = new Paginator($qb);
-        $totalItems = count($paginator);
-        $pagesCount = ($totalItems == 0) ? 1 : ceil($totalItems / $limitPerPage);
-        $currentPage = ($currentPage > $pagesCount) ? $pagesCount : $currentPage;
+        $resultCount = count($paginator);
+        $pageCount = ($resultCount == 0) ? 1 : ceil($resultCount / $limitPerPage);
+        $currentPage = ($currentPage > $pageCount) ? $pageCount : $currentPage;
 
         $paginator
             ->getQuery()
@@ -229,9 +229,9 @@ class AmbassadorController extends Controller
             'reason' => "de créneaux",
             'members' => $paginator,
             'form' => $form->createView(),
-            'nb_of_result' => $totalItems,
-            'page' => $currentPage,
-            'nb_of_pages' => $pagesCount
+            'result_count' => $resultCount,
+            'current_page' => $currentPage,
+            'page_count' => $pageCount
         ));
     }
 

--- a/src/AppBundle/Controller/HelloassoController.php
+++ b/src/AppBundle/Controller/HelloassoController.php
@@ -105,7 +105,7 @@ class HelloassoController extends Controller
                 $session->getFlashBag()->add('error','campaign not found');
                 return $this->redirectToRoute('helloasso_browser');
             }
-            $payments_json = $this->container->get('AppBundle\Helper\Helloasso')->get('campaigns/' . $campaignId . '/payments', array('page' => $page));
+            $payments_json = $this->container->get('AppBundle\Helper\Helloasso')->get('campaigns/' . $campaignId . '/payments', array('page' => $currentPage));
             $currentPage = $payments_json->pagination->page;
             $page_count = $payments_json->pagination->max_page;
             $results_per_page = $payments_json->pagination->results_per_page;

--- a/src/AppBundle/Controller/MembershipShiftExemptionController.php
+++ b/src/AppBundle/Controller/MembershipShiftExemptionController.php
@@ -96,7 +96,7 @@ class MembershipShiftExemptionController extends Controller
                 ->setParameter('shiftExemption', $filter['shiftExemption']);
         }
 
-        $limitPerPage = 1;
+        $limitPerPage = 25;
         $paginator = new Paginator($qb);
         $resultCount = count($paginator);
         $pageCount = ($resultCount == 0) ? 1 : ceil($resultCount / $limitPerPage);

--- a/src/AppBundle/Controller/MembershipShiftExemptionController.php
+++ b/src/AppBundle/Controller/MembershipShiftExemptionController.php
@@ -11,8 +11,10 @@ use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
+use Doctrine\ORM\Tools\Pagination\Paginator;
 use \Datetime;
 
 /**
@@ -31,6 +33,7 @@ class MembershipShiftExemptionController extends Controller
         $res = [
             "membership" => null,
             "shiftExemption" => null,
+            'page' => 1,
         ];
 
         // filter creation ----------------------
@@ -47,6 +50,9 @@ class MembershipShiftExemptionController extends Controller
                 'multiple' => false,
                 'required' => false,
             ))
+            ->add('page', HiddenType::class, [
+                'data' => '1'
+            ])
             ->add('submit', SubmitType::class, array(
                 'label' => 'Filtrer',
                 'attr' => array('class' => 'btn', 'value' => 'filtrer')
@@ -58,6 +64,7 @@ class MembershipShiftExemptionController extends Controller
         if ($res['form']->isSubmitted() && $res['form']->isValid()) {
             $res["membership"] = $res["form"]->get("membership")->getData();
             $res["shiftExemption"] = $res["form"]->get("shiftExemption")->getData();
+            $res["page"] = $res["form"]->get("page")->getData();
         }
 
         return $res;
@@ -77,31 +84,36 @@ class MembershipShiftExemptionController extends Controller
         $sort = 'createdAt';
         $order = 'DESC';
 
+        $qb = $em->getRepository('AppBundle:MembershipShiftExemption')->createQueryBuilder('mse')
+            ->orderBy('mse.' . $sort, $order);
+
         if ($filter['membership']) {
-            $findByFilter['membership'] = $filter['membership'];
+            $qb = $qb->andWhere('mse.membership = :membership')
+                ->setParameter('membership', $filter['membership']);
         }
         if ($filter['shiftExemption']) {
-            $findByFilter['shiftExemption'] = $filter['shiftExemption'];
+            $qb = $qb->andWhere('mse.shiftExemption = :shiftExemption')
+                ->setParameter('shiftExemption', $filter['shiftExemption']);
         }
 
-        $page = $request->get('page', 1);
-        $limit = 50;
+        $limitPerPage = 1;
+        $paginator = new Paginator($qb);
+        $resultCount = count($paginator);
+        $pageCount = ($resultCount == 0) ? 1 : ceil($resultCount / $limitPerPage);
+        $currentPage = $filter['page'];
+        $currentPage = ($currentPage > $pageCount) ? $pageCount : $currentPage;
 
-        $nb_exemptions = $em->getRepository('AppBundle:MembershipShiftExemption')->count([]);
-        if ($nb_exemptions == 0) {
-            $max_page = 1;
-        } else {
-            $max_page = intval(($nb_exemptions-1) / $limit) + 1;
-        }
-
-        $membershipShiftExemptions = $em->getRepository('AppBundle:MembershipShiftExemption')
-            ->findBy($findByFilter, array($sort => $order), $limit, ($page - 1) * $limit);
+        $paginator
+            ->getQuery()
+            ->setFirstResult($limitPerPage * ($currentPage-1)) // set the offset
+            ->setMaxResults($limitPerPage); // set the limit
 
         return $this->render('admin/membershipshiftexemption/index.html.twig', array(
-            'membershipShiftExemptions' => $membershipShiftExemptions,
+            'membershipShiftExemptions' => $paginator,
             'filter_form' => $filter['form']->createView(),
-            'current_page' => $page,
-            'max_page' => $max_page,
+            'result_count' => $resultCount,
+            'current_page' => $currentPage,
+            'page_count' => $pageCount,
         ));
     }
 

--- a/src/AppBundle/Controller/RegistrationsController.php
+++ b/src/AppBundle/Controller/RegistrationsController.php
@@ -90,8 +90,8 @@ class RegistrationsController extends Controller
 
 
         $em = $this->getDoctrine()->getManager();
-        if (!($page = $request->get('page')))
-            $page = 1;
+        if (!($currentPage = $request->get('page')))
+            $currentPage = 1;
         $limit = 25;
         $qb = $em->createQueryBuilder()->from('AppBundle\Entity\AbstractRegistration', 'r')
             ->select('count(r.id)')
@@ -103,8 +103,8 @@ class RegistrationsController extends Controller
 
         $max = $qb->getQuery()
             ->getSingleScalarResult();
-        $nb_of_pages = intval($max / $limit);
-        $nb_of_pages += (($max % $limit) > 0) ? 1 : 0;
+        $pageCount = intval($max / $limit);
+        $pageCount += (($max % $limit) > 0) ? 1 : 0;
         $repository = $em->getRepository('AppBundle:AbstractRegistration');
         $queryb = $repository->createQueryBuilder('r')
             ->where('r.date >= :from')
@@ -113,7 +113,7 @@ class RegistrationsController extends Controller
             $queryb = $queryb->andwhere('r.date <= :to')->setParameter('to', $to);
         }
         $queryb = $queryb->orderBy('r.date', 'DESC')
-            ->setFirstResult(($page - 1) * $limit)
+            ->setFirstResult(($currentPage - 1) * $limit)
             ->setMaxResults($limit);
 
         $registrations = $queryb->getQuery()->getResult();
@@ -181,10 +181,10 @@ WHERE date >= :from ".(($to) ? "AND date <= :to" : "").";");
                 'grand_total' => $grand_total,
                 'totaux' => $totaux,
                 'delete_forms' => $delete_forms,
-                'page' => $page,
                 'from' => $from,
                 'to' => $to,
-                'nb_of_pages' => $nb_of_pages));
+                'current_page' => $currentPage,
+                'page_count' => $pageCount));
     }
 
     /**

--- a/src/AppBundle/Controller/ShiftFreeLogController.php
+++ b/src/AppBundle/Controller/ShiftFreeLogController.php
@@ -33,7 +33,8 @@ class ShiftFreeLogController extends Controller
             'created_at' => null,
             'shift_start_date' => null,
             'beneficiary' => null,
-            'fixe' => 0
+            'fixe' => 0,
+            'page' => 1,
         ];
 
         // filter creation ----------------------
@@ -129,7 +130,7 @@ class ShiftFreeLogController extends Controller
         $paginator = new Paginator($qb);
         $resultCount = count($paginator);
         $pageCount = ($resultCount == 0) ? 1 : ceil($resultCount / $limitPerPage);
-        $currentPage = isset($filter['page']) ? $filter['page'] : 1;
+        $currentPage = $filter['page'];
         $currentPage = ($currentPage > $pageCount) ? $pageCount : $currentPage;
 
         $paginator

--- a/src/AppBundle/Controller/ShiftFreeLogController.php
+++ b/src/AppBundle/Controller/ShiftFreeLogController.php
@@ -12,6 +12,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Doctrine\ORM\Tools\Pagination\Paginator;
 
@@ -68,6 +69,9 @@ class ShiftFreeLogController extends Controller
                     'volant' => 1,
                 ]
             ))
+            ->add('page', HiddenType::class, [
+                'data' => '1'
+            ])
             ->add('submit', SubmitType::class, array(
                 'label' => 'Filtrer',
                 'attr' => array('class' => 'btn', 'value' => 'filtrer')
@@ -81,6 +85,7 @@ class ShiftFreeLogController extends Controller
             $res["shift_start_date"] = $res["form"]->get("shift_start_date")->getData();
             $res["beneficiary"] = $res["form"]->get("beneficiary")->getData();
             $res["fixe"] = $res["form"]->get("fixe")->getData();
+            $res["page"] = $res["form"]->get("page")->getData();
         }
 
         return $res;
@@ -122,10 +127,10 @@ class ShiftFreeLogController extends Controller
 
         $limitPerPage = 25;
         $paginator = new Paginator($qb);
-        $totalItems = count($paginator);
-        $pagesCount = ($totalItems == 0) ? 1 : ceil($totalItems / $limitPerPage);
-        $currentPage = $request->get('page', 1);
-        $currentPage = ($currentPage > $pagesCount) ? $pagesCount : $currentPage;
+        $resultCount = count($paginator);
+        $pageCount = ($resultCount == 0) ? 1 : ceil($resultCount / $limitPerPage);
+        $currentPage = isset($filter['page']) ? $filter['page'] : 1;
+        $currentPage = ($currentPage > $pageCount) ? $pageCount : $currentPage;
 
         $paginator
             ->getQuery()
@@ -135,9 +140,9 @@ class ShiftFreeLogController extends Controller
         return $this->render('admin/shiftfreelog/index.html.twig', array(
             'shiftFreeLogs' => $paginator,
             'filter_form' => $filter['form']->createView(),
+            'result_count' => $resultCount,
             'current_page' => $currentPage,
-            'pages_count' => $pagesCount,
+            'page_count' => $pageCount,
         ));
     }
-
 }


### PR DESCRIPTION
### Quoi ?

Homogénéisé l'usage de la pagination dans certains controlleurs : 
- controlleurs concernés : `AdminController`, `ShiftFreeLog`, `MembershipShiftExemption`, `HelloassoController`, `RegistrationController`, `AmbassadorController`
- généraliser l'usage de `page_count` ; `result_count` ; `current_page`

### Informations supplémentaires

- i'ai essayé au début de sortir le `<ul class="pagination"` dans un template dédié et l'importer là où l'on en a besoin, mais ça semble être plus compliqué qu'imaginais... il y a du js, des route qui changent, et des fonctionnement légèrement différent
- la pagination reste "simpliste" dans la plupart des cas, si il y a 50 pages ca les affiche tous (sauf sur "Liste des membres" qui a des règles évoluées / complexes)