### PR TITLE
Créneaux : homogénéiser l'affichage

### DIFF
--- a/app/Resources/views/admin/booking/_partial/bucket_modal.html.twig
+++ b/app/Resources/views/admin/booking/_partial/bucket_modal.html.twig
@@ -16,7 +16,7 @@ id = "modal-bucket"
     Créneaux / <span class="{{ bucket.job.color }}-text">{{ bucket.job.name }}</span>
 </h4>
 <h5>
-    {{ bucket.start | date_fr_long }} de {{ bucket.start | date('G\\hi') }} à {{ bucket.end | date('G\\hi') }}
+    {{ bucket.displayDateLongWithTime }}
 </h5>
 <span>
     remplissage : {{ nbBookedShifts }}/{{ nbShifts }} ({{ ((nbBookedShifts / nbShifts)*100) | round }}%)

--- a/app/Resources/views/admin/shift/edit.html.twig
+++ b/app/Resources/views/admin/shift/edit.html.twig
@@ -9,7 +9,7 @@
 
 {% block content %}
     <h4> Editer créneaux / <span class="{{ shift.job.color }}-text">{{ shift.job.name }}</span></h4>
-    <h5>{{ shift.start | date_fr_long }} de {{ shift.start | date('G\\hi') }} à {{ shift.end | date('G\\hi') }}</h5>
+    <h5>{{ shift.displayDateLongWithTime }}</h5>
     {{ form_start(form) }}
     <div class="row">
         <div class="col s12">
@@ -36,7 +36,9 @@
         </div>
     </div>
     <div>
-        <button type="submit" class="btn waves-effect waves-light"><i class="material-icons left">save</i>Enregistrer</button>
+        <button type="submit" class="btn waves-effect waves-light">
+            <i class="material-icons left">save</i>Enregistrer
+        </button>
     </div>
     {{ form_row(form._token) }}
     {{ form_end(form, {'render_rest': false}) }}

--- a/app/Resources/views/admin/shiftfreelog/index.html.twig
+++ b/app/Resources/views/admin/shiftfreelog/index.html.twig
@@ -94,7 +94,7 @@
                     </a>
                 </td>
                 <td>
-                    {{ shiftFreeLog.shift.job }} - {{ shiftFreeLog.shift.start | date('d/m/Y') }} de {{ shiftFreeLog.shift.start | date('H:i') }} à {{ shiftFreeLog.shift.end | date('H:i') }}
+                    {{ shiftFreeLog.shift.job.name }} du {{ shiftFreeLog.shift.displayDateWithTime }}
                 </td>
                 {% if use_fly_and_fixed %}
                     <td>{{ shiftFreeLog.fixe }}</td>

--- a/app/Resources/views/booking/_partial/home_shift_contactform.html.twig
+++ b/app/Resources/views/booking/_partial/home_shift_contactform.html.twig
@@ -3,7 +3,7 @@
 <div id="contact{{ shift.id }}" class="modal modal-fixed-footer left-align">
     <div class="modal-content">
         <h4>Envoyer un mail aux membres du créneau <span class="{{ shift.job.color }}-text">{{ shift.job.name }}</span></h4>
-        <h5>{{ shift.start | date_fr_long }} de {{ shift.start | date('G\\hi') }} à {{ shift.end | date('G\\hi') }}</h5>
+        <h5>{{ shift.displayDateLongWithTime }}</h5>
         {{ form_start(form, {'attr': {'id': 'contactform'~shift.id}})}}
         <div class="row left-align">
             <div class="col s12">
@@ -25,7 +25,8 @@
     </div>
     <div class="modal-footer">
         <a href="#!" class=" modal-close waves-effect waves-green btn-flat red-text">Retour</a>
-        <a href="#" class="modal-close waves-effect waves-green btn-flat teal white-text"
-           onclick="javascript:$('#contactform{{ shift.id }}').submit();return false;"><i class="material-icons right">send</i>Envoyer</a>
+        <a href="#" class="modal-close waves-effect waves-green btn-flat teal white-text" onclick="javascript:$('#contactform{{ shift.id }}').submit();return false;">
+            <i class="material-icons right">send</i>Envoyer
+        </a>
     </div>
 </div>

