### PR TITLE
Semaine type : savoir qui a créé et mis à jour les créneaux / postes type

### DIFF
--- a/app/DoctrineMigrations/Version20230505143756_period_createdby_updatedat_updatedby.php
+++ b/app/DoctrineMigrations/Version20230505143756_period_createdby_updatedat_updatedby.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20230505143756 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE period ADD created_by_id INT DEFAULT NULL, ADD updated_by_id INT DEFAULT NULL, ADD updated_at DATETIME NOT NULL');
+        $this->addSql('ALTER TABLE period ADD CONSTRAINT FK_C5B81ECEB03A8386 FOREIGN KEY (created_by_id) REFERENCES fos_user (id)');
+        $this->addSql('ALTER TABLE period ADD CONSTRAINT FK_C5B81ECE896DBBDE FOREIGN KEY (updated_by_id) REFERENCES fos_user (id)');
+        $this->addSql('CREATE INDEX IDX_C5B81ECEB03A8386 ON period (created_by_id)');
+        $this->addSql('CREATE INDEX IDX_C5B81ECE896DBBDE ON period (updated_by_id)');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE period DROP FOREIGN KEY FK_C5B81ECEB03A8386');
+        $this->addSql('ALTER TABLE period DROP FOREIGN KEY FK_C5B81ECE896DBBDE');
+        $this->addSql('DROP INDEX IDX_C5B81ECEB03A8386 ON period');
+        $this->addSql('DROP INDEX IDX_C5B81ECE896DBBDE ON period');
+        $this->addSql('ALTER TABLE period DROP created_by_id, DROP updated_by_id, DROP updated_at');
+    }
+}

--- a/app/DoctrineMigrations/Version20230505151923_periodposition_createdby.php
+++ b/app/DoctrineMigrations/Version20230505151923_periodposition_createdby.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20230505151923 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE period_position ADD created_by_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE period_position ADD CONSTRAINT FK_2367D496B03A8386 FOREIGN KEY (created_by_id) REFERENCES fos_user (id)');
+        $this->addSql('CREATE INDEX IDX_2367D496B03A8386 ON period_position (created_by_id)');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE period_position DROP FOREIGN KEY FK_2367D496B03A8386');
+        $this->addSql('DROP INDEX IDX_2367D496B03A8386 ON period_position');
+        $this->addSql('ALTER TABLE period_position DROP created_by_id');
+    }
+}

--- a/app/Resources/views/admin/event/edit.html.twig
+++ b/app/Resources/views/admin/event/edit.html.twig
@@ -71,11 +71,11 @@
 {% if event.createdBy or event.updatedBy %}
     <div class="card-panel">
         {% if event.createdBy %}
-            <i>Création le {{ event.createdAt | date_fr_full_with_time }} par {{ event.createdBy }}</i>
+            <i>Création le {{ event.createdAt | date_fr_full_with_time }} par {% include "admin/member/_partial/member_or_user_link.html.twig" with { user: event.createdBy, target_blank: true } %}</i>
             <br />
         {% endif %}
         {% if event.updatedBy %}
-            <i>Dernière modification le {{ event.updatedAt | date_fr_full_with_time }} par {{ event.updatedBy }}</i>
+            <i>Dernière modification le {{ event.updatedAt | date_fr_full_with_time }} par {% include "admin/member/_partial/member_or_user_link.html.twig" with { user: event.updatedBy, target_blank: true } %}</i>
         {% endif %}
     </div>
 {% endif %}

--- a/app/Resources/views/admin/period/edit.html.twig
+++ b/app/Resources/views/admin/period/edit.html.twig
@@ -169,6 +169,18 @@
             <div class="collapsible-body">
                 {{ form_start(form, {'attr': { 'style': 'display:inline;' }}) }}
                 {{ form_widget(form) }}
+                {% if period.createdBy or period.updatedBy %}
+                    <br />
+                    <div class="card-panel">
+                        {% if period.createdBy %}
+                            <i>Création le {{ period.createdAt | date_fr_full_with_time }} par {% include "admin/member/_partial/member_or_user_link.html.twig" with { user: period.createdBy, target_blank: true } %}</i>
+                            <br />
+                        {% endif %}
+                        {% if period.updatedBy %}
+                            <i>Dernière modification le {{ period.updatedAt | date_fr_full_with_time }} par {% include "admin/member/_partial/member_or_user_link.html.twig" with { user: period.updatedBy, target_blank: true } %}</i>
+                        {% endif %}
+                    </div>
+                {% endif %}
                 <br />
                 <button type="submit" class="btn waves-effect waves-light">
                     <i class="material-icons left">save</i>Enregistrer

