### PR TITLE
Semaine type : améliorations d'affichage

### DIFF
--- a/app/Resources/views/admin/period/edit.html.twig
+++ b/app/Resources/views/admin/period/edit.html.twig
@@ -66,11 +66,12 @@
                                     le <i>{{ position.bookedTime | date_fr_full_with_time }}</i>
                                     par {% include "admin/member/_partial/member_or_user_link.html.twig" with { user: position.booker, target_blank: true } %}.
                                 </p>
-                                <form action="{{ path('period_position_free', {'id': period.id, 'position' : position.id }) }}" method="post" id="free_position_{{ position.id }}">
-                                    <button type="submit" class="btn orange">
-                                        <i class="material-icons left">lock_open</i>Libérer
-                                    </button>
-                                </form>
+                                {{ form_start(positions_free_forms[position.id]) }}
+                                {{ form_widget(positions_free_forms[position.id]) }}
+                                <button type="submit" class="btn orange">
+                                    <i class="material-icons left">lock_open</i>Libérer
+                                </button>
+                                {{ form_end(positions_free_forms[position.id]) }}
                             </div>
                         </li>
                     {% else %}

--- a/src/AppBundle/Controller/PeriodController.php
+++ b/src/AppBundle/Controller/PeriodController.php
@@ -238,7 +238,7 @@ class PeriodController extends Controller
             $em->persist($period);
             $em->flush();
 
-            $session->getFlashBag()->add('success', 'Le nouveau créneau type a bien été créé !');
+            $session->getFlashBag()->add('success', 'Le nouveau créneau type ' . $period . ' a bien été créé !');
             return $this->redirectToRoute('period_edit',array('id'=>$period->getId()));
         }
 
@@ -275,7 +275,7 @@ class PeriodController extends Controller
             $em->persist($period);
             $em->flush();
 
-            $session->getFlashBag()->add('success', 'Le créneau type a bien été édité !');
+            $session->getFlashBag()->add('success', 'Le créneau type ' . $period . ' a bien été édité !');
             return $this->redirectToRoute('period_admin');
         }
 
@@ -328,22 +328,20 @@ class PeriodController extends Controller
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
+            $count = $form["nb_of_shifter"]->getData();
             foreach ($form["week_cycle"]->getData() as $week_cycle) {
                 $position->setWeekCycle($week_cycle);
                 $position->setCreatedBy($current_user);
-                $nb_of_shifter = $form["nb_of_shifter"]->getData();
-                while (0 < $nb_of_shifter) {
+                foreach (range(0, $count-1) as $iteration) {
                     $p = clone($position);
                     $period->addPosition($p);
                     $em->persist($p);
-                    $nb_of_shifter--;
                 }
             }
-
             $em->persist($period);
             $em->flush();
 
-            $session->getFlashBag()->add('success', 'Le poste '.$position.' a bien été ajouté');
+            $session->getFlashBag()->add('success', $count . ' poste' . (($count>1) ? 's':'') . ' ajouté ' . (($count>1) ? 's':'') . ' (pour chaque cycle sélectionné) !');
         }
 
         return $this->redirectToRoute('period_edit',array('id'=>$period->getId()));
@@ -365,7 +363,7 @@ class PeriodController extends Controller
             $em->remove($position);
             $em->flush();
 
-            $session->getFlashBag()->add('success', 'Le poste '.$position.' a bien été supprimé !');
+            $session->getFlashBag()->add('success', 'Le poste ' . $position . ' a bien été supprimé !');
         }
 
         return $this->redirectToRoute('period_edit',array('id'=>$period->getId()));
@@ -409,7 +407,7 @@ class PeriodController extends Controller
             $em->persist($position);
             $em->flush();
 
-            $session->getFlashBag()->add("success", "Créneau fixe réservé avec succès pour " . $position->getShifter());
+            $session->getFlashBag()->add('success', 'Créneau fixe réservé avec succès pour ' . $position->getShifter() . ' : ' . $position);
         }
 
         return $this->redirectToRoute('period_edit',array('id'=>$period->getId()));
@@ -434,7 +432,7 @@ class PeriodController extends Controller
             $em->persist($position);
             $em->flush();
 
-            $session->getFlashBag()->add('success', "Le poste a bien été libéré");
+            $session->getFlashBag()->add('success', 'Le poste ' . $position . ' a bien été libéré !');
         }
 
         return $this->redirectToRoute('period_edit',array('id'=>$position->getPeriod()->getId()));