--- a/app/Resources/views/booking/_partial/modal.html.twig
+++ b/app/Resources/views/booking/_partial/modal.html.twig
@@ -7,7 +7,7 @@
 <div id="book{{ firstBookable.id }}" class="modal">
     <div class="modal-content">
         <h5>Réserver ce créneau / <span class="{{ firstBookable.job.color }}-text">{{ firstBookable.job.name }}</span></h5>
-        <h6>{{ bucket.start | date_fr_long }} de {{ bucket.start | date('G\\hi') }} à {{ bucket.end | date('G\\hi') }}</h6>
+        <h6>{{ bucket.displayDateLongWithTime }}</h6>
 
         {% if not shift_service.canBookDuration(beneficiary, bucket.getFirst.getDuration, cycle) %}
             <div class="alert card red lighten-4 red-text text-darken-4">

--- a/app/Resources/views/default/card_reader/_partial/bucket_card.html.twig
+++ b/app/Resources/views/default/card_reader/_partial/bucket_card.html.twig
@@ -18,8 +18,7 @@
             </div>
         {% endif %}
         <div class="card-title activator">
-            <b class="{{ bucket.job.color }}-text">{{ bucket.job.name }}</b> /
-            <b>{{ bucket.start | date('H:i') }} à {{ bucket.end | date('H:i') }}</b>
+            <b class="{{ bucket.job.color }}-text">{{ bucket.job.name }}</b> / <b>{{ bucket.start | date('G\\hi') }} à {{ bucket.end | date('G\\hi') }}</b>
         </div>
         <ul>
             {% for shift in bucket.sortedShifts %}

--- a/app/Resources/views/emails/coshifter_message.html.twig
+++ b/app/Resources/views/emails/coshifter_message.html.twig
@@ -1,5 +1,5 @@
 Bonjour {{ firstnames | join(', ') }},<br /></br>
-<strong>{{ shift.shifter.firstname|lower|capitalize }} {{ shift.shifter.lastname|first|upper }}</strong> t'a envoyé un message à propos du créneau {{ shift.job.name }} du {{ shift.start | date('d/m/Y') }} de {{ shift.start | date('G\\hi') }} à {{ shift.end | date('G\\hi') }}.<br />
+<strong>{{ shift.shifter.firstname|lower|capitalize }} {{ shift.shifter.lastname|first|upper }}</strong> t'a envoyé un message à propos du créneau {{ shift.job.name }} du {{ shift.displayDateWithTime }}.<br />
 <blockquote>
     {{ message |nl2br }}
 </blockquote>

--- a/app/Resources/views/emails/shift_booked_archive.html.twig
+++ b/app/Resources/views/emails/shift_booked_archive.html.twig
@@ -1,4 +1,4 @@
 Nouvelle réservation depuis l'espace membre.
 créneau {{ shift.job.name }}
-le {{ shift.start | date('d/m/Y') }} de {{ shift.start | date('G\\hi') }} à {{ shift.end | date('G\\hi') }}
+le {{ shift.displayDateWithTime }}
 reservé par {{ shift.shifter.user }} ({{ shift.shifter.firstname }}) le {{ shift.bookedTime | date('d/m/Y à H:i') }}

--- a/app/Resources/views/emails/shift_booked_confirmation.html.twig
+++ b/app/Resources/views/emails/shift_booked_confirmation.html.twig
@@ -1,7 +1,7 @@
 Bonjour {{ shift.shifter.firstname | lower | capitalize }},<br />
 <br />
 Ta réservation du créneau
-{{ shift.job.name }} le {{ shift.start | date_fr_long }} de {{ shift.start | date('G\\hi') }} à {{ shift.end | date('G\\hi') }}
+{{ shift.job.name }} le {{ shift.displayDateLongWithTime }}
 est confirmée.<br />
 <br />
 Merci, et belle journée à toi.<br />

--- a/app/Resources/views/emails/shift_deleted.html.twig
+++ b/app/Resources/views/emails/shift_deleted.html.twig
@@ -1,6 +1,6 @@
 Bonjour {{ beneficiary.firstname | lower | capitalize }},<br />
 <br />
-le créneau {{ shift.job.name }} du {{ shift.start | date('d/m/Y') }} de {{ shift.start | date('G\\hi') }} à {{ shift.end | date('G\\hi') }}
+le créneau {{ shift.job.name }} du {{ shift.displayDateWithTime }}
 que tu avais reservé à été supprimé.<br />
 <br />
 Rendez-vous sur <a href="{{ absolute_url(path("homepage")) }}">ton espace membre</a> pour en reserver un nouveau.

