### PR TITLE
Semaine type : réorganisation de la page de modification d'un créneau type

### DIFF
--- a/app/Resources/views/admin/period/copy_periods.html.twig
+++ b/app/Resources/views/admin/period/copy_periods.html.twig
@@ -5,7 +5,7 @@
 {% block breadcrumbs %}
 <a href="{{ path('homepage') }}"><i class="material-icons">home</i></a><i class="material-icons">chevron_right</i>
 <a href="{{ path('admin') }}"><i class="material-icons">build</i>&nbsp;Administration</a><i class="material-icons">chevron_right</i>
-<a href="{{ path('period') }}"><i class="material-icons">date_range</i>&nbsp;Semaine type</a><i class="material-icons">chevron_right</i>
+<a href="{{ path('period_admin') }}"><i class="material-icons">date_range</i>&nbsp;Semaine type</a><i class="material-icons">chevron_right</i>
 <i class="material-icons">content_copy</i>&nbsp;Dupliquer les créneaux types d'un jour vers un autre
 {% endblock %}
 

--- a/app/Resources/views/admin/period/edit.html.twig
+++ b/app/Resources/views/admin/period/edit.html.twig
@@ -6,8 +6,12 @@
 <a href="{{ path('homepage') }}"><i class="material-icons">home</i></a><i class="material-icons">chevron_right</i>
 <a href="{{ path('admin') }}"><i class="material-icons">build</i>&nbsp;Administration</a><i class="material-icons">chevron_right</i>
 <a href="{{ path('period_admin') }}"><i class="material-icons">date_range</i>&nbsp;Semaine type</a><i class="material-icons">chevron_right</i>
-<i class="material-icons">edit</i>&nbsp;Editer
+<i class="material-icons">edit</i>&nbsp;Editer le créneau type
 {% endblock %}
+
+{% set periodPositionCount = period.positions | length %}
+{% set periodPositionBookedCount = period.positionsBooked | length %}
+{% set periodPositionFreeCount = periodPositionCount - periodPositionBookedCount %}
 
 {% block content %}
     <h4>Editer le créneau type</h4>
@@ -15,6 +19,18 @@
     <div class="row">
         <div class="col m4">
             {% include "period/_partial/period_card.html.twig" with { period: period, anonymized: true, show_day_of_week: true, show_details: false } %}
+        </div>
+        <div class="col m8">
+            <div class="card">
+                <div class="card-content">
+                    Ce créneau type comporte <strong>{{ periodPositionCount }}</strong> poste{% if periodPositionCount > 1 %}s{% endif %} type{% if periodPositionCount > 1 %}s{% endif %}.
+                    {% if use_fly_and_fixed %}
+                        <br />
+                        <span class="red-text">&#9673;</span>&nbsp;<strong>{{ periodPositionFreeCount }}</strong> poste{% if periodPositionFreeCount > 1 %}s{% endif %} libre{% if periodPositionFreeCount > 1 %}s{% endif %}<br />
+                        <span class="green-text">&#9673;</span>&nbsp;<strong>{{ periodPositionBookedCount }}</strong> poste{% if periodPositionBookedCount > 1 %}s{% endif %} réservé{% if periodPositionBookedCount > 1 %}s{% endif %}
+                    {% endif %}
+                </div>
+            </div>
         </div>
     </div>
 

--- a/app/Resources/views/admin/period/edit.html.twig
+++ b/app/Resources/views/admin/period/edit.html.twig
@@ -153,9 +153,12 @@
                 {{ form_end(form) }}
 
                 {% if is_granted("ROLE_ADMIN") %}
-                    <a href="#remove-period-confirmation-modal" class="btn red modal-trigger" title="Supprimer le créneau type">
+                    <a href="#remove-period-confirmation-modal" class="btn red modal-trigger" title="Supprimer le créneau type" {% if use_fly_and_fixed and not period.isEmpty %}disabled{% endif %}>
                         <i class="material-icons left">delete</i>Supprimer
                     </a>