--- a/app/Resources/views/admin/period/edit.html.twig
+++ b/app/Resources/views/admin/period/edit.html.twig
@@ -110,6 +110,12 @@
                                         {{ form_end(positions_delete_forms[position.id]) }}
                                     </div>
                                 {% endif %}
+                                {% if position.createdBy %}
+                                    <p>
+                                        Poste type créé le <i>{{ position.createdAt | date_fr_full_with_time }}</i>
+                                        par {% include "admin/member/_partial/member_or_user_link.html.twig" with { user: position.createdBy, target_blank: true } %}.
+                                    </p>
+                                {% endif %}
                             </div>
                         </li>
                     {% endif %}

--- a/src/AppBundle/Controller/PeriodController.php
+++ b/src/AppBundle/Controller/PeriodController.php
@@ -215,6 +215,7 @@ class PeriodController extends Controller
     {
         $session = new Session();
         $em = $this->getDoctrine()->getManager();
+        $current_user = $this->get('security.token_storage')->getToken()->getUser();
 
         $period = new Period();
         $job = $em->getRepository(Job::class)->findOneBy(array());
@@ -232,6 +233,7 @@ class PeriodController extends Controller
             $period->setStart(new \DateTime($start));
             $end = $form->get('end')->getData();
             $period->setEnd(new \DateTime($end));
+            $period->setCreatedBy($current_user);
 
             $em->persist($period);
             $em->flush();
@@ -253,6 +255,7 @@ class PeriodController extends Controller
     {
         $session = new Session();
         $em = $this->getDoctrine()->getManager();
+        $current_user = $this->get('security.token_storage')->getToken()->getUser();
 
         $form = $this->createForm(PeriodType::class, $period);
         $form->handleRequest($request);
@@ -267,6 +270,7 @@ class PeriodController extends Controller
             $period->setStart(new \DateTime($start));
             $end = $form->get('end')->getData();
             $period->setEnd(new \DateTime($end));
+            $period->setUpdatedBy($current_user);
 
             $em->persist($period);
             $em->flush();

--- a/src/AppBundle/Controller/PeriodController.php
+++ b/src/AppBundle/Controller/PeriodController.php
@@ -315,27 +315,30 @@ class PeriodController extends Controller
     public function newPeriodPositionAction(Request $request, Period $period)
     {
         $session = new Session();
+        $em = $this->getDoctrine()->getManager();
+        $current_user = $this->get('security.token_storage')->getToken()->getUser();
 
         $position = new PeriodPosition();
         $form = $this->createForm(PeriodPositionType::class, $position);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $em = $this->getDoctrine()->getManager();
             foreach ($form["week_cycle"]->getData() as $week_cycle) {
                 $position->setWeekCycle($week_cycle);
+                $position->setCreatedBy($current_user);
                 $nb_of_shifter = $form["nb_of_shifter"]->getData();
-                while (0 < $nb_of_shifter ){
+                while (0 < $nb_of_shifter) {
                     $p = clone($position);
                     $period->addPosition($p);
                     $em->persist($p);
                     $nb_of_shifter--;
                 }
             }
+
             $em->persist($period);
             $em->flush();
+
             $session->getFlashBag()->add('success', 'Le poste '.$position.' a bien été ajouté');
-            return $this->redirectToRoute('period_edit',array('id'=>$period->getId()));
         }
 
         return $this->redirectToRoute('period_edit',array('id'=>$period->getId()));

--- a/src/AppBundle/Entity/Event.php
+++ b/src/AppBundle/Entity/Event.php
@@ -537,7 +537,7 @@ class Event
     /**
      * Set createdBy
      *
-     * @param \AppBundle\Entity\User $createBy
+     * @param \AppBundle\Entity\User $user
      *
      * @return Event
      */
@@ -571,7 +571,7 @@ class Event
     /**
      * Set updatedBy
      *
-     * @param \AppBundle\Entity\User $createBy
+     * @param \AppBundle\Entity\User $user
      *
      * @return Event
      */

--- a/src/AppBundle/Entity/Period.php
+++ b/src/AppBundle/Entity/Period.php
@@ -65,6 +65,25 @@ class Period
     private $createdAt;
 
     /**
+     * @ORM\ManyToOne(targetEntity="User")
+     * @ORM\JoinColumn(name="created_by_id", referencedColumnName="id")
+     */
+    private $createdBy;
+
+    /**
+     * @ORM\Column(type="datetime")
+     *
+     * @var \DateTime
+     */
+    private $updatedAt;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="User")
+     * @ORM\JoinColumn(name="updated_by_id", referencedColumnName="id")
+     */
+    private $updatedBy;
+
+    /**
      * Constructor
      */
     public function __construct()
@@ -78,6 +97,15 @@ class Period
     public function setCreatedAtValue()
     {
         $this->createdAt = new \DateTime();
+    }
+
+    /**
+     * @ORM\PrePersist
+     * @ORM\PreUpdate
+     */
+    public function setUpdatedAtValue()
+    {
+        $this->updatedAt = new \DateTime();
     }
 
     /**
@@ -248,6 +276,64 @@ class Period
     public function getCreatedAt()
     {
         return $this->createdAt;
+    }
+
+    /**
+     * Get createdBy
+     *
+     * @return \AppBundle\Entity\User
+     */
+    public function getCreatedBy()
+    {
+        return $this->createdBy;
+    }
+
+    /**
+     * Set createdBy
+     *
+     * @param \AppBundle\Entity\User $user
+     *
+     * @return Period
+     */
+    public function setCreatedBy(\AppBundle\Entity\User $user = null)
+    {
+        $this->createdBy = $user;
+
+        return $this;
+    }
+
+    /**
+     * Get updatedAt
+     *
+     * @return \DateTime
+     */
+    public function getUpdatedAt()
+    {
+        return $this->updatedAt;
+    }
+
+    /**
+     * Get updatedBy
+     *
+     * @return \AppBundle\Entity\User
+     */
+    public function getUpdatedBy()
+    {
+        return $this->updatedBy;
+    }
+
+    /**
+     * Set updatedBy
+     *
+     * @param \AppBundle\Entity\User $user
+     *
+     * @return Period
+     */
+    public function setUpdatedBy(\AppBundle\Entity\User $user = null)
+    {
+        $this->updatedBy = $user;
+
+        return $this;
     }
 
     /**

--- a/src/AppBundle/Entity/PeriodPosition.php
+++ b/src/AppBundle/Entity/PeriodPosition.php
@@ -73,6 +73,12 @@ class PeriodPosition
     private $createdAt;
 
     /**
+     * @ORM\ManyToOne(targetEntity="User")
+     * @ORM\JoinColumn(name="created_by_id", referencedColumnName="id")
+     */
+    private $createdBy;
+
+    /**
      * Constructor
      */
     public function __construct()
@@ -268,6 +274,30 @@ class PeriodPosition
     public function getCreatedAt()
     {
         return $this->createdAt;
+    }
+
+    /**
+     * Get createdBy
+     *
+     * @return \AppBundle\Entity\User
+     */
+    public function getCreatedBy()
+    {
+        return $this->createdBy;
+    }
+
+    /**
+     * Set createdBy
+     *
+     * @param \AppBundle\Entity\User $user
+     *
+     * @return PeriodPosition
+     */
+    public function setCreatedBy(\AppBundle\Entity\User $user = null)
+    {
+        $this->createdBy = $user;
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
### Quoi ?

Créneaux type : nouveaux champs `Period.created_by`, `Period.updated_at` & `Period.updated_by`
Postes type : nouveau champ `PeriodPosition.created_by`

Afficher l'information dans les formulaires existants

### Pourquoi ?

Pouvoir plus facilement remonter à la source des modifications

### Captures d'écran

||Image|
|---|---|
|Poste type|![image](https://user-images.githubusercontent.com/7147385/236506602-cf86990b-bc19-414c-a569-d25f7fb16bad.png)|
|Formulaire de modification d'un créneau type|![Screenshot from 2023-05-05 17-49-52](https://user-images.githubusercontent.com/7147385/236506643-5ac4be78-7713-4ab3-b0c7-33eb8fbe7558.png)|