### PR TITLE
E-mail de confirmation lors de la libération d'un créneau

### DIFF
--- a/app/Resources/views/admin/content/list.html.twig
+++ b/app/Resources/views/admin/content/list.html.twig
@@ -21,8 +21,8 @@
                             <span class="card-title"><i class="material-icons left">content_paste</i>{{ dynamicContent.name }}</span>
                             {{ dynamicContent.description }}
                             {% if dynamicContent.updatedBy %}
-                                <br >
-                                <br >
+                                <br />
+                                <br />
                                 <i>Dernière modification le {{ dynamicContent.updatedAt | date('d/m/Y H:i') }} par {{ dynamicContent.updatedBy }}</i>
                             {% endif %}
                         </div>

--- a/app/Resources/views/emails/cycle_half.html.twig
+++ b/app/Resources/views/emails/cycle_half.html.twig
@@ -1,9 +1,8 @@
-Bonjour {{ membership.mainBeneficiary.firstname | lower | capitalize }},<br >
-<br >
-Ton cycle a commencé il y a 14 jours déjà !<br >
+Bonjour {{ membership.mainBeneficiary.firstname | lower | capitalize }},<br />
+<br />
+Ton cycle a commencé il y a 14 jours déjà !<br />
 Il ne te reste donc que 2 semaines pour effectuer ton bénévolat.
-Tu passes faire un tour sur <a href="{{ home_url }}">ton espace membre</a> pour trouver le créneau qui te convient le mieux ?<br >
-<br >
-Merci<br >
-<br >
+Tu passes faire un tour sur <a href="{{ home_url }}">ton espace membre</a> pour trouver le créneau qui te convient le mieux ?<br />
+<br />
+Merci, et belle journée à toi.<br />
 Céleste, la petite fée des créneaux :)

--- a/app/Resources/views/emails/cycle_start.html.twig
+++ b/app/Resources/views/emails/cycle_start.html.twig
@@ -1,11 +1,12 @@
-Bonjour {{ beneficiary.firstname | lower | capitalize }},<br >
-<br >
+Bonjour {{ beneficiary.firstname | lower | capitalize }},<br />
+<br />
 {% if beneficiary.membership.beneficiaries | length %}
-Votre nouveau cycle commence aujourd'hui.<br >
-Pensez à aller sur <a href="{{ home_url }}">votre espace membre</a> pour réserver vos créneaux.<br >{% else %}
-Ton nouveau cycle commence aujourd'hui.<br >
-Pense à aller sur <a href="{{ home_url }}">ton espace membre</a> pour réserver tes créneaux.<br >{% endif %}
-<br >
-Merci<br >
-<br >
+Votre nouveau cycle commence aujourd'hui.<br />
+Pensez à aller sur <a href="{{ home_url }}">votre espace membre</a> pour réserver vos créneaux.<br />
+{% else %}
+Ton nouveau cycle commence aujourd'hui.<br />
+Pense à aller sur <a href="{{ home_url }}">ton espace membre</a> pour réserver tes créneaux.<br />
+{% endif %}
+<br />
+Merci, et belle journée à toi.<br />
 Céleste, la petite fée des créneaux :)

--- a/app/Resources/views/emails/shift_deleted.html.twig
+++ b/app/Resources/views/emails/shift_deleted.html.twig
@@ -1,4 +1,4 @@
 Bonjour {{ shift.shifter.firstname | lower | capitalize }},<br />
 le créneau {{ shift.job.name }} du {{ shift.start | date('d/m/Y') }} de {{ shift.start | date('G\\hi') }} à {{ shift.end | date('G\\hi') }}<br />
 que tu avais reservé le {{ shift.bookedTime | date('d/m/Y à H:i') }} à été supprimé.<br />
-Rendez-vous sur <a href="{{ absolute_url(path("homepage")) }}">ton espace membre</a> pour un reserver un nouveau.
+Rendez-vous sur <a href="{{ absolute_url(path("homepage")) }}">ton espace membre</a> pour en reserver un nouveau.

--- a/app/Resources/views/emails/shift_deleted.html.twig
+++ b/app/Resources/views/emails/shift_deleted.html.twig
@@ -1,4 +1,9 @@
-Bonjour {{ beneficiary.firstname | lower | capitalize }},<br >
-le créneau {{ shift.job.name }} du {{ shift.start | date('d/m/Y') }} de {{ shift.start | date('G\\hi') }} à {{ shift.end | date('G\\hi') }}<br />
+Bonjour {{ beneficiary.firstname | lower | capitalize }},<br />
+<br />
+le créneau {{ shift.job.name }} du {{ shift.start | date('d/m/Y') }} de {{ shift.start | date('G\\hi') }} à {{ shift.end | date('G\\hi') }}
 que tu avais reservé à été supprimé.<br />
+<br />
 Rendez-vous sur <a href="{{ absolute_url(path("homepage")) }}">ton espace membre</a> pour en reserver un nouveau.
+<br />
+Belle journée à toi.<br />
+Céleste, la petite fée des créneaux :)

