### PR TITLE
Créneaux : pouvoir supprimer un bucket seulement si tous les créneaux sont libres

### DIFF
--- a/app/Resources/views/admin/booking/_partial/bucket_modal.html.twig
+++ b/app/Resources/views/admin/booking/_partial/bucket_modal.html.twig
@@ -207,11 +207,15 @@ id = "modal-bucket"
     <i class="material-icons left">edit</i>Editer
 </a>
 {% if is_granted("ROLE_ADMIN") %}
+    <!-- bucket delete is allowed only if all shifts are free -->
     {{ form_start(bucket_delete_form, {'attr': { 'style': 'display:inline;' }}) }}
-    <button id="bucket_delete" class="btn red" title="Supprimer tous les créneaux à cette heure et ce poste">
+    <button id="bucket_delete" class="btn red" title="Supprimer tous les créneaux à cette heure et ce poste" {% if nbBookedShifts > 0 %}disabled{% endif %}>
         <i class="material-icons left">delete</i>Supprimer
     </button>
     {{ form_end(bucket_delete_form) }}
+    {% if nbBookedShifts > 0 %}
+        <i class="material-icons grey-text tooltipped" style="vertical-align:middle;" data-tooltip="Tous les créneaux doivent être libérés avant de pouvoir les supprimer">info</i>
+    {% endif %}
 {% endif %}
 
 <script>
@@ -250,11 +254,12 @@ id = "modal-bucket"
         }
         event.preventDefault();
     }
-    $('form[name="bucket_delete_form"]').on('submit', {confirmation: "Etes-vous sûr de vouloir supprimer ces créneaux et leurs réservations ?!"}, makeAjaxCall);
+    $('form[name="bucket_delete_form"]').on('submit', {confirmation: "Etes-vous sûr de vouloir supprimer ces créneaux ?!"}, makeAjaxCall);
     $('form[name^="shift_delete_forms_"]').on('submit', {confirmation: "Etes-vous sûr de vouloir supprimer ce poste ?!"}, makeAjaxCall);
     $('form[name^="shift_free_forms_"]').on('submit', {confirmation: "Etes-vous sûr de vouloir libérer ce poste ?!"}, makeAjaxCall);
     $('form[name="bucket_shift_add_form"]').on('submit', {}, makeAjaxCall);
     $('form[name="bucket_lock_unlock_form"]').on('submit', {}, makeAjaxCall);
     $('form[name^="shift_book_forms_"]').on('submit', {}, makeAjaxCall);
     $('form[name^="shift_validate_invalidate_forms_"]').on('submit', {}, makeAjaxCall);
+    $('.tooltipped').tooltip();
 </script>

--- a/app/Resources/views/admin/booking/index.html.twig
+++ b/app/Resources/views/admin/booking/index.html.twig
@@ -134,7 +134,6 @@
                     $('#modal-bucket-content').html('');
                 },
                 onOpenStart: function(modal, trigger) {
-                    console.log("onOpenStart");
                     var url = $(trigger).attr('data-source');
                     $.get(url, function( data ) {
                         $('#modal-bucket-content').html(data);


### PR DESCRIPTION
### Quoi ?

Dans Admin > Gérer les créneaux, lorsqu'on affiche un bucket (lot de créneaux ayant lieu à la même date / heure / job), un bouton "Supprimer" est affiché.

Le changement apporté est d'activer ce bouton seulement si tous les créneaux ont été au préalable libérés. Sinon, il est grisé + un popup d'information apparait.

### Pourquoi ?

Eviter les fausses manips

### Captures d'écran

||Image|
|---|---|
|Bucket avec des créneaux réservés|![Screenshot from 2023-05-03 22-19-17](https://user-images.githubusercontent.com/7147385/236040595-27127376-8e13-433f-b472-31877a983d97.png)|
|Bucket avec tous les créneaux libres|![image](https://user-images.githubusercontent.com/7147385/236030874-71c45dcd-9c90-40fc-ad7d-95f944980753.png)|