### PR TITLE
Time logs : utiliser la méthode DELETE lors de la suppression

### DIFF
--- a/app/Resources/views/default/tools/_postit.html.twig
+++ b/app/Resources/views/default/tools/_postit.html.twig
@@ -34,12 +34,12 @@
                     {{ child.textWithBr  | markdown | raw }}
                 </p>
             </div>
-                {{ form_start(notes_delete_form[child.id], {'attr': {'id': 'form_note_delete_'~child.id }}) }}
-                {{ form_widget(notes_delete_form[child.id]) }}
-                {{ form_end(notes_delete_form[child.id]) }}
+                {{ form_start(note_delete_forms[child.id], {'attr': {'id': 'form_note_delete_'~child.id }}) }}
+                {{ form_widget(note_delete_forms[child.id]) }}
+                {{ form_end(note_delete_forms[child.id]) }}
             {% endfor %}
             {{ form_start(new_notes_form[note.id], {'attr': {'id': 'new_note_form_child_'~note.id ,'class':'reply'}}) }}
-                {{ form_row(new_notes_form[note.id].text, {'id': 'note_text_reply_'~note.id}) }}
+            {{ form_row(new_notes_form[note.id].text, {'id': 'note_text_reply_'~note.id}) }}
             {{ form_end(new_notes_form[note.id]) }}
         </div>
         <div class="modal-footer">
@@ -54,7 +54,7 @@
                     Ajouter une réponse
                 </h4>
             {{ form_start(new_notes_form[note.id], {'attr': {'id': 'new_note_form_'~note.id ,'class':'reply'}}) }}
-                {{ form_row(new_notes_form[note.id].text, {'id': 'note_text_reply_'~note.id}) }}
+            {{ form_row(new_notes_form[note.id].text, {'id': 'note_text_reply_'~note.id}) }}
             {{ form_end(new_notes_form[note.id]) }}
             </div>
             <div class="modal-footer">
@@ -70,13 +70,13 @@
     <div class="modal-content">
         <h4>Editer ce post-it</h4>
         {{ form_start(notes_form[note.id], {'attr': {'id': 'form_note_edit_'~note.id,'class': 'edit-post-it' }}) }}
-            {{ form_row(notes_form[note.id].text, {'id': 'note_text_edit_'~note.id}) }}
+        {{ form_row(notes_form[note.id].text, {'id': 'note_text_edit_'~note.id}) }}
         {{ form_end(notes_form[note.id]) }}
 
         {% if is_granted('delete',note) %}
-        {{ form_start(notes_delete_form[note.id], {'attr': {'id': 'form_note_delete_'~note.id }}) }}
-        {{ form_widget(notes_delete_form[note.id]) }}
-        {{ form_end(notes_delete_form[note.id]) }}
+        {{ form_start(note_delete_forms[note.id], {'attr': {'id': 'form_note_delete_'~note.id }}) }}
+        {{ form_widget(note_delete_forms[note.id]) }}
+        {{ form_end(note_delete_forms[note.id]) }}
         {% endif %}
     </div>
     <div class="modal-footer">

--- a/app/Resources/views/member/_partial/time_logs.html.twig
+++ b/app/Resources/views/member/_partial/time_logs.html.twig
@@ -1,3 +1,5 @@
+{% set from_admin = from_admin ?? false %}
+
 <table>
     <thead>
         <tr>
@@ -24,64 +26,67 @@
     </tbody>
 </table>
 