+                    {% if use_fly_and_fixed and not period.isEmpty %}
+                        <i class="material-icons grey-text tooltipped" style="vertical-align:middle;" data-tooltip="Tous les postes doivent être libérés avant de pouvoir supprimer le créneau type">info</i>
+                    {% endif %}
                     {{ form_start(period_delete_form) }}
                     <div id="remove-period-confirmation-modal" class="modal">
                         <div class="modal-content">

--- a/app/Resources/views/admin/period/edit.html.twig
+++ b/app/Resources/views/admin/period/edit.html.twig
@@ -116,29 +116,36 @@
         {% endfor %}
     {% endif %}
 
-    <h5>Ajouter un poste</h5>
-
-    {{ form_start(position_add_form) }}
-    <div class="row">
-        <div class="col s3">
-            {{ form_label(position_add_form.nb_of_shifter) }}
-            {{ form_widget(position_add_form.nb_of_shifter) }}
-        </div>
-        <div class="col s3">
-            {{ form_label(position_add_form.week_cycle) }}
-            {{ form_widget(position_add_form.week_cycle) }}
-        </div>
-        <div class="col s6">
-            {{ form_label(position_add_form.formation) }}
-            {{ form_widget(position_add_form.formation) }}
-        </div>
-        <div class="col s6">
-            <button type="submit" class="btn waves-effect waves-light teal"><i class="material-icons left">add</i>Ajouter</button>
-        </div>
-    </div>
-    {{ form_end(position_add_form) }}
+    <br />
+    <h5>Actions supplémentaires</h5>
 
     <ul class="collapsible">
+        <li>
+            <div class="collapsible-header">
+                <i class="material-icons">add</i>Ajouter un poste
+            </div>
+            <div class="collapsible-body">
+                {{ form_start(position_add_form) }}
+                <div class="row">
+                    <div class="col s3">
+                        {{ form_label(position_add_form.nb_of_shifter) }}
+                        {{ form_widget(position_add_form.nb_of_shifter) }}
+                    </div>
+                    <div class="col s3">
+                        {{ form_label(position_add_form.week_cycle) }}
+                        {{ form_widget(position_add_form.week_cycle) }}
+                    </div>
+                    <div class="col s6">
+                        {{ form_label(position_add_form.formation) }}
+                        {{ form_widget(position_add_form.formation) }}
+                    </div>
+                    <div class="col s6">
+                        <button type="submit" class="btn waves-effect waves-light teal"><i class="material-icons left">add</i>Ajouter</button>
+                    </div>
+                </div>
+                {{ form_end(position_add_form) }}
+            </div>
+        </li>
         <li>
             <div class="collapsible-header">
                 <i class="material-icons">edit</i>Editer le créneau type

--- a/app/Resources/views/admin/period/edit.html.twig
+++ b/app/Resources/views/admin/period/edit.html.twig
@@ -5,41 +5,18 @@
 {% block breadcrumbs %}
 <a href="{{ path('homepage') }}"><i class="material-icons">home</i></a><i class="material-icons">chevron_right</i>
 <a href="{{ path('admin') }}"><i class="material-icons">build</i>&nbsp;Administration</a><i class="material-icons">chevron_right</i>
-<a href="{{ path('period') }}"><i class="material-icons">date_range</i>&nbsp;Semaine type</a><i class="material-icons">chevron_right</i>
+<a href="{{ path('period_admin') }}"><i class="material-icons">date_range</i>&nbsp;Semaine type</a><i class="material-icons">chevron_right</i>
 <i class="material-icons">edit</i>&nbsp;Editer
 {% endblock %}
 
 {% block content %}
     <h4>Editer le créneau type</h4>
 
