### PR TITLE
Evénements : pouvoir créer des widgets

### DIFF
--- a/app/Resources/views/admin/event/index.html.twig
+++ b/app/Resources/views/admin/event/index.html.twig
@@ -30,4 +30,5 @@
     <br />
     <a href="{{ path('event_new') }}" class="btn"><i class="material-icons left">add</i>Ajouter un événement</a>
 {% endif %}
+<a href="{{ path('event_widget_generator') }}" class="btn"><i class="material-icons left">tune</i>Générer un widget</a>
 {% endblock %}

--- a/app/Resources/views/admin/event/widget/generate.html.twig
+++ b/app/Resources/views/admin/event/widget/generate.html.twig
@@ -1,0 +1,41 @@
+{% extends 'layout.html.twig' %}
+
+{% block title %}Générer un widget (événement) - {{ site_name }}{% endblock %}
+
+{% block breadcrumbs %}
+<a href="{{ path('homepage') }}"><i class="material-icons">home</i></a><i class="material-icons">chevron_right</i>
+<a href="{{ path('admin') }}"><i class="material-icons">build</i>&nbsp;Administration</a><i class="material-icons">chevron_right</i>
+<a href="{{ path('event_index') }}"><i class="material-icons">event</i>&nbsp;Événements</a><i class="material-icons">chevron_right</i>
+<i class="material-icons">tune</i>&nbsp;Générer un widget
+{% endblock %}
+
+{% block content %}
+<h4>Générer un widget (événement)</h4>
+
+{{ form_start(form) }}
+<div class="errors">
+    {{ form_errors(form) }}
+</div>
+<div class="row">
+    <div class="col s12">
+        {{ form_label(form.kind) }}
+        {{ form_widget(form.kind) }}
+    </div>
+</div>
+<div class="row">
+    <div class="col s12">
+        {{ form.title.vars.label }}
+        <div class="switch">
+            <label>
+                masquer le titre
+                {{ form_widget(form.title) }}
+                <span class="lever"></span>
+                afficher le titre
+            </label>
+        </div>
+    </div>
+</div>
+<br />
+{{ form_widget(form.generate, {'attr': {'class': 'btn waves-effect waves-light'}}) }}
+{{ form_end(form) }}
+{% endblock %}

--- a/app/Resources/views/admin/event/widget/generate.html.twig
+++ b/app/Resources/views/admin/event/widget/generate.html.twig
@@ -38,4 +38,20 @@
 <br />
 {{ form_widget(form.generate, {'attr': {'class': 'btn waves-effect waves-light'}}) }}
 {{ form_end(form) }}
+
+{% if query_string is defined %}
+    <br />
+    <h4>Résultat</h4>
+    <div class="row">
+        <div class="col m4">
+            <iframe src="{{ path('event_widget') }}?{{ query_string }}" frameborder="0" style="border: 2px solid green;"></iframe>
+        </div>
+        <div class="col m8">
+            texte à copier-coller 👇
+            <div class="card-panel" style="overflow:scroll;">
+                <pre>&lt;iframe src="{{ absolute_url(path('event_widget')) }}?{{ query_string }}" frameborder="0"&gt;&lt;/iframe&gt;</pre>
+            </div>
+        </div>
+    </div>
+{% endif %}
 {% endblock %}

--- a/app/Resources/views/admin/event/widget/widget.html.twig
+++ b/app/Resources/views/admin/event/widget/widget.html.twig
@@ -1,0 +1,17 @@
+{% extends 'layoutlight.html.twig' %}
+
+{% block content %}
+    {% if job %}
+        {% if title %}liste des prochains créneaux de <strong>{{ job.name }}</strong>{% endif %}
+        <ul>
+            {% for bucket in buckets %}
+                {% if bucket.shifterCount > 0 or display_on_empty %}
+                    <li>{{ bucket.start| date_fr_long }} {% if not display_end %}à{% else %}de{% endif %} {{ bucket.start|date('G\\hi') }}{% if display_end %} à {{ bucket.end|date('G\\hi') }}{% endif %}</li>
+                {% endif %}
+            {% endfor %}
+        </ul>
+        {% if display_on_empty %}<small>Les créneaux vides sont affichés</small>{% endif %}
+    {% else %}
+        Aucun type de créneau choisi
+    {% endif %}
+{% endblock %}