--- a/app/Resources/views/emails/shift_freed.html.twig
+++ b/app/Resources/views/emails/shift_freed.html.twig
@@ -1,6 +1,6 @@
 Bonjour {{ beneficiary.firstname | lower | capitalize }},<br />
 <br />
-le créneau {{ shift.job.name }} du {{ shift.start | date('d/m/Y') }} de {{ shift.start | date('G\\hi') }} à {{ shift.end | date('G\\hi') }}
+le créneau {{ shift.job.name }} du {{ shift.displayDateWithTime }}
 que tu avais reservé à été libéré.<br />
 <br />
 Rendez-vous sur <a href="{{ absolute_url(path("homepage")) }}">ton espace membre</a> pour en reserver un nouveau.<br />

--- a/app/Resources/views/emails/shift_reminder.html.twig
+++ b/app/Resources/views/emails/shift_reminder.html.twig
@@ -1,7 +1,7 @@
 Bonjour {{ shift.shifter.firstname | lower | capitalize }},<br />
 <br />
 Ceci est juste un petit message pour te rappeler que tu as réservé un créneau
-{{ shift.job.name }} le {{ shift.start | date_fr_long }} de {{ shift.start | date('G\\hi') }} à {{ shift.end | date('G\\hi') }}.<br />
+{{ shift.job.name }} le {{ shift.displayDateLongWithTime }}.<br />
 
 {{ dynamicContent | markdown | raw }}
 

--- a/app/Resources/views/emails/shift_reserved.html.twig
+++ b/app/Resources/views/emails/shift_reserved.html.twig
@@ -1,7 +1,7 @@
 Bonjour {{ shift.lastShifter.firstname | lower | capitalize }},<br />
 <br />
 Tu viens de réaliser un créneau à l'épicerie, merci de rendre possible notre projet.<br />
-Nous te proposons de reprendre le même créneau dans {{ days }} jours, soit le {{ shift.start | date_fr_full }} de {{ shift.start | date('G\\hi') }} à {{ shift.end | date('G\\hi') }}.<br />
+Nous te proposons de reprendre le même créneau dans {{ days }} jours, soit le {{ shift.displayDateLongWithTime }}.<br />
 Tu es prioritaire sur ce créneau pendant 7 jours, ensuite il deviendra disponible à la réservation pour les autres membres.<br />
 <br />
 Merci de nous indiquer si tu souhaites le reprendre :<br />

--- a/app/Resources/views/member/_partial/time_logs.html.twig
+++ b/app/Resources/views/member/_partial/time_logs.html.twig
@@ -53,7 +53,7 @@
                     <td>{{ timeLog.typeDisplay }}</td>
                     <td>
                         {% if timeLog.shift %}
-                            {{ timeLog.shift.job.name }} du {{ timeLog.shift.start | date('d/m/Y') }} de {{ timeLog.shift.start | date('H:i') }} à {{ timeLog.shift.end | date('H:i') }}
+                            {{ timeLog.shift.job.name }} du {{ timeLog.shift.displayDateWithTime }}
                             {% if timeLog.shift.shifter %}
                                 ({{ timeLog.shift.shifter }})
                             {% endif %}

--- a/app/Resources/views/user/_partial/shift_card_header.html.twig
+++ b/app/Resources/views/user/_partial/shift_card_header.html.twig
@@ -1,4 +1,4 @@
-<span class="card-title">{{ shift.start | date_fr_long }} de {{ shift.start | date('H:i') }} à {{ shift.end | date('H:i') }}</span>
+<span class="card-title">{{ shift.displayDateLongWithTime }}</span>
 <p>
     <i class="material-icons">person</i>{{ shift.shifter.firstname }}
     <br />

