### PR TITLE
PeriodPositionFreeLog : autoriser la suppression par un SUPER_ADMIN

### DIFF
--- a/app/Resources/views/admin/index.html.twig
+++ b/app/Resources/views/admin/index.html.twig
@@ -72,7 +72,7 @@
                     <i class="material-icons left orange-text">date_range</i>Gérer la semaine type
                 </a>
                 <a href="{{ path("admin_periodpositionfreelog_list") }}" class="waves-effect waves-light btn orange">
-                    <i class="material-icons left">delete_sweep</i>Annulations postes fixes
+                    <i class="material-icons left">delete_sweep</i>Annulations postes types
                 </a>
             {% endif %}
 

--- a/app/Resources/views/admin/periodpositionfreelog/list.html.twig
+++ b/app/Resources/views/admin/periodpositionfreelog/list.html.twig
@@ -62,6 +62,9 @@
                 {% if is_granted("ROLE_ADMIN") %}
                     <th>Route</th>
                 {% endif %}
+                {% if is_granted("ROLE_SUPER_ADMIN") %}
+                    <th>Actions</th>
+                {% endif %}
             </tr>
         </thead>
 
@@ -98,6 +101,16 @@
                 </td>
                 {% if is_granted("ROLE_ADMIN") %}
                     <td>{{ periodPositionFreeLog.requestRoute }}</td>
+                {% endif %}
+                {% if is_granted("ROLE_SUPER_ADMIN") %}
+                    <td>
+                        {{ form_start(period_position_free_log_delete_forms_[periodPositionFreeLog.id]) }}
+                        {{ form_widget(period_position_free_log_delete_forms_[periodPositionFreeLog.id]) }}
+                        <button type="submit" class="btn-floating waves-effect waves-light red" title="Supprimer" onclick="return confirm('Etes-vous sûr de vouloir supprimer cette annulation de poste type ?!');">
+                            <i class="material-icons left">delete</i>
+                        </button>
+                        {{ form_end(period_position_free_log_delete_forms_[periodPositionFreeLog.id]) }}
+                    </td>
                 {% endif %}
             </tr>
         {% endfor %}

--- a/src/AppBundle/Controller/PeriodPositionFreeLogController.php
+++ b/src/AppBundle/Controller/PeriodPositionFreeLogController.php
@@ -108,12 +108,54 @@ class PeriodPositionFreeLogController extends Controller
             ->setFirstResult($limitPerPage * ($currentPage-1)) // set the offset
             ->setMaxResults($limitPerPage); // set the limit
 
+        $periodPositionFreeLogDeleteForms = [];
+        foreach ($paginator as $periodPositionFreeLog) {
+            $periodPositionFreeLogDeleteForms[$periodPositionFreeLog->getId()] = $this->getDeleteForm($periodPositionFreeLog)->createView();
+        }
+
         return $this->render('admin/periodpositionfreelog/list.html.twig', array(
             'periodPositionFreeLogs' => $paginator,
             'filter_form' => $filter['form']->createView(),
             'result_count' => $resultCount,
             'current_page' => $currentPage,
             'page_count' => $pageCount,
+            'period_position_free_log_delete_forms_' => $periodPositionFreeLogDeleteForms,
         ));
+    }
+
+    /**
+     * Delete PeriodPositionFreeLog
+     *
+     * @Route("/{id}", name="admin_periodpositionfreelog_delete", methods={"DELETE"})
+     * @Security("has_role('ROLE_SUPER_ADMIN')")
+     */
+    public function deleteAction(Request $request, PeriodPositionFreeLog $periodPositionFreeLog)
+    {
+        $session = new Session();
+        $em = $this->getDoctrine()->getManager();
+
+        $form = $this->getDeleteForm($periodPositionFreeLog);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $em->remove($periodPositionFreeLog);
+            $em->flush();
+
+            $session->getFlashBag()->add('success', 'Le log d\'annulation de poste type a bien été supprimé !');
+        }
+
+        return $this->redirectToRoute('admin_periodpositionfreelog_list');
+    }
+
+    /**
+     * @param PeriodPositionFreeLog $periodPositionFreeLog
+     * @return \Symfony\Component\Form\FormInterface
+     */
+    protected function getDeleteForm(PeriodPositionFreeLog $periodPositionFreeLog)
+    {
+        return $this->get('form.factory')->createNamedBuilder('period_position_free_log_delete_forms_' . $periodPositionFreeLog->getId())
+            ->setAction($this->generateUrl('admin_periodpositionfreelog_delete', array('id' => $periodPositionFreeLog->getId())))
+            ->setMethod('DELETE')
+            ->getForm();
     }
 }


### PR DESCRIPTION
Suite de #840 ; similaire à #832

### Quoi ?

Dans de rares cas, on souhaite pouvoir supprimer un PeriodPositionFreeLog.
Comme c'est le cas pour les TimeLog, on autorise les ROLE_SUPER_ADMIN à supprimer.

### Capture d'écran

![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/2b9a00e4-a656-4956-a39f-2121dae8464f)