-    {{ form_start(form) }}
-    {{ form_widget(form) }}
-    <div>
-        <button type="submit" class="btn waves-effect waves-light"><i class="material-icons left">save</i>Enregistrer</button>
-    </div>
-    {{ form_end(form) }}
-
-    {% if is_granted("ROLE_ADMIN") %}
-        <a href="#remove-period-confirmation-modal" class="modal-trigger btn waves-effect waves-light red" title="Supprimer le créneau type">
-            Supprimer
-        </a>
-        {{ form_start(period_delete_form) }}
-        <div id="remove-period-confirmation-modal" class="modal">
-            <div class="modal-content">
-                <h5><i class="material-icons left small">remove_circle_outline</i>Supprimer le créneau type</h5>
-                <p>Attention, cela va aussi supprimer tous les postes de ce créneau type.</p>
-            </div>
-            <div class="modal-footer">
-                <a href="#!" class="modal-action modal-close waves-effect waves-green btn-flat green-text">
-                    Retour à la raison
-                </a>
-                <button type="submit" class="btn waves-effect waves-light orange">
-                    <i class="material-icons left">check</i>Je sais ce que je fais !
-                </button>
-            </div>
+    <div class="row">
+        <div class="col m4">
+            {% include "period/_partial/period_card.html.twig" with { period: period, anonymized: true, show_day_of_week: true, show_details: false } %}
         </div>
-        {{ form_end(period_delete_form) }}
-    {% endif %}
+    </div>
 
     <h5>Postes disponibles</h5>
 
@@ -138,7 +115,9 @@
             </ul>
         {% endfor %}
     {% endif %}
+
     <h5>Ajouter un poste</h5>
+
     {{ form_start(position_add_form) }}
     <div class="row">
         <div class="col s3">
@@ -158,4 +137,43 @@
         </div>
     </div>
     {{ form_end(position_add_form) }}
+
+    <ul class="collapsible">
+        <li>
+            <div class="collapsible-header">
+                <i class="material-icons">edit</i>Editer le créneau type
+            </div>
+            <div class="collapsible-body">
+                {{ form_start(form, {'attr': { 'style': 'display:inline;' }}) }}
+                {{ form_widget(form) }}
+                <br />
+                <button type="submit" class="btn waves-effect waves-light">
+                    <i class="material-icons left">save</i>Enregistrer
+                </button>
+                {{ form_end(form) }}
+
+                {% if is_granted("ROLE_ADMIN") %}
+                    <a href="#remove-period-confirmation-modal" class="btn red modal-trigger" title="Supprimer le créneau type">
+                        <i class="material-icons left">delete</i>Supprimer
+                    </a>
+                    {{ form_start(period_delete_form) }}
+                    <div id="remove-period-confirmation-modal" class="modal">
+                        <div class="modal-content">
+                            <h5><i class="material-icons left small">remove_circle_outline</i>Supprimer le créneau type</h5>
+                            <p>Attention, cela va aussi supprimer tous les postes de ce créneau type.</p>
+                        </div>
+                        <div class="modal-footer">
+                            <a href="#!" class="modal-action modal-close waves-effect waves-green btn-flat green-text">
+                                Retour à la raison
+                            </a>
+                            <button type="submit" class="btn waves-effect waves-light orange">
+                                <i class="material-icons left">check</i>Je sais ce que je fais !
+                            </button>
+                        </div>
+                    </div>
+                    {{ form_end(period_delete_form) }}
+                {% endif %}
+            </div>
+        </li>
+    </ul>
 {% endblock %}

--- a/app/Resources/views/admin/period/generate_shifts.html.twig
+++ b/app/Resources/views/admin/period/generate_shifts.html.twig
@@ -5,7 +5,7 @@
 {% block breadcrumbs %}
 <a href="{{ path('homepage') }}"><i class="material-icons">home</i></a><i class="material-icons">chevron_right</i>
 <a href="{{ path('admin') }}"><i class="material-icons">build</i>&nbsp;Administration</a><i class="material-icons">chevron_right</i>
-<a href="{{ path('period') }}"><i class="material-icons">date_range</i>&nbsp;Semaine type</a><i class="material-icons">chevron_right</i>
+<a href="{{ path('period_admin') }}"><i class="material-icons">date_range</i>&nbsp;Semaine type</a><i class="material-icons">chevron_right</i>
 <i class="material-icons">add</i>&nbsp;Générer
 {% endblock %}
 