-{% if (from_admin ?? false) and is_granted("ROLE_SHIFT_MANAGER") %}
+<div style="max-height:500px;overflow:scroll;">
+    <table>
+        <thead>
+            <tr class="grey lighten-2">
+                <th>Date du log</th>
+                <th>Auteur</th>
+                <th>Temps</th>
+                <th>Motif</th>
+                <th>Créneau</th>
+                {% if from_admin and is_granted("ROLE_ADMIN") %}
+                    <th>Route</th>
+                {% endif %}
+                {% if from_admin and is_granted("ROLE_SUPER_ADMIN") %}
+                    <th>Actions</th>
+                {% endif %}
+            </tr>
+        </thead>
+        <tbody>
+            {% for timeLog in member.timeLogs %}
+                <tr class="{% if timeLog.type == 20 %}blue{% elseif timeLog.time > 0 %}green{% elseif timeLog.time < 0 %}red{% else %}grey{% endif %} lighten-5">
+                    <td title="{{ timeLog.createdAt | date_fr_full_with_time }}">{{ timeLog.createdAt | date('d/m/Y') }}</td>
+                    <td>{{ timeLog.createdBy }}</td>
+                    <td>{{ timeLog.time | duration_from_minutes }}</td>
+                    <td>{{ timeLog.typeDisplay }}</td>
+                    <td>
+                        {% if timeLog.shift %}
+                            {{ timeLog.shift.job.name }} du {{ timeLog.shift.start | date('d/m/Y') }} de {{ timeLog.shift.start | date('H:i') }} à {{ timeLog.shift.end | date('H:i') }}
+                            {% if timeLog.shift.shifter %}
+                                ({{ timeLog.shift.shifter }})
+                            {% endif %}
+                        {% endif %}
+                    </td>
+                    {% if from_admin and is_granted("ROLE_ADMIN") %}
+                        <td>{{ timeLog.requestRoute }}</td>
+                    {% endif %}
+                    {% if from_admin and is_granted("ROLE_SUPER_ADMIN") %}
+                        <td title="Supprimer">
+                            <a href="{{ path('member_timelog_delete', { "id": member.id, "timelog_id": timeLog.id }) }}" class="red-text">X</a>
+                        </td>
+                    {% endif %}
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+
+{% if from_admin and is_granted("ROLE_SHIFT_MANAGER") %}
+    <br />
     <a href="#add-time-log" class="modal-trigger waves-effect waves-light btn teal">
         <i class="material-icons left">add</i>Ajouter un log de temps
     </a>
-    {{ form_start(time_log_form) }}
+    {{ form_start(time_log_new_form) }}
     <div id="add-time-log" class="modal">
         <div class="modal-content">
             <h5><i class="material-icons left small">access_time</i>Ajouter un log de temps</h5>
-            {{ form_widget(time_log_form) }}
+            {{ form_widget(time_log_new_form) }}
         </div>
         <div class="modal-footer">
             <a href="#!" class="modal-action modal-close waves-effect waves-green btn-flat orange-text">Annuler</a>
             <button type="submit" class="btn green"><i class="material-icons left">add</i>Ajouter le log de temps</button>
         </div>
     </div>
-    {{ form_end(time_log_form) }}
+    {{ form_end(time_log_new_form) }}
 {% endif %}
-
-<table>
-    <thead>
-        <tr class="grey lighten-2">
-            <th>Date du log</th>
-            <th>Auteur</th>
-            <th>Temps</th>
-            <th>Motif</th>
-            <th>Créneau</th>
-            {% if (from_admin ?? false) and is_granted("ROLE_ADMIN") %}
-                <th>Route</th>
-            {% endif %}
-            {% if (from_admin ?? false) and is_granted("ROLE_SUPER_ADMIN") %}
-                <th>Actions</th>
-            {% endif %}
-        </tr>
-    </thead>
-    <tbody>
-        {% for timeLog in member.timeLogs %}
-            <tr class="{% if timeLog.type == 20 %}blue{% elseif timeLog.time > 0 %}green{% elseif timeLog.time < 0 %}red{% else %}grey{% endif %} lighten-5">
-                <td title="{{ timeLog.createdAt | date_fr_full_with_time }}">{{ timeLog.createdAt | date('d/m/Y') }}</td>
-                <td>{{ timeLog.createdBy }}</td>
-                <td>{{ timeLog.time | duration_from_minutes }}</td>
-                <td>{{ timeLog.typeDisplay }}</td>
-                <td>
-                    {% if timeLog.shift %}
-                        {{ timeLog.shift.job.name }} du {{ timeLog.shift.start | date('d/m/Y') }} de {{ timeLog.shift.start | date('H:i') }} à {{ timeLog.shift.end | date('H:i') }}
-                        {% if timeLog.shift.shifter %}
-                            ({{ timeLog.shift.shifter }})
-                        {% endif %}
-                    {% endif %}
-                </td>
-                {% if (from_admin ?? false) and is_granted("ROLE_ADMIN") %}
-                    <td>{{ timeLog.requestRoute }}</td>
-                {% endif %}
-                {% if (from_admin ?? false) and is_granted("ROLE_SUPER_ADMIN") %}
-                    <td title="Supprimer">
-                        <a href="{{ path('member_timelog_delete', { "id": member.id, "timelog_id": timeLog.id }) }}" class="red-text">X</a>
-                    </td>
-                {% endif %}
-            </tr>
-        {% endfor %}
-    </tbody>
-</table>