--- a/app/Resources/views/admin/event/widget/widget.html.twig
+++ b/app/Resources/views/admin/event/widget/widget.html.twig
@@ -1,10 +1,11 @@
 {% extends 'layoutlight.html.twig' %}
 
 {% block content %}
-{% if title %}liste des prochains événements <strong>{{ eventKind.name }}</strong>{% endif %}
+{% if title %}liste des prochains événements <strong>{{ eventKind.name }}</strong> :{% endif %}
 <ul>
     {% for event in events %}
         <li>
+            - <strong>{{ event.title }}</strong>
             {{ event.date | date_fr_full_with_time }}
             {% if event.end %}<i>({{ event.duration }})</i>{% endif %}
         </li>

--- a/app/Resources/views/admin/event/widget/widget.html.twig
+++ b/app/Resources/views/admin/event/widget/widget.html.twig
@@ -1,17 +1,13 @@
 {% extends 'layoutlight.html.twig' %}
 
 {% block content %}
-    {% if job %}
-        {% if title %}liste des prochains créneaux de <strong>{{ job.name }}</strong>{% endif %}
-        <ul>
-            {% for bucket in buckets %}
-                {% if bucket.shifterCount > 0 or display_on_empty %}
-                    <li>{{ bucket.start| date_fr_long }} {% if not display_end %}à{% else %}de{% endif %} {{ bucket.start|date('G\\hi') }}{% if display_end %} à {{ bucket.end|date('G\\hi') }}{% endif %}</li>
-                {% endif %}
-            {% endfor %}
-        </ul>
-        {% if display_on_empty %}<small>Les créneaux vides sont affichés</small>{% endif %}
-    {% else %}
-        Aucun type de créneau choisi
-    {% endif %}
+{% if title %}liste des prochains événements <strong>{{ eventKind.name }}</strong>{% endif %}
+<ul>
+    {% for event in events %}
+        <li>
+            {{ event.date | date_fr_full_with_time }}
+            {% if event.end %}<i>({{ event.duration }})</i>{% endif %}
+        </li>
+    {% endfor %}
+</ul>
 {% endblock %}

--- a/app/Resources/views/admin/job/widget/generate.html.twig
+++ b/app/Resources/views/admin/job/widget/generate.html.twig
@@ -10,74 +10,74 @@
 {% endblock %}
 
 {% block content %}