--- a/app/Resources/views/admin/period/index.html.twig
+++ b/app/Resources/views/admin/period/index.html.twig
@@ -232,8 +232,7 @@
                                         or (filling_filter == "full" and period.isFull(week_filter))
                                         or (filling_filter == "partial" and period.isPartial(week_filter))
                                         or (beneficiary_filter and period.hasShifter(beneficiary_filter) | length > 0) %}
-                                        {% include 'period/_partial/period_card.html.twig'
-                                                with {'period':period, 'week_filter':week_filter, 'anonymized':false} %}
+                                        {% include "period/_partial/period_card.html.twig" with { period: period, week_filter: week_filter, anonymized: false } %}
                                     {% endif %}
                                 {% endfor %}
                             </td>

--- a/app/Resources/views/admin/period/new.html.twig
+++ b/app/Resources/views/admin/period/new.html.twig
@@ -5,8 +5,8 @@
 {% block breadcrumbs %}
 <a href="{{ path('homepage') }}"><i class="material-icons">home</i></a><i class="material-icons">chevron_right</i>
 <a href="{{ path('admin') }}"><i class="material-icons">build</i>&nbsp;Administration</a><i class="material-icons">chevron_right</i>
-<a href="{{ path('period') }}"><i class="material-icons">date_range</i>&nbsp;Semaine type</a><i class="material-icons">chevron_right</i>
-<i class="material-icons">add</i>&nbsp;Nouveau
+<a href="{{ path('period_admin') }}"><i class="material-icons">date_range</i>&nbsp;Semaine type</a><i class="material-icons">chevron_right</i>
+<i class="material-icons">add</i>&nbsp;Nouveau créneau type
 {% endblock %}
 
 {% block content %}

--- a/app/Resources/views/period/_partial/period_card.html.twig
+++ b/app/Resources/views/period/_partial/period_card.html.twig
@@ -22,45 +22,47 @@
 {% endmacro %}
 
 