--- a/app/Resources/views/emails/shift_freed.html.twig
+++ b/app/Resources/views/emails/shift_freed.html.twig
@@ -1,4 +1,9 @@
-Bonjour {{ beneficiary.firstname | lower | capitalize }},<br >
-le créneau {{ shift.job.name }} du {{ shift.start | date('d/m/Y') }} de {{ shift.start | date('G\\hi') }} à {{ shift.end | date('G\\hi') }}<br />
+Bonjour {{ beneficiary.firstname | lower | capitalize }},<br />
+<br />
+le créneau {{ shift.job.name }} du {{ shift.start | date('d/m/Y') }} de {{ shift.start | date('G\\hi') }} à {{ shift.end | date('G\\hi') }}
 que tu avais reservé à été libéré.<br />
-Rendez-vous sur <a href="{{ absolute_url(path("homepage")) }}">ton espace membre</a> pour en reserver un nouveau.
+<br />
+Rendez-vous sur <a href="{{ absolute_url(path("homepage")) }}">ton espace membre</a> pour en reserver un nouveau.<br />
+<br />
+Belle journée à toi.<br />
+Céleste, la petite fée des créneaux :)

--- a/app/Resources/views/emails/shift_freed.html.twig
+++ b/app/Resources/views/emails/shift_freed.html.twig
@@ -1,4 +1,4 @@
 Bonjour {{ beneficiary.firstname | lower | capitalize }},<br >
 le créneau {{ shift.job.name }} du {{ shift.start | date('d/m/Y') }} de {{ shift.start | date('G\\hi') }} à {{ shift.end | date('G\\hi') }}<br />
-que tu avais reservé à été supprimé.<br />
+que tu avais reservé à été libéré.<br />
 Rendez-vous sur <a href="{{ absolute_url(path("homepage")) }}">ton espace membre</a> pour en reserver un nouveau.

--- a/app/Resources/views/emails/shift_reserved.html.twig
+++ b/app/Resources/views/emails/shift_reserved.html.twig
@@ -1,15 +1,15 @@
-Bonjour {{ shift.lastShifter.firstname | lower | capitalize }},<br >
-<br >
-Tu viens de réaliser un créneau à l'épicerie, merci de rendre possible notre projet.<br >
-Nous te proposons de reprendre le même créneau dans {{ days }} jours, soit le {{ shift.start | date_fr_full }} de {{ shift.start | date('G\\hi') }} à {{ shift.end | date('G\\hi') }}.<br >
-Tu es prioritaire sur ce créneau pendant 7 jours, ensuite il deviendra disponible à la réservation pour les autres membres.<br >
-<br >
-Merci de nous indiquer si tu souhaites le reprendre :<br >
+Bonjour {{ shift.lastShifter.firstname | lower | capitalize }},<br />
+<br />
+Tu viens de réaliser un créneau à l'épicerie, merci de rendre possible notre projet.<br />
+Nous te proposons de reprendre le même créneau dans {{ days }} jours, soit le {{ shift.start | date_fr_full }} de {{ shift.start | date('G\\hi') }} à {{ shift.end | date('G\\hi') }}.<br />
+Tu es prioritaire sur ce créneau pendant 7 jours, ensuite il deviendra disponible à la réservation pour les autres membres.<br />
+<br />
+Merci de nous indiquer si tu souhaites le reprendre :<br />
 
 <a href="{{ accept_url }}" style="-webkit-box-sizing:inherit;box-sizing:inherit;-webkit-box-shadow:0 2px 2px 0 rgba(0,0,0,0.14),0 1px 5px 0 rgba(0,0,0,0.12),0 3px 1px -2px rgba(0,0,0,0.2);box-shadow:0 2px 2px 0 rgba(0,0,0,0.14),0 1px 5px 0 rgba(0,0,0,0.12),0 3px 1px -2px rgba(0,0,0,0.2);border-style:none;border-radius:2px;height:36px;line-height:36px;padding-top:0;padding-bottom:0;padding-right:2rem;padding-left:2rem;text-transform:uppercase;font-size:1rem;outline-color:0;text-decoration:none;text-align:center;letter-spacing:.5px;position:relative;cursor:pointer;display:inline-block;overflow:hidden;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none;-webkit-tap-highlight-color:transparent;vertical-align:middle;z-index:1;-webkit-transition:.3s ease-out;transition:.3s ease-out;background-color:#4CAF50 !important;margin-bottom:5px;color:white;" >J'accepte</a>
 <a href="{{ reject_url }}" style="-webkit-box-sizing:inherit;box-sizing:inherit;-webkit-box-shadow:0 2px 2px 0 rgba(0,0,0,0.14),0 1px 5px 0 rgba(0,0,0,0.12),0 3px 1px -2px rgba(0,0,0,0.2);box-shadow:0 2px 2px 0 rgba(0,0,0,0.14),0 1px 5px 0 rgba(0,0,0,0.12),0 3px 1px -2px rgba(0,0,0,0.2);border-style:none;border-radius:2px;height:36px;line-height:36px;padding-top:0;padding-bottom:0;padding-right:2rem;padding-left:2rem;text-transform:uppercase;font-size:1rem;outline-color:0;text-decoration:none;text-align:center;letter-spacing:.5px;position:relative;cursor:pointer;display:inline-block;overflow:hidden;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none;-webkit-tap-highlight-color:transparent;vertical-align:middle;z-index:1;-webkit-transition:.3s ease-out;transition:.3s ease-out;background-color:#ff9800 !important;margin-bottom:5px;color:white;" >Je refuse</a>