--- a/app/Resources/views/member/_partial/time_logs.html.twig
+++ b/app/Resources/views/member/_partial/time_logs.html.twig
@@ -1,4 +1,5 @@
 {% set from_admin = from_admin ?? false %}
+{% set time_log_delete_forms = time_log_delete_forms ?? [] %}
 
 <table>
     <thead>
@@ -62,9 +63,14 @@
                         <td>{{ timeLog.requestRoute }}</td>
                     {% endif %}
                     {% if from_admin and is_granted("ROLE_SUPER_ADMIN") %}
-                        <td title="Supprimer">
-                            <a href="{{ path('member_timelog_delete', { "id": member.id, "timelog_id": timeLog.id }) }}" class="red-text">X</a>
-                        </td>
+                    <td>
+                        {{ form_start(time_log_delete_forms[timeLog.id], {'attr': {'id': 'form_time_log_delete_'~timeLog.id }}) }}
+                        {{ form_widget(time_log_delete_forms[timeLog.id]) }}
+                        <button type="submit" class="btn-floating red" title="Supprimer" onclick="return confirm('Etes-vous sûr de vouloir supprimer ce time log ?!');">
+                            <i class="material-icons left">delete</i>
+                        </button>
+                        {{ form_end(time_log_delete_forms[timeLog.id]) }}
+                    </td>
                     {% endif %}
                 </tr>
             {% endfor %}

--- a/app/Resources/views/member/show.html.twig
+++ b/app/Resources/views/member/show.html.twig
@@ -147,7 +147,7 @@
                 <i class="material-icons">access_time</i>Compteur de temps
             </div>
             <div class="collapsible-body white">
-                {% include "member/_partial/time_logs.html.twig" with { member: member, from_admin: true, time_log_form: time_log_form } %}
+                {% include "member/_partial/time_logs.html.twig" with { member: member, from_admin: true, time_log_new_form: time_log_new_form } %}
             </div>
         </li>
 

--- a/app/Resources/views/member/show.html.twig
+++ b/app/Resources/views/member/show.html.twig
@@ -154,7 +154,7 @@
                 <i class="material-icons">access_time</i>Compteur de temps
             </div>
             <div class="collapsible-body white">
-                {% include "member/_partial/time_logs.html.twig" with { member: member, from_admin: true, time_log_new_form: time_log_new_form } %}
+                {% include "member/_partial/time_logs.html.twig" with { member: member, from_admin: true, time_log_new_form: time_log_new_form, time_log_delete_forms: time_log_delete_forms } %}
             </div>
         </li>
 

--- a/app/Resources/views/member/show.html.twig
+++ b/app/Resources/views/member/show.html.twig
@@ -33,6 +33,7 @@
         {% endif %}
     </h4>
 
+    <!-- Détails sur le(s) bénéficiaire(s) -->
     {% if member.beneficiaries | length %}
         <div class="row">
             {% for beneficiary in member.beneficiariesWithMainInFirstPosition %}
@@ -41,6 +42,7 @@
         </div>
     {% endif %}
 
+    <!-- Note(s) -->
     {% if member.notes | length %}
         <h5>Note{% if member.notes | length > 1 %}s{% endif %} à propos de ce membre</h5>
         <div class="row">
@@ -54,11 +56,12 @@
         </div>
     {% endif %}
 