--- a/src/AppBundle/Entity/Period.php
+++ b/src/AppBundle/Entity/Period.php
@@ -95,7 +95,7 @@ class Period
     }
 
     /**
-     * Example: Epicerie/Livraison - Lundi - 09:30 à 12:30
+     * Example: "Epicerie/Livraison - Lundi - 09:30 à 12:30"
      */
     public function __toString()
     {

--- a/src/AppBundle/Entity/PeriodPosition.php
+++ b/src/AppBundle/Entity/PeriodPosition.php
@@ -86,7 +86,7 @@ class PeriodPosition
     }
 
     /**
-     * Example: Epicerie/Livraison - Lundi - 09:30 à 12:30 (Semaine D) (sans formation)
+     * Example: "Epicerie/Livraison - Lundi - 09:30 à 12:30 (Semaine D) (sans formation)"
      */
     public function __toString()
     {

--- a/src/AppBundle/Entity/Shift.php
+++ b/src/AppBundle/Entity/Shift.php
@@ -629,20 +629,20 @@ class Shift
     }
 
     /**
-     * Example: "vendredi 22 juillet de 09:30 à 12:30"
+     * Example: "vendredi 22 juillet de 9h30 à 12h30"
      */
     public function getDisplayDateLongWithTime()
     {
         setlocale(LC_TIME, 'fr_FR.UTF8');
-        return strftime("%A %e %B", $this->getStart()->getTimestamp()) . ' de ' . $this->getStart()->format('H:i') . ' à ' . $this->getEnd()->format('H:i');
+        return strftime("%A %e %B", $this->getStart()->getTimestamp()) . ' de ' . $this->getStart()->format('G\\hi') . ' à ' . $this->getEnd()->format('G\\hi');
     }
 
     /**
-     * Example: "22/07/2022 de 09:30 à 12:30"
+     * Example: "22/07/2022 de 9h30 à 12h30"
      */
     public function getDisplayDateWithTime()
     {
         setlocale(LC_TIME, 'fr_FR.UTF8');
-        return $this->getStart()->format('d/m/Y') . ' de ' . $this->getStart()->format('H:i') . ' à ' . $this->getEnd()->format('H:i');
+        return $this->getStart()->format('d/m/Y') . ' de ' . $this->getStart()->format('G\\hi') . ' à ' . $this->getEnd()->format('G\\hi');
     }
 }

--- a/src/AppBundle/Entity/Shift.php
+++ b/src/AppBundle/Entity/Shift.php
@@ -131,10 +131,13 @@ class Shift
         $this->wasCarriedOut = false;
     }
 
+    /**
+     * Example: "vendredi 22 juillet de 09:30 à 12:30 [#0001 Prénom NOM]"
+     */
     public function __toString()
     {
         setlocale(LC_TIME, 'fr_FR.UTF8');
-        return strftime("%A %e %B de %R", $this->getStart()->getTimestamp()).' à '.strftime("%R", $this->getEnd()->getTimestamp()).' ['.$this->getShifter().']';
+        return strftime("%A %e %B", $this->getStart()->getTimestamp()) . ' de ' . $this->getStart()->format('H:i') . ' à ' . $this->getEnd()->format('H:i') . ' [' . $this->getShifter() . ']';
     }
 
     /**
@@ -623,5 +626,23 @@ class Shift
     public function getTmpToken($key = '')
     {
         return md5($this->getId().$this->getStart()->format('d/m/Y').$this->getEnd()->format('d/m/Y').$key);
+    }
+
+    /**
+     * Example: "vendredi 22 juillet de 09:30 à 12:30"
+     */
+    public function getDisplayDateLongWithTime()
+    {
+        setlocale(LC_TIME, 'fr_FR.UTF8');
+        return strftime("%A %e %B", $this->getStart()->getTimestamp()) . ' de ' . $this->getStart()->format('H:i') . ' à ' . $this->getEnd()->format('H:i');
+    }
+
+    /**
+     * Example: "22/07/2022 de 09:30 à 12:30"
+     */
+    public function getDisplayDateWithTime()
+    {
+        setlocale(LC_TIME, 'fr_FR.UTF8');
+        return $this->getStart()->format('d/m/Y') . ' de ' . $this->getStart()->format('H:i') . ' à ' . $this->getEnd()->format('H:i');
     }
 }