-<br >
-Il n'est pas nécessaire de répondre à ce mail, sauf si tu as des questions.<br >
-<br >
-Belle journée à toi.<br >
+<br />
+Il n'est pas nécessaire de répondre à ce mail, sauf si tu as des questions.<br />
+<br />
+Belle journée à toi.<br />
 Céleste, la petite fée des créneaux :)

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -155,7 +155,7 @@ services:
             tags:
                 - { name: kernel.event_listener, event: code.new, method: onCodeNew }
                 - { name: kernel.event_listener, event: shift.booked, method: onShiftBooked }
-                - { name: kernel.event_listener, event: shift.booked, method: onShiftFreed }
+                - { name: kernel.event_listener, event: shift.freed, method: onShiftFreed }
                 - { name: kernel.event_listener, event: shift.deleted, method: onShiftDeleted }
                 - { name: kernel.event_listener, event: member.cycle.start, method: onMemberCycleStart }
                 - { name: kernel.event_listener, event: member.cycle.half, method: onMemberCycleHalf }

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -155,6 +155,7 @@ services:
             tags:
                 - { name: kernel.event_listener, event: code.new, method: onCodeNew }
                 - { name: kernel.event_listener, event: shift.booked, method: onShiftBooked }
+                - { name: kernel.event_listener, event: shift.booked, method: onShiftFreed }
                 - { name: kernel.event_listener, event: shift.deleted, method: onShiftDeleted }
                 - { name: kernel.event_listener, event: member.cycle.start, method: onMemberCycleStart }
                 - { name: kernel.event_listener, event: member.cycle.half, method: onMemberCycleHalf }

--- a/src/AppBundle/EventListener/EmailingEventListener.php
+++ b/src/AppBundle/EventListener/EmailingEventListener.php
@@ -223,11 +223,12 @@ class EmailingEventListener
         $this->logger->info("Emailing Listener: onShiftBooked");
 
         $shift = $event->getShift();
+        $beneficiary = $shift->getShifter();
 
         // send a "confirmation" e-mail to the beneficiary
         $confirmation = (new \Swift_Message('[ESPACE MEMBRES] Réservation de ton créneau confirmée'))
             ->setFrom($this->shiftEmail['address'], $this->shiftEmail['from_name'])
-            ->setTo($shift->getShifter()->getEmail())
+            ->setTo($beneficiary->getEmail())
             ->setBody(
                 $this->renderView(
                     'emails/shift_booked_confirmation.html.twig',
@@ -241,7 +242,7 @@ class EmailingEventListener
         $archive = (new \Swift_Message('[ESPACE MEMBRES] BOOKING'))
             ->setFrom($this->shiftEmail['address'], $this->shiftEmail['from_name'])
             ->setTo($this->shiftEmail['address'])
-            ->setReplyTo($shift->getShifter()->getEmail())
+            ->setReplyTo($beneficiary->getEmail())
             ->setBody(
                 $this->renderView(
                     'emails/shift_booked_archive.html.twig',
@@ -263,7 +264,7 @@ class EmailingEventListener
         $shift = $event->getShift();
         $beneficiary = $event->getBeneficiary();
 
-        if ($beneficiary) { // warn shifter
+        if ($beneficiary) { // warn beneficiary
             $warn = (new \Swift_Message('[ESPACE MEMBRES] Crénéau libéré'))
                 ->setFrom($this->shiftEmail['address'], $this->shiftEmail['from_name'])
                 ->setTo($beneficiary->getEmail())
@@ -292,7 +293,7 @@ class EmailingEventListener
         $shift = $event->getShift();
         $beneficiary = $event->getBeneficiary();
 
-        if ($beneficiary) { // warn shifter
+        if ($beneficiary) { // warn beneficiary
             $warn = (new \Swift_Message('[ESPACE MEMBRES] Crénéau supprimé'))
                 ->setFrom($this->shiftEmail['address'], $this->shiftEmail['from_name'])
                 ->setTo($beneficiary->getEmail())

--- a/src/AppBundle/EventListener/EmailingEventListener.php
+++ b/src/AppBundle/EventListener/EmailingEventListener.php
@@ -268,7 +268,7 @@ class EmailingEventListener
                 ->setTo($beneficiary->getEmail())
                 ->setBody(
                     $this->renderView(
-                        'emails/deleted_shift.html.twig',
+                        'emails/shift_deleted.html.twig',
                         array('shift' => $shift)
                     ),
                     'text/html'


### PR DESCRIPTION
### Quoi ?

Lors d'un événement `onShiftFreed`, on ajoute ici un e-mail envoyé au bénéficiaire pour lui confirmer son annulation.

J'en ai profité pour renommer le template de l'e-mail `onShiftDeleted` pour homogénéiser + quelques cleanup sur les autres template d'e-mails