-    <h4>Générer un widget (créneaux d'un poste)</h4>
+<h4>Générer un widget (créneaux d'un poste)</h4>
 
-    {{ form_start(form) }}
-    <div class="errors">
-        {{ form_errors(form) }}
+{{ form_start(form) }}
+<div class="errors">
+    {{ form_errors(form) }}
+</div>
+<div class="row">
+    <div class="col s12">
+        {{ form_label(form.job) }}
+        {{ form_widget(form.job) }}
     </div>
-    <div class="row">
-        <div class="col s12">
-            {{ form_label(form.job) }}
-            {{ form_widget(form.job) }}
+</div>
+<div class="row">
+    <div class="col s12">
+        {{ form.display_end.vars.label }}
+        <div class="switch">
+            <label>
+                heure de début (à X:XX)
+                {{ form_widget(form.display_end) }}
+                <span class="lever"></span>
+                heure de début et de fin (de X:XX à X:XX)
+            </label>
         </div>
     </div>
-    <div class="row">
-        <div class="col s12">
-            {{ form.display_end.vars.label }}
-            <div class="switch">
-                <label>
-                    heure de début (à X:XX)
-                    {{ form_widget(form.display_end) }}
-                    <span class="lever"></span>
-                    heure de début et de fin (de X:XX à X:XX)
-                </label>
-            </div>
+</div>
+<div class="row">
+    <div class="col s12">
+        {{ form.display_on_empty.vars.label }}
+        <div class="switch">
+            <label>
+                uniquement les créneaux occupés
+                {{ form_widget(form.display_on_empty) }}
+                <span class="lever"></span>
+                tous les créneaux
+            </label>
         </div>
     </div>
-    <div class="row">
-        <div class="col s12">
-            {{ form.display_on_empty.vars.label }}
-            <div class="switch">
-                <label>
-                    uniquement les créneaux occupés
-                    {{ form_widget(form.display_on_empty) }}
-                    <span class="lever"></span>
-                    tous les créneaux
-                </label>
-            </div>
+</div>
+<div class="row">
+    <div class="col s12">
+        {{ form.title.vars.label }}
+        <div class="switch">
+            <label>
+                masquer le titre
+                {{ form_widget(form.title) }}
+                <span class="lever"></span>
+                afficher le titre
+            </label>
         </div>
     </div>
-    <div class="row">
-        <div class="col s12">
-            {{ form.title.vars.label }}
-            <div class="switch">
-                <label>
-                    masquer le titre
-                    {{ form_widget(form.title) }}
-                    <span class="lever"></span>
-                    afficher le titre
-                </label>
-            </div>
-        </div>
-    </div>
+</div>
+<br />
+{{ form_widget(form.generate, {'attr': {'class': 'btn waves-effect waves-light'}}) }}
+{{ form_end(form) }}
+
+{% if query_string is defined %}
     <br />
-    {{ form_widget(form.generate, {'attr': {'class': 'btn waves-effect waves-light'}}) }}
-    {{ form_end(form) }}
-
-    {% if query_string is defined %}
-        <br />
-        <h4>Résultat</h4>
-        <div class="row">
-            <div class="col m4">
-                <iframe src="{{ path('shift_widget') }}?{{ query_string }}" frameborder="0" style="border: 2px solid green;"></iframe>
-            </div>
-            <div class="col m8">
-                texte à copier-coller 👇
-                <div class="card-panel" style="overflow:scroll;">
-                    <pre>&lt;iframe src="{{ absolute_url(path('shift_widget')) }}?{{ query_string }}" frameborder="0"&gt;&lt;/iframe&gt;</pre>
-                </div>
+    <h4>Résultat</h4>
+    <div class="row">
+        <div class="col m4">
+            <iframe src="{{ path('shift_widget') }}?{{ query_string }}" frameborder="0" style="border: 2px solid green;"></iframe>
+        </div>
+        <div class="col m8">
+            texte à copier-coller 👇
+            <div class="card-panel" style="overflow:scroll;">
+                <pre>&lt;iframe src="{{ absolute_url(path('shift_widget')) }}?{{ query_string }}" frameborder="0"&gt;&lt;/iframe&gt;</pre>
             </div>
         </div>
-    {% endif %}
+    </div>
+{% endif %}
 {% endblock %}

--- a/app/Resources/views/admin/job/widget/generate.html.twig
+++ b/app/Resources/views/admin/job/widget/generate.html.twig
@@ -6,7 +6,7 @@
 <a href="{{ path('homepage') }}"><i class="material-icons">home</i></a><i class="material-icons">chevron_right</i>
 <a href="{{ path('admin') }}"><i class="material-icons">build</i>&nbsp;Administration</a><i class="material-icons">chevron_right</i>
 <a href="{{ path('job_list') }}"><i class="material-icons">list</i>&nbsp;Liste des postes de bénévolat</a><i class="material-icons">chevron_right</i>
-<i class="material-icons">add</i>&nbsp;Générer un widget (créneaux d'un poste)
+<i class="material-icons">tune</i>&nbsp;Générer un widget (créneaux d'un poste)
 {% endblock %}
 
 {% block content %}

--- a/app/Resources/views/admin/shift/widget/widget.html.twig
+++ b/app/Resources/views/admin/shift/widget/widget.html.twig
@@ -1,17 +1,17 @@
 {% extends 'layoutlight.html.twig' %}
 
 {% block content %}
-    {% if job %}
-        {% if title %}liste des prochains créneaux de <strong>{{ job.name }}</strong>{% endif %}
-        <ul>
-            {% for bucket in buckets %}
-                {% if bucket.shifterCount > 0 or display_on_empty %}
-                    <li>{{ bucket.start| date_fr_long }} {% if not display_end %}à{% else %}de{% endif %} {{ bucket.start|date('G\\hi') }}{% if display_end %} à {{ bucket.end|date('G\\hi') }}{% endif %}</li>
-                {% endif %}
-            {% endfor %}
-        </ul>
-        {% if display_on_empty %}<small>Les créneaux vides sont affichés</small>{% endif %}
-    {% else %}
-        Aucun type de créneau choisi
-    {% endif %}
+{% if job %}
+    {% if title %}liste des prochains créneaux de <strong>{{ job.name }}</strong>{% endif %}
+    <ul>
+        {% for bucket in buckets %}
+            {% if bucket.shifterCount > 0 or display_on_empty %}
+                <li>{{ bucket.start| date_fr_long }} {% if not display_end %}à{% else %}de{% endif %} {{ bucket.start|date('G\\hi') }}{% if display_end %} à {{ bucket.end|date('G\\hi') }}{% endif %}</li>
+            {% endif %}
+        {% endfor %}
+    </ul>
+    {% if display_on_empty %}<small>Les créneaux vides sont affichés</small>{% endif %}
+{% else %}
+    Aucun type de créneau choisi
+{% endif %}
 {% endblock %}

--- a/src/AppBundle/Controller/BookingController.php
+++ b/src/AppBundle/Controller/BookingController.php
@@ -309,9 +309,7 @@ class BookingController extends Controller
 
         $jobs = $em->getRepository(Job::class)->findByEnabled(true);
         $beneficiaries = $em->getRepository(Beneficiary::class)->findAllActive();
-        $shifts = $em
-            ->getRepository(Shift::class)
-            ->findFrom($filter["from"], $filter["to"], $filter["job"]);
+        $shifts = $em->getRepository(Shift::class)->findFrom($filter["from"], $filter["to"], $filter["job"]);
 
         $bucketsByDay = $this->get('shift_service')->generateShiftBucketsByDayAndJob($shifts);
         $bucketsByDay = $this->get('shift_service')->filterBucketsByDayAndJobByFilling($bucketsByDay, $filter["filling"]);

--- a/src/AppBundle/Controller/EventController.php
+++ b/src/AppBundle/Controller/EventController.php
@@ -788,6 +788,34 @@ class EventController extends Controller
         ));
     }
 
+    /**
+     * Event widget display
+     * 
+     * @Route("/widget", name="event_widget", methods={"GET"})
+     */
+    public function widgetAction(Request $request)
+    {
+        $buckets = array();
+        $eventKind = null;
+
+        $event_kind_id = $request->get('event_kind_id');
+        $title = $request->query->has('title') ? ($request->get('title') == 1) : true;
+
+        if ($event_kind_id) {
+            $em = $this->getDoctrine()->getManager();
+            $eventKind = $em->getRepository('AppBundle:EventKind')->find($event_kind_id);
+            if ($eventKind) {
+                $events = $em->getRepository('AppBundle:Event')->findFutures($eventKind);
+            }
+        }
+
+        return $this->render('admin/event/widget/widget.html.twig', [
+            'events' => $events,
+            'eventKind' => $eventKind,
+            'title' => $title
+        ]);
+    }
+
 
     /**
      * @param Event $event

--- a/src/AppBundle/Controller/EventController.php
+++ b/src/AppBundle/Controller/EventController.php
@@ -768,7 +768,7 @@ class EventController extends Controller
                 'multiple' => false,
                 'required' => true
             ))
-            ->add('title', CheckboxType::class, array('required' => false, 'data' => true, 'label' => 'Afficher le titre ?'))
+            ->add('title', CheckboxType::class, array('required' => false, 'data' => true, 'label' => 'Afficher le titre du widget ?'))
             ->add('generate', SubmitType::class, array('label' => 'Générer'))
             ->getForm();
 
@@ -805,7 +805,7 @@ class EventController extends Controller
             $em = $this->getDoctrine()->getManager();
             $eventKind = $em->getRepository('AppBundle:EventKind')->find($event_kind_id);
             if ($eventKind) {
-                $events = $em->getRepository('AppBundle:Event')->findFutures($eventKind);
+                $events = $em->getRepository('AppBundle:Event')->findFutures(null, $eventKind);
             }
         }
 

--- a/src/AppBundle/Controller/EventController.php
+++ b/src/AppBundle/Controller/EventController.php
@@ -9,9 +9,10 @@ use AppBundle\Form\ProxyType;
 use AppBundle\Repository\EventKindRepository;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Symfony\Component\Form\Extension\Core\Type\TextType;
-use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpFoundation\Response;
@@ -748,6 +749,42 @@ class EventController extends Controller
         return $this->render('admin/event/signatures.html.twig', array(
             'event' => $event,
             'beneficiaries' => $beneficiaries,
+        ));
+    }
+
+    /**
+     * Event widget generator
+     *
+     * @Route("/widget_generator", name="event_widget_generator", methods={"GET","POST"})
+     * @Security("has_role('ROLE_PROCESS_MANAGER')")
+     */
+    public function widgetGeneratorAction(Request $request)
+    {
+        $form = $this->createFormBuilder()
+            ->add('kind', EntityType::class, array(
+                'label' => "Quel type d'événement ?",
+                'class' => 'AppBundle:EventKind',
+                'choice_label' => 'name',
+                'multiple' => false,
+                'required' => true
+            ))
+            ->add('title', CheckboxType::class, array('required' => false, 'data' => true, 'label' => 'Afficher le titre ?'))
+            ->add('generate', SubmitType::class, array('label' => 'Générer'))
+            ->getForm();
+
+        if ($form->handleRequest($request)->isValid()) {
+            $data = $form->getData();
+
+            $widgetQueryString = 'event_kind_id='.$data['kind']->getId().'&title='.($data['title'] ? 1 : 0);
+
+            return $this->render('admin/event/widget/generate.html.twig', array(
+                'query_string' => $widgetQueryString,
+                'form' => $form->createView(),
+            ));
+        }
+
+        return $this->render('admin/event/widget/generate.html.twig', array(
+            'form' => $form->createView(),
         ));
     }
 

--- a/src/AppBundle/Controller/JobController.php
+++ b/src/AppBundle/Controller/JobController.php
@@ -185,7 +185,7 @@ class JobController extends Controller
             ))
             ->add('display_end', CheckboxType::class, array('required' => false, 'label' => 'Afficher l\'heure de fin ?'))
             ->add('display_on_empty', CheckboxType::class, array('required' => false, 'label' => 'Afficher les créneaux vides ?'))
