### PR TITLE
Créneaux : optimisation des requêtes SQL

### DIFF
--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -41,6 +41,7 @@ services:
     AppBundle\Controller\BookingController:
         arguments:
             - "%use_fly_and_fixed%"
+            - "%display_name_shifters%"
     AppBundle\Controller\ShiftController:
         arguments:
             - "%forbid_own_shift_book_admin%"

--- a/src/AppBundle/Controller/BookingController.php
+++ b/src/AppBundle/Controller/BookingController.php
@@ -94,6 +94,7 @@ class BookingController extends Controller
     public function indexAction(Request $request)
     {
         $session = new Session();
+
         $mode = null;
         if ($this->getUser()->getBeneficiary() == null) {
             $session->getFlashBag()->add('error', 'Oups, tu n\'as pas de bénéficiaire enregistré ! MODE ADMIN');
@@ -129,8 +130,8 @@ class BookingController extends Controller
 
         //beneficiary selected, or only one beneficiary
         if ($beneficiaryForm->isSubmitted() || $beneficiaries->count() == 1) {
-
             $em = $this->getDoctrine()->getManager();
+
             if ($beneficiaries->count() > 1) {
                 $beneficiary = $beneficiaryForm->get('beneficiary')->getData();
             } else {
@@ -153,7 +154,6 @@ class BookingController extends Controller
             ]);
 
         } else { // no beneficiary selected
-
             return $this->render('booking/index.html.twig', [
                 'beneficiary_form' => $beneficiaryForm->createView(),
             ]);
@@ -307,18 +307,13 @@ class BookingController extends Controller
         $em = $this->getDoctrine()->getManager();
         $filter = $this->adminFilterFormFactory($em, $request);
 
-        $jobs = $em->getRepository(Job::class)->findByEnabled(true);
-        $beneficiaries = $em->getRepository(Beneficiary::class)->findAllActive();
-        $shifts = $em->getRepository(Shift::class)->findFrom($filter["from"], $filter["to"], $filter["job"]);
-
+        $shifts = $em->getRepository(Shift::class)->findFrom($filter["from"], $filter["to"], $filter["job"], true);
         $bucketsByDay = $this->get('shift_service')->generateShiftBucketsByDayAndJob($shifts);
         $bucketsByDay = $this->get('shift_service')->filterBucketsByDayAndJobByFilling($bucketsByDay, $filter["filling"]);
 
         return $this->render('admin/booking/index.html.twig', [
             'filterForm' => $filter["form"]->createView(),
             'bucketsByDay' => $bucketsByDay,
-            'jobs' => $jobs,
-            'beneficiaries' => $beneficiaries,
         ]);
     }
 

--- a/src/AppBundle/Controller/BookingController.php
+++ b/src/AppBundle/Controller/BookingController.php
@@ -41,11 +41,13 @@ class BookingController extends Controller
     /**
      * @var boolean
      */
-    private $useFlyAndFixed;
+    private $use_fly_and_fixed;
+    private $display_name_shifters;
 
-    public function __construct(bool $useFlyAndFixed)
+    public function __construct(bool $use_fly_and_fixed, bool $display_name_shifters)
     {
-        $this->useFlyAndFixed = $useFlyAndFixed;
+        $this->use_fly_and_fixed = $use_fly_and_fixed;
+        $this->display_name_shifters = $display_name_shifters;
     }
 
     /**
@@ -138,7 +140,7 @@ class BookingController extends Controller
                 $beneficiary = $beneficiaries->first();
             }
 
-            $shifts = $em->getRepository('AppBundle:Shift')->findFutures();
+            $shifts = $em->getRepository('AppBundle:Shift')->findFutures(null, null, $this->display_name_shifters);
             $bucketsByDay = $this->get('shift_service')->generateShiftBucketsByDayAndJob($shifts);
 
             $hours = array();
@@ -558,7 +560,7 @@ class BookingController extends Controller
             ->setAction($this->generateUrl('shift_book_admin', array('id' => $shift->getId())))
             ->add('shifter', AutocompleteBeneficiaryType::class, array('label' => 'Numéro d\'adhérent ou nom du membre', 'required' => true));
 
-        if ($this->useFlyAndFixed) {
+        if ($this->use_fly_and_fixed) {
             $form = $form->add('fixe', RadioChoiceType::class, [
                 'choices'  => [
                     'Volant' => 0,

--- a/src/AppBundle/Repository/ShiftRepository.php
+++ b/src/AppBundle/Repository/ShiftRepository.php
@@ -24,11 +24,11 @@ class ShiftRepository extends \Doctrine\ORM\EntityRepository
     {
         $qb = $this->createQueryBuilder('s');
         $qb
-            ->leftJoin('s.shifter', 'u')
-            ->addSelect('u')
-            ->leftJoin('u.formations', 'f')
+            ->leftJoin('s.shifter', 'b')
+            ->addSelect('b')
+            ->leftJoin('b.formations', 'f')
             ->addSelect('f')
-            ->leftJoin('u.membership', 'm')
+            ->leftJoin('b.membership', 'm')
             ->addSelect('m')
             ->where('s.start = :start')
             ->andWhere('s.end = :end')
@@ -47,45 +47,13 @@ class ShiftRepository extends \Doctrine\ORM\EntityRepository
             ->getResult();
     }
 
-    public function findFutures(\DateTime $max = null, Job $job = null)
+    public function findFrom(\DateTime $from, \DateTime $max = null, Job $job = null, $withShifters = null)
     {
         $qb = $this->createQueryBuilder('s')
-            ->select('s, j')
             ->leftJoin('s.job', 'j')
-            ->where('s.start > :now')
-            ->setParameter('now', new \Datetime('now'));
-
-        if ($max) {
-            $qb
-                ->andWhere('s.end < :max')
-                ->setParameter('max', $max);
-        }
-
-        if ($job) {
-            $qb
-                ->andwhere('s.job = :job')
-                ->setParameter('job', $job);
-        }
-
-        $qb->orderBy('s.start', 'ASC');
-
-        return $qb
-            ->getQuery()
-            ->getResult();
-    }
-
-    public function findFrom(\DateTime $from, \DateTime $max = null, Job $job=null)
-    {
-        $qb = $this->createQueryBuilder('s');
-
-        $qb
-            ->select('s, j, f')
-            ->leftJoin('s.job', 'j')
-            ->leftJoin('s.formation', 'f')
-            ->leftJoin('s.shifter', 'b')
-            ->addSelect('b')
-            ->leftJoin('b.formations', 'bf')
-            ->addSelect('bf')
+            ->addSelect('j')
+            ->leftJoin('s.formation', 'sf')
+            ->addSelect('sf')
             ->where('s.start > :from')
             ->setParameter('from', $from);
 
@@ -101,11 +69,28 @@ class ShiftRepository extends \Doctrine\ORM\EntityRepository
                 ->setParameter('job', $job);
         }
 
+        if ($withShifters) {
+            $qb
+                ->leftJoin('s.shifter', 'b')
+                ->addSelect('b')
+                ->leftJoin('b.formations', 'bf')
+                ->addSelect('bf')
+                ->leftJoin('b.shifts', 'bs')  // for Beneficiary.isNew()
+                ->addSelect('bs');
+        }
+
         $qb->orderBy('s.start', 'ASC');
 
         return $qb
             ->getQuery()
             ->getResult();
+    }
+
+    public function findFutures(\DateTime $max = null, Job $job = null, $withShifters = null)
+    {
+        $now = new \Datetime('now');
+
+        return $this->findFrom($now, $max, $job, $withShifters);
     }
 
     /**


### PR DESCRIPTION
Suite de #845

### Quoi ?

Optimiser le chargement des pages qui affichent des créneaux.

|Page|Nombre de requêtes avant|Nombre de requêtes après|Commentaire|
|---|---|---|---|
|`/booking`|13||pas besoin|
|`/schedule`|7||pas besoin|
|`/booking/admin`|238|10 :tada:|✅|