+    <!-- Ajouter un bénéficiaire -->
     {% if is_granted("beneficiary_add", member) and member.beneficiaries | length < maximum_nb_of_beneficiaries_in_membership %}
         <ul class="collapsible">
             <li>
                 <div class="collapsible-header"><i class="material-icons">person_add</i>Ajouter un bénéficiaire</div>
-                <div class="collapsible-body new_registration_form">
+                <div class="collapsible-body white new_registration_form">
                     {{ form_start(new_beneficiary_form) }}
                     {% include "beneficiary/_partial/beneficiary_form.html.twig" with { form: new_beneficiary_form } %}
                     <div class="col s3">
@@ -71,6 +74,7 @@
     {% endif %}
 
     <ul class="collapsible collapsible-expandable">
+        <!-- Adhésion(s) -->
         <li id="registration" class="{% if frontend_cookie and frontend_cookie.user_show is defined and frontend_cookie.user_show.registration_open is defined and frontend_cookie.user_show.registration_open %}active{% endif %}">
             <div class="collapsible-header">
                 <i class="material-icons">card_membership</i>Adhésions
@@ -126,6 +130,8 @@
                 {% endif %}
             </div>
         </li>
+
+        <!-- Ajouter une note -->
         {% if is_granted("create", note) %}
             <li id="note">
                 <div class="collapsible-header {% if frontend_cookie and frontend_cookie.user_show is defined and frontend_cookie.user_show.note_open is defined and frontend_cookie.user_show.note_open %}active{% endif %}">
@@ -142,6 +148,7 @@
             </li>
         {% endif %}
 
+        <!-- Compteur de temps -->
         <li id="time_log">
             <div class="collapsible-header {% if frontend_cookie and frontend_cookie.user_show is defined and frontend_cookie.user_show.time_log_open is defined and frontend_cookie.user_show.time_log_open %}active{% endif %}">
                 <i class="material-icons">access_time</i>Compteur de temps
@@ -151,6 +158,7 @@
             </div>
         </li>
 
+        <!-- Créneaux -->
         <li id="shifts">
             <div class="collapsible-header {% if frontend_cookie and frontend_cookie.user_show is defined and frontend_cookie.user_show.shifts_open is defined and frontend_cookie.user_show.shifts_open %}active{% endif %}">
                 <i class="material-icons">date_range</i>Créneaux
@@ -160,6 +168,7 @@
             </div>
         </li>
 
+        <!-- Badges -->
         {% if is_granted("ROLE_USER_MANAGER") %}
             <li id="badges">
                 <div class="collapsible-header {% if frontend_cookie and frontend_cookie.user_show is defined and frontend_cookie.user_show.badges_open is defined and frontend_cookie.user_show.badges_open %}active{% endif %}">
@@ -219,6 +228,7 @@
             </li>
         {% endif %}
 
+        <!-- Geler/Dégeler le compte -->
         {% if is_granted("ROLE_USER_MANAGER") %}
             <li id="freeze">
                 <div class="collapsible-header {% if frontend_cookie and frontend_cookie.user_show is defined and frontend_cookie.user_show.freeze_open is defined and frontend_cookie.user_show.freeze_open %}active{% endif %}">
@@ -305,6 +315,7 @@
             </li>
         {% endif %}
 
+        <!-- Fermer le compte -->
         {% if is_granted("ROLE_USER_MANAGER") and is_granted("close",member) %}
             <li id="close">
                 <div class="collapsible-header {% if frontend_cookie and frontend_cookie.user_show is defined and frontend_cookie.user_show.close_open is defined and frontend_cookie.user_show.close_open %}active{% endif %}">
@@ -370,6 +381,7 @@
             </li>
         {% endif %}
 
+        <!-- Rôles -->
         {% if is_granted("ROLE_ADMIN") %}
             <li id="super">
                 <div class="collapsible-header {% if frontend_cookie and frontend_cookie.user_show is defined and frontend_cookie.user_show.admin_open is defined and frontend_cookie.user_show.admin_open %}active{% endif %}">
@@ -381,6 +393,7 @@
             </li>
         {% endif %}
 