-            ->add('title', CheckboxType::class, array('required' => false, 'data' => true, 'label' => 'Afficher le titre ?'))
+            ->add('title', CheckboxType::class, array('required' => false, 'data' => true, 'label' => 'Afficher le titre du widget ?'))
             ->add('generate', SubmitType::class, array('label' => 'Générer'))
             ->getForm();
 

--- a/src/AppBundle/Controller/ShiftController.php
+++ b/src/AppBundle/Controller/ShiftController.php
@@ -677,7 +677,7 @@ class ShiftController extends Controller
             $em = $this->getDoctrine()->getManager();
             $job = $em->getRepository('AppBundle:Job')->find($job_id);
             if ($job) {
-                $shifts = $em->getRepository('AppBundle:Shift')->findFuturesWithJob($job);
+                $shifts = $em->getRepository('AppBundle:Shift')->findFutures(null, $job);
                 foreach ($shifts as $shift) {
                     $day = $shift->getStart()->format("d m Y");
                     $interval = $shift->getIntervalCode();

--- a/src/AppBundle/Controller/WidgetController.php
+++ b/src/AppBundle/Controller/WidgetController.php
@@ -35,7 +35,7 @@ class WidgetController extends Controller
             $em = $this->getDoctrine()->getManager();
             $job = $em->getRepository('AppBundle:Job')->find($job_id);
             if ($job) {
-                $shifts = $em->getRepository('AppBundle:Shift')->findFuturesWithJob($job);
+                $shifts = $em->getRepository('AppBundle:Shift')->findFutures(null, $job);
                 foreach ($shifts as $shift) {
                     $day = $shift->getStart()->format("d m Y");
                     $interval = $shift->getIntervalCode();

--- a/src/AppBundle/Repository/EventRepository.php
+++ b/src/AppBundle/Repository/EventRepository.php
@@ -2,6 +2,8 @@
 
 namespace AppBundle\Repository;
 
+use AppBundle\Entity\EventKind;
+
 /**
  * EventRepository
  *
@@ -15,11 +17,17 @@ class EventRepository extends \Doctrine\ORM\EntityRepository
         return $this->findBy(array(), array('date' => 'DESC'));
     }
 
-    public function findFutures(\DateTime $max = null)
+    public function findFutures(EventKind $eventKind = null, \DateTime $max = null)
     {
         $qb = $this->createQueryBuilder('e')
             ->where('e.date > :now')
             ->setParameter('now', new \Datetime('now'));
+
+        if ($eventKind) {
+            $qb
+                ->andwhere('e.kind = :kind')
+                ->setParameter('kind', $eventKind);
+        }
 
         if ($max) {
             $qb

--- a/src/AppBundle/Repository/EventRepository.php
+++ b/src/AppBundle/Repository/EventRepository.php
@@ -17,22 +17,24 @@ class EventRepository extends \Doctrine\ORM\EntityRepository
         return $this->findBy(array(), array('date' => 'DESC'));
     }
 
-    public function findFutures(EventKind $eventKind = null, \DateTime $max = null)
+    public function findFutures(\DateTime $max = null, EventKind $eventKind = null)
     {
         $qb = $this->createQueryBuilder('e')
+            ->select('e, ek')
+            ->leftJoin('e.kind', 'ek')
             ->where('e.date > :now')
             ->setParameter('now', new \Datetime('now'));
-
-        if ($eventKind) {
-            $qb
-                ->andwhere('e.kind = :kind')
-                ->setParameter('kind', $eventKind);
-        }
 
         if ($max) {
             $qb
                 ->andWhere('e.date < :max')
                 ->setParameter('max', $max);
+        }
+
+        if ($eventKind) {
+            $qb
+                ->andwhere('e.kind = :kind')
+                ->setParameter('kind', $eventKind);
         }
 
         $qb->orderBy('e.date', 'ASC');

--- a/src/AppBundle/Repository/ShiftRepository.php
+++ b/src/AppBundle/Repository/ShiftRepository.php
@@ -47,11 +47,9 @@ class ShiftRepository extends \Doctrine\ORM\EntityRepository
             ->getResult();
     }
 
-    public function findFutures(\DateTime $max = null)
+    public function findFutures(\DateTime $max = null, Job $job = null)
     {
-        $qb = $this->createQueryBuilder('s');
-
-        $qb
+        $qb = $this->createQueryBuilder('s')
             ->select('s, j')
             ->leftJoin('s.job', 'j')
             ->where('s.start > :now')
@@ -63,30 +61,10 @@ class ShiftRepository extends \Doctrine\ORM\EntityRepository
                 ->setParameter('max', $max);
         }
 
-        $qb->orderBy('s.start', 'ASC');
-
-        return $qb
-            ->getQuery()
-            ->getResult();
-    }
-
-    public function findFuturesWithJob(Job $job = null, \DateTime $max = null)
-    {
-        $qb = $this->createQueryBuilder('s')
-            ->where('s.start > :now')
-            ->setParameter('now', new \Datetime('now'));
-
         if ($job) {
             $qb
-                ->leftJoin('s.job', 'j')
                 ->andwhere('s.job = :job')
                 ->setParameter('job', $job);
-        }
-
-        if ($max) {
-            $qb
-                ->andWhere('s.end < :max')
-                ->setParameter('max', $max);
         }
 
         $qb->orderBy('s.start', 'ASC');
@@ -101,19 +79,22 @@ class ShiftRepository extends \Doctrine\ORM\EntityRepository
         $qb = $this->createQueryBuilder('s');
 
         $qb
-            ->select('s, f')
+            ->select('s, j, f')
+            ->leftJoin('s.job', 'j')
             ->leftJoin('s.formation', 'f')
-            ->leftJoin('s.shifter', 'u')
-            ->addSelect('u')
-            ->leftJoin('u.formations', 'f1')
-            ->addSelect('f1')
+            ->leftJoin('s.shifter', 'b')
+            ->addSelect('b')
+            ->leftJoin('b.formations', 'bf')
+            ->addSelect('bf')
             ->where('s.start > :from')
             ->setParameter('from', $from);
+
         if ($max) {
             $qb
                 ->andWhere('s.end < :max')
                 ->setParameter('max', $max);
         }
+
         if ($job) {
             $qb
                 ->andWhere('s.job = :job')

--- a/src/AppBundle/Repository/ShiftRepository.php
+++ b/src/AppBundle/Repository/ShiftRepository.php
@@ -7,6 +7,7 @@ use AppBundle\Entity\Job;
 use AppBundle\Entity\Membership;
 use AppBundle\Entity\PeriodPosition;
 use AppBundle\Entity\Shift;
+use AppBundle\Entity\User;
 use Doctrine\Common\Collections\ArrayCollection;
 use \Datetime;
 
@@ -69,16 +70,18 @@ class ShiftRepository extends \Doctrine\ORM\EntityRepository
             ->getResult();
     }
 
-    public function findFuturesWithJob($job, \DateTime $max = null)
+    public function findFuturesWithJob(Job $job = null, \DateTime $max = null)
     {
-        $qb = $this->createQueryBuilder('s');
-
-        $qb
-            ->join('s.job', "job")
+        $qb = $this->createQueryBuilder('s')
             ->where('s.start > :now')
-            ->andwhere('job.id = :jid')
-            ->setParameter('now', new \Datetime('now'))
-            ->setParameter('jid', $job->getId());
+            ->setParameter('now', new \Datetime('now'));
+
+        if ($job) {
+            $qb
+                ->leftJoin('s.job', 'j')
+                ->andwhere('s.job = :job')
+                ->setParameter('job', $job);
+        }
 
         if ($max) {
             $qb
@@ -129,7 +132,7 @@ class ShiftRepository extends \Doctrine\ORM\EntityRepository
      * @return mixed
      * @throws NonUniqueResultException
      */
-    public function findFirst($user)
+    public function findFirst(User $user)
     {
         $qb = $this->createQueryBuilder('s');
 


### PR DESCRIPTION
Suite de #836

### Quoi ?

Similaire à la création de widget pour un type de créneau donné, ici on permet de créer un widget pour un type d'événement donné.

### Captures d'écran

|URL|Image|
|---|---|
|`/event`|![image](https://user-images.githubusercontent.com/7147385/236631370-5ca9b0aa-8706-4b62-abc8-73c030f92cc8.png)|
|`/event/widget_generator`|![image](https://user-images.githubusercontent.com/7147385/235936492-6d5dd063-4491-48bc-81bd-65fe8e881b7b.png)|