@@ -461,7 +459,7 @@ class PeriodController extends Controller
             $em->remove($period);
             $em->flush();
 
-            $session->getFlashBag()->add('success', 'Le créneau type a bien été supprimé !');
+            $session->getFlashBag()->add('success', 'Le créneau type ' . $period . ' a bien été supprimé !');
         }
 
         return $this->redirectToRoute('period_admin');

--- a/src/AppBundle/Controller/ShiftExemptionController.php
+++ b/src/AppBundle/Controller/ShiftExemptionController.php
@@ -77,7 +77,7 @@ class ShiftExemptionController extends Controller
         if ($editForm->isSubmitted() && $editForm->isValid()) {
             $this->getDoctrine()->getManager()->flush();
 
-            $session->getFlashBag()->add('success', 'Le motif d\'exemption a bien été modifié !');
+            $session->getFlashBag()->add('success', 'Le motif d\'exemption a bien été édité !');
             return $this->redirectToRoute('admin_shiftexemption_index');
         }
 

--- a/src/AppBundle/Entity/Period.php
+++ b/src/AppBundle/Entity/Period.php
@@ -92,6 +92,14 @@ class Period
     }
 
     /**
+     * Example: Epicerie/Livraison - Lundi - 09:30 à 12:30
+     */
+    public function __toString()
+    {
+        return $this->getJob() . ' - ' . ucfirst($this->getDayOfWeekString()) . ' - ' . $this->getStart()->format('H:i') . ' à ' . $this->getEnd()->format('H:i');
+    }
+
+    /**
      * @ORM\PrePersist
      */
     public function setCreatedAtValue()

--- a/src/AppBundle/Entity/PeriodPosition.php
+++ b/src/AppBundle/Entity/PeriodPosition.php
@@ -85,12 +85,18 @@ class PeriodPosition
     {
     }
 
+    /**
+     * Example: Epicerie/Livraison - Lundi - 09:30 à 12:30 (Semaine D) (sans formation)
+     */
     public function __toString()
     {
-        if ($this->getFormation())
-            return $this->getFormation()->getName();
-        else
-            return "Membre";
+        $name = $this->getPeriod() . ' (Semaine ' . $this->getWeekCycle() . ')';
+        if ($this->getFormation()) {
+            $name .= ' (' . $this->getFormation()->getName() . ')';
+        } else {
+            $name .= ' (sans formation)';
+        }
+        return $name;
     }
 
     /**


### PR DESCRIPTION
### Quoi ?

- ajouté un vrai formulaire pour la libération des postes type
- ajouté des méthodes `__toString` pour les entités `Period` & `PeriodPosition` : pour les afficher de façon uniforme dans l'interface (en particulier les "success messages")

### Captures d'écran

||Avant / Après|
|---|---|
|Modification d'un créneau type|![image](https://user-images.githubusercontent.com/7147385/236514138-cff5bfa2-c8d2-4110-bccb-5fb262df25ba.png) ![image](https://user-images.githubusercontent.com/7147385/236508273-5554522f-6d4a-4660-82a3-208ffb24e13e.png)|
|Création d'un poste type|![image](https://user-images.githubusercontent.com/7147385/236514045-794e32c7-2afb-48cf-81b6-dad27b23e3f2.png) ![image](https://user-images.githubusercontent.com/7147385/236513399-d0d35a6e-4ec2-432e-beb3-4da6cc2f17e1.png)|
|Réservation d'un poste type|![image](https://user-images.githubusercontent.com/7147385/236513794-695775cc-2afa-4ab4-896c-c0f828c07ef4.png) ![image](https://user-images.githubusercontent.com/7147385/236508573-a51b206e-aaca-4f43-856f-ed1cce49a9c7.png)|
|Libération d'un poste type|![image](https://user-images.githubusercontent.com/7147385/236514532-1d935918-7bb5-4566-a1a2-7f0899753591.png) ![image](https://user-images.githubusercontent.com/7147385/236513938-2cdaae34-7706-4c84-a384-1cf619c309a9.png) |
|Suppression d'un poste type|![image](https://user-images.githubusercontent.com/7147385/236513622-4f46313d-4daa-4d8f-962e-6f23fb7275bc.png) ![image](https://user-images.githubusercontent.com/7147385/236509996-a4119d63-a299-43c2-8a87-28d1e8a5a5a1.png)|