-<div class="card {{ period.job? period.job.color : "blue" }} lighten-2 hoverable" style="padding: 15px;">
-    {# Card header #}
-    {%  if anonymized %}
-        <div>
-            {{ _self.period_title(period, show_day_of_week) }}
-        </div>
-    {% else %}
-        <a href="{{ path("period_edit",{'id': period.id}) }}" class="black-text">
-            <div class="black-text editable-box">
+<div class="card {{ period.job? period.job.color : "blue" }} lighten-2 hoverable">
+    <div class="card-content">
+        {# Card title #}
+        {%  if anonymized %}
+            <div>
                 {{ _self.period_title(period, show_day_of_week) }}
             </div>
-        </a>
-    {% endif %}
+        {% else %}
+            <a href="{{ path("period_edit",{'id': period.id}) }}" class="black-text">
+                <div class="black-text editable-box">
+                    {{ _self.period_title(period, show_day_of_week) }}
+                </div>
+            </a>
+        {% endif %}
 
-    {% if show_details %}
-        {# if display by job/training #}
-        <div id="training" style="margin-top:1em;">
-            {% for week, positions in period.groupedpositionsperweekcycle(week_filter) %}
-                <h6>Semaine {{ week }}</h6>
-                {% for training, nb_shifters in positions %}
-                    <i class="material-icons">person</i>{{ nb_shifters }} x {{ training }}
-                    <br/>
-                {% endfor %}
-            {% endfor %}
-        </div>
-
-        {# if display by member name #}
-        {% if use_fly_and_fixed %}
-            <div id="shifter" style="margin-top:1em;">
-                {% for week, positions in period.positionsperweekcycle %}
-                    {% if (week in week_filter) or not week_filter %}
-                        <h6>Semaine {{ week }}</h6>
-                        {% for position in positions %}
-                            {% include 'period/_partial/position_shifter_display.html.twig'
-                                with {'position':position, 'anonymized':anonymized} %}
-                        {% endfor %}
-                    {% endif %}
+        {% if show_details %}
+            {# if display by job/training #}
+            <div id="training" style="margin-top:1em;">
+                {% for week, positions in period.groupedpositionsperweekcycle(week_filter) %}
+                    <h6>Semaine {{ week }}</h6>
+                    {% for training, nb_shifters in positions %}
+                        <i class="material-icons">person</i>{{ nb_shifters }} x {{ training }}
+                        <br/>
+                    {% endfor %}
                 {% endfor %}
             </div>
+
+            {# if display by member name #}
+            {% if use_fly_and_fixed %}
+                <div id="shifter" style="margin-top:1em;">
+                    {% for week, positions in period.positionsperweekcycle %}
+                        {% if (week in week_filter) or not week_filter %}
+                            <h6>Semaine {{ week }}</h6>
+                            {% for position in positions %}
+                                {% include 'period/_partial/position_shifter_display.html.twig'
+                                    with {'position':position, 'anonymized':anonymized} %}
+                            {% endfor %}
+                        {% endif %}
+                    {% endfor %}
+                </div>
+            {% endif %}
         {% endif %}
-    {% endif %}
+    </div>
 </div>

--- a/app/Resources/views/period/_partial/period_card.html.twig
+++ b/app/Resources/views/period/_partial/period_card.html.twig
@@ -6,59 +6,61 @@
 # will use the editable-box css class if anonymized is false
 #}
 
+{% set week_filter = week_filter ?? null %}
+{% set anonymized = anonymized ?? true %}
+{% set show_day_of_week = show_day_of_week ?? false %}
+{% set show_details = show_details ?? true %}
+
 {# generate a form input, used for the filters #}
-{% macro period_title(period) %}
+{% macro period_title(period, show_day_of_week) %}
     {% if period.job %}
         <b>{{ period.job.name }}</b>
-        <br>
-        {{ period.start | date('H:i') }}-{{ period.end | date('H:i') }}
-    {% else %}
-        {{ period.start | date('H:i') }}-{{ period.end | date('H:i') }}
-        <br>
+        <br />
     {% endif %}
+        {% if show_day_of_week %}{{ period.dayOfweekString | capitalize }}{% endif %}
+        {{ period.start | date('H:i') }}-{{ period.end | date('H:i') }}
 {% endmacro %}
 
 
 <div class="card {{ period.job? period.job.color : "blue" }} lighten-2 hoverable" style="padding: 15px;">
-
     {# Card header #}
     {%  if anonymized %}
         <div>
-            {{ _self.period_title(period) }}
+            {{ _self.period_title(period, show_day_of_week) }}
         </div>
-
     {% else %}
         <a href="{{ path("period_edit",{'id': period.id}) }}" class="black-text">
             <div class="black-text editable-box">
-                {{ _self.period_title(period) }}
+                {{ _self.period_title(period, show_day_of_week) }}
             </div>
         </a>
     {% endif %}
 
-
-    {# if display by job/training #}
-    <div id="training" style="margin-top:1em;">
-        {% for week, positions in period.groupedpositionsperweekcycle(week_filter) %}
-            <h6>Semaine {{ week }}</h6>
-            {% for training, nb_shifters in positions %}
-                <i class="material-icons">person</i>{{ nb_shifters }} x {{ training }}
-                <br/>
-            {% endfor %}
-        {% endfor %}
-    </div>
-
-    {# if display by member name #}
-    {% if use_fly_and_fixed %}
-        <div id="shifter" style="margin-top:1em;">
-            {% for week, positions in period.positionsperweekcycle %}
-                {% if (week in week_filter) or not week_filter %}
-                    <h6>Semaine {{ week }}</h6>
-                    {% for position in positions %}
-                        {% include 'period/_partial/position_shifter_display.html.twig'
-                            with {'position':position, 'anonymized':anonymized} %}
-                    {% endfor %}
-                {% endif %}
+    {% if show_details %}
+        {# if display by job/training #}
+        <div id="training" style="margin-top:1em;">
+            {% for week, positions in period.groupedpositionsperweekcycle(week_filter) %}
+                <h6>Semaine {{ week }}</h6>
+                {% for training, nb_shifters in positions %}
+                    <i class="material-icons">person</i>{{ nb_shifters }} x {{ training }}
+                    <br/>
+                {% endfor %}
             {% endfor %}
         </div>
+
+        {# if display by member name #}
+        {% if use_fly_and_fixed %}
+            <div id="shifter" style="margin-top:1em;">
+                {% for week, positions in period.positionsperweekcycle %}
+                    {% if (week in week_filter) or not week_filter %}
+                        <h6>Semaine {{ week }}</h6>
+                        {% for position in positions %}
+                            {% include 'period/_partial/position_shifter_display.html.twig'
+                                with {'position':position, 'anonymized':anonymized} %}
+                        {% endfor %}
+                    {% endif %}
+                {% endfor %}
+            </div>
+        {% endif %}
     {% endif %}
 </div>

--- a/app/Resources/views/period/index.html.twig
+++ b/app/Resources/views/period/index.html.twig
@@ -105,8 +105,7 @@ It display a page with all the avaible periods (a.k.a the "Semaine type")
                                     or (filling_filter == "empty" and period.isEmpty(week_filter))
                                     or (filling_filter == "full" and period.isFull(week_filter))
                                     or (filling_filter == "partial" and period.isPartial(week_filter)) %}
-                                    {% include 'period/_partial/period_card.html.twig'
-                                        with {'period':period, 'week_filter':week_filter, 'anonymized':true} %}
+                                    {% include "period/_partial/period_card.html.twig" with { period: period, week_filter: week_filter, anonymized: true} %}
                                 {% endif %}
                             {% endfor %}
                         </td>

--- a/src/AppBundle/Controller/PeriodController.php
+++ b/src/AppBundle/Controller/PeriodController.php
@@ -78,7 +78,6 @@ class PeriodController extends Controller
                         ->orderBy('j.name', 'ASC');
                 }
             ))
-
             ->add('week', ChoiceType::class, array(
                 'label' => 'Semaine',
                 'required' => false,
@@ -97,35 +96,32 @@ class PeriodController extends Controller
         if ($withBeneficiaryField) {
             $formBuilder
                 ->setAction($this->generateUrl('period_admin'))
-
                 ->add('beneficiary', AutocompleteBeneficiaryType::class, array(
-                'label' => 'Bénéficiaire',
-                'required' => false,)
-                )
-
+                    'label' => 'Bénéficiaire',
+                    'required' => false,
+                ))
                 ->add('filling', ChoiceType::class, array(
-                'label' => 'Remplissage',
-                'required' => false,
-                'choices' => array(
-                    'Complet' => 'full',
-                    'Partiel' => 'partial',
-                    'Vide' => 'empty',
-                    'Problématique' => 'problematic'
-                ),
-            ));
+                    'label' => 'Remplissage',
+                    'required' => false,
+                    'choices' => array(
+                        'Complet' => 'full',
+                        'Partiel' => 'partial',
+                        'Vide' => 'empty',
+                        'Problématique' => 'problematic'
+                    ),
+                ));
         }else{
             $formBuilder
                 ->setAction($this->generateUrl('period'))
-
                 ->add('filling', ChoiceType::class, array(
-                'label' => 'Remplissage',
-                'required' => false,
-                'choices' => array(
-                    'Complet' => 'full',
-                    'Partiel' => 'partial',
-                    'Vide' => 'empty',
-                ),
-            ));
+                    'label' => 'Remplissage',
+                    'required' => false,
+                    'choices' => array(
+                        'Complet' => 'full',
+                        'Partiel' => 'partial',
+                        'Vide' => 'empty',
+                    ),
+                ));
         }
 
         $res["form"] = $formBuilder->getForm();
@@ -276,7 +272,7 @@ class PeriodController extends Controller
             $em->flush();
 
             $session->getFlashBag()->add('success', 'Le créneau type a bien été édité !');
-            return $this->redirectToRoute('period');
+            return $this->redirectToRoute('period_admin');
         }
 
         $beneficiaries = $em->getRepository(Beneficiary::class)->findAllActive();
@@ -449,7 +445,7 @@ class PeriodController extends Controller
             $session->getFlashBag()->add('success', 'Le créneau type a bien été supprimé !');
         }
 
-        return $this->redirectToRoute('period');
+        return $this->redirectToRoute('period_admin');
 
     }
 
@@ -497,7 +493,7 @@ class PeriodController extends Controller
             $session = new Session();
             $session->getFlashBag()->add('success',$count.' creneaux copiés de'.array_search($from,$days).' à '.array_search($to,$days));
 
-            return $this->redirectToRoute('period');
+            return $this->redirectToRoute('period_admin');
         }
 
         return $this->render('admin/period/copy_periods.html.twig',array(
@@ -539,7 +535,7 @@ class PeriodController extends Controller
             $session = new Session();
             $session->getFlashBag()->add('success',$content);
 
-            return $this->redirectToRoute('period');
+            return $this->redirectToRoute('period_admin');
         }
 
         return $this->render('admin/period/generate_shifts.html.twig',array(

--- a/src/AppBundle/Controller/PeriodController.php
+++ b/src/AppBundle/Controller/PeriodController.php
@@ -215,7 +215,7 @@ class PeriodController extends Controller
      * @Route("/new", name="period_new", methods={"GET","POST"})
      * @Security("has_role('ROLE_SHIFT_MANAGER')")
      */
-    public function newAction(Request $request)
+    public function newPeriodAction(Request $request)
     {
         $session = new Session();
         $em = $this->getDoctrine()->getManager();

--- a/src/AppBundle/Entity/Period.php
+++ b/src/AppBundle/Entity/Period.php
@@ -269,6 +269,18 @@ class Period
     }
 
     /**
+     * Get all the positions booked
+     *
+     * @return \Doctrine\Common\Collections\Collection
+     */
+    public function getPositionsBooked()
+    {
+        return $this->getPositions()->filter(function (\AppBundle\Entity\PeriodPosition $position) {
+            return $position->getShifter();
+        });
+    }
+
+    /**
      * Return true if at least one shifter (a.k.a. beneficiary) registered for
      * this period is "problematic", meaning with a withdrawn or frozen membership
      * of if the shifter is member of the flying team.

--- a/src/AppBundle/Entity/Period.php
+++ b/src/AppBundle/Entity/Period.php
@@ -280,7 +280,6 @@ class Period
      */
     public function isProblematic(?String $weekFilter=null): bool
     {
-
         foreach ($this->positions as $position) {
             if($shifter = $position->getShifter()){
                 if((($weekFilter && $position->getWeekCycle()==$weekFilter) or !$weekFilter)


### PR DESCRIPTION
### Quoi ?

Modifications apportées sur la page `period/edit` : 
- nouveau header "informatif"
- déplacé le formulaire de modification tout en bas + dans un collapsible
- déplacé le formulaire d'ajout d'un poste type dans un collapsible
- pas possible de supprimer un créneau type si tous les postes ne sont pas libres (similaire à #838)
- réparé certains urls qui pointaient vers `period` au lieu de `period_admin`

### Pourquoi ?

- pour mieux s'y retrouver
- pour éviter les fausses manips

### Captures d'écran

||Image|
|---|---|
|Nouveau header|![image](https://user-images.githubusercontent.com/7147385/236058920-1d55c5d0-0c5e-4d23-8599-acf6b9d71a47.png)|
|Formulaires en bas|![image](https://user-images.githubusercontent.com/7147385/236059035-7747d1ab-fab2-4950-ae0d-b08a224f71b0.png)|