+        <!-- Actions super admin (supprimer le membre ; adhésions enregistrées) -->
         {% if is_granted("ROLE_SUPER_ADMIN") %}
             <li id="super">
                 <div class="collapsible-header {% if frontend_cookie and frontend_cookie.user_show is defined and frontend_cookie.user_show.super_admin_open is defined and frontend_cookie.user_show.super_admin_open %}active{% endif %}">

--- a/app/Resources/views/user/_partial/note.html.twig
+++ b/app/Resources/views/user/_partial/note.html.twig
@@ -20,13 +20,13 @@
             </div>
         </div>
         {% if note.children | length %}
-        <div class="row">
-            <div class="col s12">
-                {% for child in note.children %}
-                    {% include "user/_partial/note.html.twig" with { note: child } %}
-                {% endfor %}
+            <div class="row">
+                <div class="col s12">
+                    {% for child in note.children %}
+                        {% include "user/_partial/note.html.twig" with { note: child } %}
+                    {% endfor %}
+                </div>
             </div>
-        </div>
         {% endif %}
     </div>
 
@@ -62,9 +62,9 @@
             </p>
         {% endif %}
     </div>
-    {{ form_start(notes_delete_form[note.id], {'attr': {'id': 'form_note_delete_'~note.id }}) }}
-        {{ form_widget(notes_delete_form[note.id]) }}
-    {{ form_end(notes_delete_form[note.id]) }}
+    {{ form_start(note_delete_forms[note.id], {'attr': {'id': 'form_note_delete_'~note.id }}) }}
+    {{ form_widget(note_delete_forms[note.id]) }}
+    {{ form_end(note_delete_forms[note.id]) }}
     <div class="modal-footer">
         <a href="#!" class="modal-action modal-close btn-flat">Retour</a>
         {% if is_granted("delete",note) %}

--- a/src/AppBundle/Controller/MembershipController.php
+++ b/src/AppBundle/Controller/MembershipController.php
@@ -159,7 +159,7 @@ class MembershipController extends Controller
         }
         $beneficiaryForm = $this->createNewBeneficiaryForm($member);
 
-        $timeLogForm = $this->createNewTimeLogForm($member);
+        $timeLogNewForm = $this->createNewTimeLogForm($member);
 
         $period_positions = $em->getRepository('AppBundle:PeriodPosition')->findByBeneficiaries($member->getBeneficiaries());
         $previous_cycle_start = $this->get('membership_service')->getStartOfCycle($member, -1 * $this->getParameter('max_nb_of_past_cycles_to_display'));
@@ -194,7 +194,7 @@ class MembershipController extends Controller
             'close_form' => $closeForm->createView(),
             'open_form' => $openForm->createView(),
             'delete_form' => $deleteForm->createView(),
-            'time_log_form' => $timeLogForm->createView(),
+            'time_log_new_form' => $timeLogNewForm->createView(),
             'period_positions' => $period_positions,
             'in_progress_and_upcoming_shifts' => $in_progress_and_upcoming_shifts,
             'shifts_by_cycle' => $shifts_by_cycle,

--- a/src/AppBundle/Controller/TimeLogController.php
+++ b/src/AppBundle/Controller/TimeLogController.php
@@ -68,7 +68,7 @@ class TimeLogController extends Controller
     /**
      * Delete time log
      *
-     * @Route("/{id}/timelog_delete/{timelog_id}", name="member_timelog_delete", methods={"GET"})
+     * @Route("/{id}/timelog_delete/{timelog_id}", name="member_timelog_delete", methods={"DELETE"})
      * @Security("has_role('ROLE_SUPER_ADMIN')")
      * @param Membership $member
      * @param $timelog_id


### PR DESCRIPTION
### Quoi ?

Actuellement, la route `member_timelog_delete` est appelée via la méthode `GET`

Modifications apportées : 
- utiliser la méthode `DELETE`
- créer des formulaires de suppression
- ajouter une confirmation pour éviter les fausses manip
- améliorations à la marge (wording, valeurs par défaut des paramètres de templates, commentaires)