### PR TITLE
Optimisations des requêtes SQL (1/4)

### DIFF
--- a/src/AppBundle/Controller/AdminController.php
+++ b/src/AppBundle/Controller/AdminController.php
@@ -85,7 +85,7 @@ class AdminController extends Controller
 
         $action = $form->get('action')->getData();
 
-        $qb = $formHelper->initSearchQuery($this->getDoctrine()->getManager());
+        $qb = $formHelper->initSearchQuery($this->getDoctrine()->getManager(), 'search');
 
         if ($form->isSubmitted() && $form->isValid()) {
             $formHelper->processSearchFormData($form, $qb);

--- a/src/AppBundle/Controller/AmbassadorController.php
+++ b/src/AppBundle/Controller/AmbassadorController.php
@@ -194,7 +194,9 @@ class AmbassadorController extends Controller
         $qb = $formHelper->initSearchQuery($this->getDoctrine()->getManager());
         $qb = $qb->leftJoin("o.registrations", "lr", Join::WITH,'lr.date > r.date')->addSelect("lr")
             ->where('lr.id IS NULL') // registration is the last one registered
-            ->addSelect("(SELECT SUM(ti.time) FROM AppBundle\Entity\TimeLog ti WHERE ti.membership = o.id) AS HIDDEN time");
+            ->addSelect("(SELECT SUM(ti.time) FROM AppBundle\Entity\TimeLog ti WHERE ti.membership = o.id) AS HIDDEN time")
+            ->leftJoin("o.timeLogs", "tl")->addSelect("tl")
+            ->leftJoin("o.notes", "n")->addSelect("n");
 
         if ($form->isSubmitted() && $form->isValid()) {
             $qb = $formHelper->processSearchFormAmbassadorData($form, $qb);

--- a/src/AppBundle/Controller/ShiftFreeLogController.php
+++ b/src/AppBundle/Controller/ShiftFreeLogController.php
@@ -106,7 +106,6 @@ class ShiftFreeLogController extends Controller
         $order = 'DESC';
 
         $qb = $em->getRepository('AppBundle:ShiftFreeLog')->createQueryBuilder('sfl')
-            ->leftJoin("sfl.shift", "s")
             ->orderBy('sfl.' . $sort, $order);
 
         if ($filter["created_at"]) {

--- a/src/AppBundle/Entity/AnonymousBeneficiary.php
+++ b/src/AppBundle/Entity/AnonymousBeneficiary.php
@@ -39,7 +39,7 @@ class AnonymousBeneficiary
     private $email;
 
     /**
-     * @ORM\OneToOne(targetEntity="Beneficiary")
+     * @ORM\OneToOne(targetEntity="Beneficiary", fetch="EAGER")
      * @ORM\JoinColumn(name="join_to", referencedColumnName="id", onDelete="SET NULL")
      * @AppAssert\BeneficiaryCanHost
      */
@@ -67,7 +67,7 @@ class AnonymousBeneficiary
     private $mode;
 
     /**
-     * @ORM\ManyToOne(targetEntity="User")
+     * @ORM\ManyToOne(targetEntity="User", fetch="EAGER")
      * @ORM\JoinColumn(name="registrar_id", referencedColumnName="id", onDelete="SET NULL")
      */
     private $registrar;

--- a/src/AppBundle/Entity/Event.php
+++ b/src/AppBundle/Entity/Event.php
@@ -88,7 +88,7 @@ class Event
     private $end;
 
     /**
-     * @ORM\ManyToOne(targetEntity="EventKind", inversedBy="events")
+     * @ORM\ManyToOne(targetEntity="EventKind", inversedBy="events", fetch="EAGER")
      * @ORM\JoinColumn(name="event_kind_id", referencedColumnName="id", onDelete="SET NULL")
      */
     private $kind;

--- a/src/AppBundle/Entity/HelloassoPayment.php
+++ b/src/AppBundle/Entity/HelloassoPayment.php
@@ -86,7 +86,7 @@ class HelloassoPayment
     private $status;
 
     /**
-     * @ORM\OneToOne(targetEntity="Registration", inversedBy="helloassoPayment")
+     * @ORM\OneToOne(targetEntity="Registration", inversedBy="helloassoPayment", fetch="EAGER")
      * @ORM\JoinColumn(name="registration_id", referencedColumnName="id", onDelete="SET NULL")
      */
     private $registration;

--- a/src/AppBundle/Entity/MembershipShiftExemption.php
+++ b/src/AppBundle/Entity/MembershipShiftExemption.php
@@ -44,7 +44,7 @@ class MembershipShiftExemption
     private $createdBy;
 
     /**
-     * @ORM\ManyToOne(targetEntity="ShiftExemption", inversedBy="membershipShiftExemptions")
+     * @ORM\ManyToOne(targetEntity="ShiftExemption", inversedBy="membershipShiftExemptions", fetch="EAGER")
      * @ORM\JoinColumn(name="shift_exemption_id", referencedColumnName="id")
      */
     private $shiftExemption;

--- a/src/AppBundle/Entity/Period.php
+++ b/src/AppBundle/Entity/Period.php
@@ -46,7 +46,7 @@ class Period
 
     /**
      * One Period has One Job.
-     * @ORM\ManyToOne(targetEntity="Job", inversedBy="periods")
+     * @ORM\ManyToOne(targetEntity="Job", inversedBy="periods", fetch="EAGER")
      * @ORM\JoinColumn(name="job_id", referencedColumnName="id", nullable=false)
      */
     private $job;

--- a/src/AppBundle/Entity/PeriodPosition.php
+++ b/src/AppBundle/Entity/PeriodPosition.php
@@ -24,13 +24,13 @@ class PeriodPosition
 
     /**
      * One Period has One Formation.
-     * @ORM\ManyToOne(targetEntity="Formation")
+     * @ORM\ManyToOne(targetEntity="Formation", fetch="EAGER")
      * @ORM\JoinColumn(name="formation_id", referencedColumnName="id", onDelete="CASCADE")
      */
     private $formation;
 
     /**
-     * @ORM\ManyToOne(targetEntity="Period", inversedBy="positions")
+     * @ORM\ManyToOne(targetEntity="Period", inversedBy="positions", fetch="EAGER")
      * @ORM\JoinColumn(name="period_id", referencedColumnName="id", onDelete="CASCADE")
      */
     private $period;

--- a/src/AppBundle/Entity/Registration.php
+++ b/src/AppBundle/Entity/Registration.php
@@ -74,7 +74,7 @@ class Registration
     private $registrar;
 
     /**
-     * @ORM\OneToOne(targetEntity="HelloassoPayment", mappedBy="registration", cascade={"persist"})
+     * @ORM\OneToOne(targetEntity="HelloassoPayment", mappedBy="registration", cascade={"persist"}, fetch="EAGER")
      */
     private $helloassoPayment;
 

--- a/src/AppBundle/Entity/Shift.php
+++ b/src/AppBundle/Entity/Shift.php
@@ -77,7 +77,7 @@ class Shift
 
     /**
      * One Shift has One Job.
-     * @ORM\ManyToOne(targetEntity="Job", inversedBy="shifts")
+     * @ORM\ManyToOne(targetEntity="Job", inversedBy="shifts", fetch="EAGER")
      * @ORM\JoinColumn(name="job_id", referencedColumnName="id", nullable=false)
      */
     private $job;

--- a/src/AppBundle/Entity/ShiftFreeLog.php
+++ b/src/AppBundle/Entity/ShiftFreeLog.php
@@ -37,7 +37,7 @@ class ShiftFreeLog
     private $createdBy;
 
     /**
-     * @ORM\ManyToOne(targetEntity="Shift", cascade={"remove"})
+     * @ORM\ManyToOne(targetEntity="Shift", inversedBy="shiftFreeLogs", cascade={"remove"}, fetch="EAGER")
      * @ORM\JoinColumn(referencedColumnName="id", onDelete="CASCADE")
      */
     private $shift;

--- a/src/AppBundle/Repository/BeneficiaryRepository.php
+++ b/src/AppBundle/Repository/BeneficiaryRepository.php
@@ -49,17 +49,15 @@ class BeneficiaryRepository extends \Doctrine\ORM\EntityRepository
     /**
      * findAllActive
      *
-     * return all the active beneficiaries meaning with
-     * an active membership
+     * return all the active beneficiaries with an active membership
      */
     public function findAllActive()
     {
-
-        $qb = $this->createQueryBuilder('beneficiary')
-            ->select('beneficiary, membership')
-            ->join('beneficiary.user', 'user')
-            ->join('beneficiary.membership', 'membership')
-            ->where('membership.withdrawn = 0');
+        $qb = $this->createQueryBuilder('b')
+            ->select('b, m')
+            ->join('b.user', 'user')
+            ->join('b.membership', 'm')
+            ->where('m.withdrawn = 0');
 
         return $qb
             ->getQuery()

--- a/src/AppBundle/Repository/EventRepository.php
+++ b/src/AppBundle/Repository/EventRepository.php
@@ -20,8 +20,6 @@ class EventRepository extends \Doctrine\ORM\EntityRepository
     public function findFutures(\DateTime $max = null, EventKind $eventKind = null)
     {
         $qb = $this->createQueryBuilder('e')
-            ->select('e, ek')
-            ->leftJoin('e.kind', 'ek')
             ->where('e.date > :now')
             ->setParameter('now', new \Datetime('now'));
 
@@ -44,7 +42,7 @@ class EventRepository extends \Doctrine\ORM\EntityRepository
             ->getResult();
     }
 
-    public function findPast(int $limit = null)
+    public function findPast(int $limit = null, EventKind $eventKind = null)
     {
         $qb = $this->createQueryBuilder('e')
             ->where('e.date < :now')
@@ -52,6 +50,12 @@ class EventRepository extends \Doctrine\ORM\EntityRepository
 
         if ($limit) {
             $qb->setMaxResults($limit);
+        }
+
+        if ($eventKind) {
+            $qb
+                ->andwhere('e.kind = :kind')
+                ->setParameter('kind', $eventKind);
         }
 
         $qb->orderBy('e.date', 'DESC');

--- a/src/AppBundle/Repository/EventRepository.php
+++ b/src/AppBundle/Repository/EventRepository.php
@@ -20,6 +20,8 @@ class EventRepository extends \Doctrine\ORM\EntityRepository
     public function findFutures(\DateTime $max = null, EventKind $eventKind = null)
     {
         $qb = $this->createQueryBuilder('e')
+            ->leftJoin('e.kind', 'ek')
+            ->addSelect('ek')
             ->where('e.date > :now')
             ->setParameter('now', new \Datetime('now'));
 
@@ -45,6 +47,8 @@ class EventRepository extends \Doctrine\ORM\EntityRepository
     public function findPast(int $limit = null, EventKind $eventKind = null)
     {
         $qb = $this->createQueryBuilder('e')
+            ->leftJoin('e.kind', 'ek')
+            ->addSelect('ek')
             ->where('e.date < :now')
             ->setParameter('now', new \Datetime('now'));
 

--- a/src/AppBundle/Repository/MembershipRepository.php
+++ b/src/AppBundle/Repository/MembershipRepository.php
@@ -25,7 +25,6 @@ class MembershipRepository extends \Doctrine\ORM\EntityRepository
         preg_match('/#(\d+)\s/s', $membership, $matches);
         $membershipMemberNumber = $matches[1];
 
-
         $qb = $this->createQueryBuilder('m')
             ->where('m.member_number = :memberNumber')
             ->setParameter('memberNumber', $membershipMemberNumber);
@@ -35,10 +34,19 @@ class MembershipRepository extends \Doctrine\ORM\EntityRepository
             ->getOneOrNullResult();
     }
 
-    public function findAllActive()
+    /**
+     * return all the active memberships
+     */
+    public function findAllActive($prefetchBeneficiaries = true)
     {
         $qb = $this->createQueryBuilder('m')
             ->where('m.withdrawn = 0');
+
+        if ($prefetchBeneficiaries) {
+            $qb
+                ->leftJoin('m.beneficiaries', 'b')
+                ->addSelect('b');
+        }
 
         return $qb
             ->getQuery()

--- a/src/AppBundle/Service/SearchUserFormHelper.php
+++ b/src/AppBundle/Service/SearchUserFormHelper.php
@@ -320,12 +320,16 @@ class SearchUserFormHelper {
      * @param EntityManager $doctrineManager
      * @return QueryBuilder
      */
-    public function initSearchQuery($doctrineManager) {
+    public function initSearchQuery($doctrineManager, $type = null) {
         $qb = $doctrineManager->getRepository("AppBundle:Membership")->createQueryBuilder('o');
         $qb = $qb->leftJoin("o.beneficiaries", "b")
             ->leftJoin("b.user", "u")
             ->leftJoin("o.registrations", "r")->addSelect("r")
-            ->leftJoin("o.membershipShiftExemptions", "e");
+            ->leftJoin("o.membershipShiftExemptions", "mse")->addSelect("mse");
+        if ($type == 'search') {
+            $qb->leftJoin("b.commissions", "c")->addSelect("b, c");
+            $qb->leftJoin("b.formations", "f")->addSelect("b, f");
+        }
         // do not include admin user
         $qb = $qb->andWhere('o.member_number > 0');
         return $qb;
@@ -426,10 +430,10 @@ class SearchUserFormHelper {
         }
         if ($form->get('exempted')->getData() > 0) {
             if ($form->get('exempted')->getData() == 2) {
-                $qb = $qb->andWhere('e.start <= :date AND e.end >= :date')
+                $qb = $qb->andWhere('mse.start <= :date AND mse.end >= :date')
                          ->setParameter('date', $now);
             } else if ($form->get('exempted')->getData() == 1) {
-                $qb = $qb->andWhere('e.start IS NULL OR e.start > :date OR e.end < :date')
+                $qb = $qb->andWhere('mse.start IS NULL OR mse.start > :date OR mse.end < :date')
                          ->setParameter('date', $now);
             }
         }
@@ -559,9 +563,8 @@ class SearchUserFormHelper {
                 $ids_groups = array();
                 foreach ($formations as $formation) {
                     $tmp_qb = clone $qb;
-                    $tmp_qb = $tmp_qb->leftjoin("b.formations", "ro")
-                        ->andWhere('ro.id IN (:rid)')
-                        ->setParameter('rid', $formation );
+                    $tmp_qb = $tmp_qb->andWhere('f.id IN (:fid)')
+                        ->setParameter('fid', $formation);
                     $ids_groups[] = $tmp_qb->select('DISTINCT o.id')->getQuery()->getArrayResult();
                 }
                 $ids = $ids_groups[0];
@@ -576,26 +579,23 @@ class SearchUserFormHelper {
                 $qb = $qb->andWhere('o.id IN (:all_formations)')
                     ->setParameter('all_formations', $ids);
             } else {
-                $qb = $qb->leftjoin("b.formations", "ro")
-                    ->andWhere('ro.id IN (:rids)')
-                    ->setParameter('rids', $form->get('formations')->getData());
+                $qb = $qb->andWhere('f.id IN (:fids)')
+                    ->setParameter('fids', $form->get('formations')->getData());
                 $join_formations = true;
             }
         }
         $join_commissions = false;
         if ($form->get('commissions')->getData() && count($form->get('commissions')->getData())) {
-            $qb = $qb->leftjoin("b.commissions", "c")
-                ->andWhere('c.id IN (:cids)')
-                ->setParameter('cids', $form->get('commissions')->getData() );
+            $qb->andWhere('c.id IN (:cids)')
+                ->setParameter('cids', $form->get('commissions')->getData());
             $join_commissions = true;
         }
         if ($form->get('not_formations')->getData() && count($form->get('not_formations')->getData())) {
             $nrqb = clone $qb;
             if (!$join_formations) {
-                $nrqb = $nrqb->leftjoin("b.formations", "ro")
-                    ->andWhere('ro.id IN (:rids)');
+                $nrqb = $nrqb->andWhere('f.id IN (:fids)');
             }
-            $nrqb->setParameter('rids', $form->get('not_formations')->getData() );
+            $nrqb->setParameter('fids', $form->get('not_formations')->getData() );
             $subQuery = $nrqb->select('DISTINCT o.id')->getQuery()->getArrayResult();
 
             if (count($subQuery)) {
@@ -607,10 +607,9 @@ class SearchUserFormHelper {
         if ($form->get('not_commissions')->getData() && count($form->get('not_commissions')->getData())) {
             $ncqb = clone $qb;
             if (!$join_commissions) {
-                $ncqb = $ncqb->leftjoin("b.commissions", "c")
-                    ->andWhere('c.id IN (:cids)');
+                $ncqb->andWhere('c.id IN (:cids)');
             }
-            $ncqb->setParameter('cids', $form->get('not_commissions')->getData() );
+            $ncqb->setParameter('cids', $form->get('not_commissions')->getData());
             $subQuery = $ncqb->select('DISTINCT o.id')->getQuery()->getArrayResult();
 
             if (count($subQuery)) {

--- a/src/AppBundle/Service/SearchUserFormHelper.php
+++ b/src/AppBundle/Service/SearchUserFormHelper.php
@@ -322,14 +322,14 @@ class SearchUserFormHelper {
      */
     public function initSearchQuery($doctrineManager, $type = null) {
         $qb = $doctrineManager->getRepository("AppBundle:Membership")->createQueryBuilder('o');
-        $qb = $qb->leftJoin("o.beneficiaries", "b")
-            ->leftJoin("b.user", "u")
+        $qb = $qb->leftJoin("o.beneficiaries", "b")->addSelect("b")
+            ->leftJoin("b.user", "u")->addSelect("u")
             ->leftJoin("o.registrations", "r")->addSelect("r")
             ->leftJoin("r.helloassoPayment", "rhp")->addSelect("rhp")
             ->leftJoin("o.membershipShiftExemptions", "mse")->addSelect("mse");
         if ($type == 'search') {
-            $qb->leftJoin("b.commissions", "c")->addSelect("b, c");
-            $qb->leftJoin("b.formations", "f")->addSelect("b, f");
+            $qb->leftJoin("b.commissions", "c")->addSelect("c");
+            $qb->leftJoin("b.formations", "f")->addSelect("f");
         }
         // do not include admin user
         $qb = $qb->andWhere('o.member_number > 0');

--- a/src/AppBundle/Service/SearchUserFormHelper.php
+++ b/src/AppBundle/Service/SearchUserFormHelper.php
@@ -325,6 +325,7 @@ class SearchUserFormHelper {
         $qb = $qb->leftJoin("o.beneficiaries", "b")
             ->leftJoin("b.user", "u")
             ->leftJoin("o.registrations", "r")->addSelect("r")
+            ->leftJoin("r.helloassoPayment", "rhp")->addSelect("rhp")
             ->leftJoin("o.membershipShiftExemptions", "mse")->addSelect("mse");
         if ($type == 'search') {
             $qb->leftJoin("b.commissions", "c")->addSelect("b, c");


### PR DESCRIPTION
### Quoi ?

- utiliser `fetch="EAGER"` pour réduire le nombre de requêtes N+1
- ajouter des `leftJoin / addSelect`

|Page|Nombre de requêtes avant|Nombre de requêtes après|Commentaire|
|---|---|---|---|
|`/`|41|31|✅|
|`/booking`|13||pas de besoins d'optimisations|
|`/schedule`|7||pas de besoins d'optimisations|
|`/period`|810 :warning:||#846|
|`user/pre_users`|63|43|✅ (améliorations possibles, mais pas prioritaire)|
|`ambassador/noregistration`|79|23|✅|
|`ambassador/lateregistration`|?||
|`/admin/users`|341 :warning:|11 :tada:|✅|
|`/member/2121/show`|2825 :warning:||#848|
|`ambassador/shifttimelog`|184 :warning:|9 :tada:|✅|
|`/admin/membershipshiftexemption/`|302 :warning:|11 :tada:|✅|
|`/commissions`|11||pas de besoins d'optimisations|
|`/admin/formations`|27||pas de besoins d'optimisations|
|`/booking/admin`|238 :warning:|238|#847|
|`/admin/shifts/freelogs/`|28|12|✅|
|`/period/admin`|459 :warning:|451|#846|
|`/event`|9|8|✅|
|`/helloasso/payments`|155 :warning:|106|todo|

> todo = prochaine PR