--- a/src/AppBundle/Entity/ShiftBucket.php
+++ b/src/AppBundle/Entity/ShiftBucket.php
@@ -242,11 +242,11 @@ class ShiftBucket
     }
 
     /**
-     * Example: "vendredi 22 juillet de 09:30 à 12:30"
+     * Example: "vendredi 22 juillet de 09h30 à 12h30"
      */
     public function getDisplayDateLongWithTime()
     {
         setlocale(LC_TIME, 'fr_FR.UTF8');
-        return strftime("%A %e %B", $this->getStart()->getTimestamp()) . ' de ' . $this->getStart()->format('H:i') . ' à ' . $this->getEnd()->format('H:i');
+        return strftime("%A %e %B", $this->getStart()->getTimestamp()) . ' de ' . $this->getStart()->format('G\\hi') . ' à ' . $this->getEnd()->format('G\\hi');
     }
 }

--- a/src/AppBundle/Entity/ShiftBucket.php
+++ b/src/AppBundle/Entity/ShiftBucket.php
@@ -240,4 +240,13 @@ class ShiftBucket
             };
         }
     }
+
+    /**
+     * Example: "vendredi 22 juillet de 09:30 à 12:30"
+     */
+    public function getDisplayDateLongWithTime()
+    {
+        setlocale(LC_TIME, 'fr_FR.UTF8');
+        return strftime("%A %e %B", $this->getStart()->getTimestamp()) . ' de ' . $this->getStart()->format('H:i') . ' à ' . $this->getEnd()->format('H:i');
+    }
 }

--- a/src/AppBundle/Twig/Extension/AppExtension.php
+++ b/src/AppBundle/Twig/Extension/AppExtension.php
@@ -120,7 +120,7 @@ class AppExtension extends AbstractExtension
     }
 
     /**
-     * exemple output: "29 juin 2022"
+     * Exemple: "29 juin 2022"
      */
     public function date_fr(\DateTime $date)
     {
@@ -129,7 +129,7 @@ class AppExtension extends AbstractExtension
     }
 
     /**
-     * exemple output: "mercredi 29 juin"
+     * Example: "mercredi 29 juin"
      */
     public function date_fr_long(\DateTime $date)
     {
@@ -138,7 +138,7 @@ class AppExtension extends AbstractExtension
     }
 
     /**
-     * exemple output: "06/29/22 11:30"
+     * Example: "06/29/22 11:30"
      */
     public function date_time(\DateTime $date)
     {
@@ -147,7 +147,7 @@ class AppExtension extends AbstractExtension
     }
 
     /**
-     * exemple output: "mercredi 29 juin 2022"
+     * Example: "mercredi 29 juin 2022"
      */
     public function date_fr_full(\DateTime $date)
     {
@@ -156,7 +156,7 @@ class AppExtension extends AbstractExtension
     }
 
         /**
-     * exemple output: "29 juin 2022 à 11:31"
+     * Example: "29 juin 2022 à 11:31"
      */
     public function date_fr_with_time(\DateTime $date)
     {
@@ -165,7 +165,7 @@ class AppExtension extends AbstractExtension
     }
 
     /**
-     * exemple output: "mercredi 29 juin 2022 à 11:31"
+     * Example: "mercredi 29 juin 2022 à 11:31"
      *
      * @param: \DateTime|\DateTimeImmutable $date
      */
@@ -176,7 +176,7 @@ class AppExtension extends AbstractExtension
     }
 
     /**
-     * exemple output: "2022-06-29T11:32:18+02:00"
+     * Example: "2022-06-29T11:32:18+02:00"
      */
     public function date_w3c(\DateTime $date)
     {


### PR DESCRIPTION
### Quoi ?

Pour les entités `Shift` & `ShiftBucket`, création de méthodes pour homogénéiser l'affichage.

Remplacé aussi `H:i` par `Hhi` !

|Méthode|Exemple|
|---|---|
|`getDisplayDateLongWithTime`|vendredi 22 juillet de 9h30 à 12h30|
|`getDisplayDateWithTime`|22/07/2022 de 9h30 à 12h30|

### Captures d'écran

||Avant|Après|
|---|---|---|
|Shift card|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/de8bb26f-9390-4688-ae41-948542104f78)|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/91f6ce12-c907-4f9d-9dbf-dc779adc90d0)|
|Compteur de temps|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/2d24e27f-4bb8-4f1b-ad1a-29ad4dbcc4fd)|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/6de12fe2-d0f3-450c-8340-53219479fb8f)|
|Historique annulation|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/8a838cda-619f-4924-8164-3edff52a59b7)|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/5d21faf3-d079-4594-ab06-a4a667fdcbec)|
