### PR TITLE
ShiftFreeLog : nouveau champ shiftString

### DIFF
--- a/app/DoctrineMigrations/Version20230518142222_shiftfreelog_shift_string.php
+++ b/app/DoctrineMigrations/Version20230518142222_shiftfreelog_shift_string.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20230518142222 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE shiftfreelog DROP FOREIGN KEY FK_6B5F3126BB70BC0E');
+        $this->addSql('ALTER TABLE shiftfreelog ADD shift_string LONGTEXT NOT NULL');
+        $this->addSql('ALTER TABLE shiftfreelog ADD CONSTRAINT FK_6B5F3126BB70BC0E FOREIGN KEY (shift_id) REFERENCES shift (id) ON DELETE SET NULL');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE shiftfreelog DROP FOREIGN KEY FK_6B5F3126BB70BC0E');
+        $this->addSql('ALTER TABLE shiftfreelog DROP shift_string');
+        $this->addSql('ALTER TABLE shiftfreelog ADD CONSTRAINT FK_6B5F3126BB70BC0E FOREIGN KEY (shift_id) REFERENCES shift (id) ON DELETE CASCADE');
+    }
+}

--- a/app/Resources/views/admin/shiftfreelog/index.html.twig
+++ b/app/Resources/views/admin/shiftfreelog/index.html.twig
@@ -94,7 +94,7 @@
                     </a>
                 </td>
                 <td>
-                    {{ shiftFreeLog.shift.job.name }} du {{ shiftFreeLog.shift.displayDateWithTime }}
+                    {{ shiftFreeLog.shiftString }}
                 </td>
                 {% if use_fly_and_fixed %}
                     <td>{{ shiftFreeLog.fixe }}</td>

--- a/app/Resources/views/emails/coshifter_message.html.twig
+++ b/app/Resources/views/emails/coshifter_message.html.twig
@@ -1,5 +1,5 @@
 Bonjour {{ firstnames | join(', ') }},<br /></br>
-<strong>{{ shift.shifter.firstname|lower|capitalize }} {{ shift.shifter.lastname|first|upper }}</strong> t'a envoyé un message à propos du créneau {{ shift.job.name }} du {{ shift.displayDateWithTime }}.<br />
+<strong>{{ shift.shifter.firstname|lower|capitalize }} {{ shift.shifter.lastname|first|upper }}</strong> t'a envoyé un message à propos du créneau {{ shift.job.name }} du {{ shift.displayDateLongWithTime }}.<br />
 <blockquote>
     {{ message |nl2br }}
 </blockquote>

--- a/app/Resources/views/emails/shift_booked_archive.html.twig
+++ b/app/Resources/views/emails/shift_booked_archive.html.twig
@@ -1,4 +1,4 @@
 Nouvelle réservation depuis l'espace membre.
 créneau {{ shift.job.name }}
-le {{ shift.displayDateWithTime }}
+le {{ shift.displayDateFullWithTime }}
 reservé par {{ shift.shifter.user }} ({{ shift.shifter.firstname }}) le {{ shift.bookedTime | date_fr_full_with_time }}

--- a/app/Resources/views/emails/shift_deleted.html.twig
+++ b/app/Resources/views/emails/shift_deleted.html.twig
@@ -1,6 +1,6 @@
 Bonjour {{ beneficiary.firstname | lower | capitalize }},<br />
 <br />
-le créneau {{ shift.job.name }} du {{ shift.displayDateWithTime }}
+le créneau {{ shift.job.name }} du {{ shift.displayDateLongWithTime }}
 que tu avais reservé à été supprimé.<br />
 <br />
 Rendez-vous sur <a href="{{ absolute_url(path("homepage")) }}">ton espace membre</a> pour en reserver un nouveau.

--- a/app/Resources/views/emails/shift_freed.html.twig
+++ b/app/Resources/views/emails/shift_freed.html.twig
@@ -1,6 +1,6 @@
 Bonjour {{ beneficiary.firstname | lower | capitalize }},<br />
 <br />
-le créneau {{ shift.job.name }} du {{ shift.displayDateWithTime }}
+le créneau {{ shift.job.name }} du {{ shift.displayDateLongWithTime }}
 que tu avais reservé à été libéré.<br />
 <br />
 Rendez-vous sur <a href="{{ absolute_url(path("homepage")) }}">ton espace membre</a> pour en reserver un nouveau.<br />

--- a/app/Resources/views/member/_partial/time_logs.html.twig
+++ b/app/Resources/views/member/_partial/time_logs.html.twig
@@ -53,7 +53,7 @@
                     <td>{{ timeLog.typeDisplay }}</td>
                     <td>
                         {% if timeLog.shift %}
-                            {{ timeLog.shift.job.name }} du {{ timeLog.shift.displayDateWithTime }}
+                            {{ timeLog.shift.job.name }} - {{ timeLog.shift.displayDateSeperateTime }}
                             {% if timeLog.shift.shifter %}
                                 ({{ timeLog.shift.shifter }})
                             {% endif %}

--- a/src/AppBundle/Entity/PeriodPosition.php
+++ b/src/AppBundle/Entity/PeriodPosition.php
@@ -66,6 +66,11 @@ class PeriodPosition
     private $shifts;
 
     /**
+     * @ORM\OneToMany(targetEntity="PeriodPositionFreeLog", mappedBy="periodPosition")
+     */
+    private $freeLogs;
+
+    /**
      * @var \DateTime
      *
      * @ORM\Column(name="created_at", type="datetime")

--- a/src/AppBundle/Entity/PeriodPosition.php
+++ b/src/AppBundle/Entity/PeriodPosition.php
@@ -95,11 +95,9 @@ class PeriodPosition
      */
     public function __toString()
     {
-        $name = $this->getPeriod() . ' (Semaine ' . $this->getWeekCycle() . ')';
+        $name = $this->getPeriod() . ' - Semaine ' . $this->getWeekCycle();
         if ($this->getFormation()) {
             $name .= ' (' . $this->getFormation()->getName() . ')';
-        } else {
-            $name .= ' (sans formation)';
         }
         return $name;
     }

--- a/src/AppBundle/Entity/PeriodPositionFreeLog.php
+++ b/src/AppBundle/Entity/PeriodPositionFreeLog.php
@@ -24,7 +24,7 @@ class PeriodPositionFreeLog
     private $id;
 
     /**
-     * @ORM\ManyToOne(targetEntity="PeriodPosition")
+     * @ORM\ManyToOne(targetEntity="PeriodPosition", inversedBy="freeLogs")
      * @ORM\JoinColumn(referencedColumnName="id", onDelete="SET NULL")
      */
     private $periodPosition;

--- a/src/AppBundle/Entity/Shift.php
+++ b/src/AppBundle/Entity/Shift.php
@@ -629,12 +629,12 @@ class Shift
     }
 
     /**
-     * Example: "vendredi 22 juillet de 9h30 à 12h30"
+     * Example: "22/07/2022 - 9h30 à 12h30"
      */
-    public function getDisplayDateLongWithTime()
+    public function getDisplayDateSeperateTime()
     {
         setlocale(LC_TIME, 'fr_FR.UTF8');
-        return strftime("%A %e %B", $this->getStart()->getTimestamp()) . ' de ' . $this->getStart()->format('G\\hi') . ' à ' . $this->getEnd()->format('G\\hi');
+        return $this->getStart()->format('d/m/Y') . ' - ' . $this->getStart()->format('G\\hi') . ' à ' . $this->getEnd()->format('G\\hi');
     }
 
     /**
@@ -644,5 +644,23 @@ class Shift
     {
         setlocale(LC_TIME, 'fr_FR.UTF8');
         return $this->getStart()->format('d/m/Y') . ' de ' . $this->getStart()->format('G\\hi') . ' à ' . $this->getEnd()->format('G\\hi');
+    }
+
+    /**
+     * Example: "vendredi 22 juillet de 9h30 à 12h30"
+     */
+    public function getDisplayDateLongWithTime()
+    {
+        setlocale(LC_TIME, 'fr_FR.UTF8');
+        return strftime("%A %e %B", $this->getStart()->getTimestamp()) . ' de ' . $this->getStart()->format('G\\hi') . ' à ' . $this->getEnd()->format('G\\hi');
+    }
+
+    /**
+     * Example: "vendredi 22 juillet 2022 de 9h30 à 12h30"
+     */
+    public function getDisplayDateFullWithTime()
+    {
+        setlocale(LC_TIME, 'fr_FR.UTF8');
+        return strftime("%A %e %B %Y", $this->getStart()->getTimestamp()) . ' de ' . $this->getStart()->format('G\\hi') . ' à ' . $this->getEnd()->format('G\\hi');
     }
 }

--- a/src/AppBundle/Entity/Shift.php
+++ b/src/AppBundle/Entity/Shift.php
@@ -97,7 +97,7 @@ class Shift
     /**
      * @ORM\OneToMany(targetEntity="ShiftFreeLog", mappedBy="shift")
      */
-    private $shiftFreeLogs;
+    private $freeLogs;
 
     /**
      * @var bool

--- a/src/AppBundle/Entity/ShiftFreeLog.php
+++ b/src/AppBundle/Entity/ShiftFreeLog.php
@@ -24,7 +24,7 @@ class ShiftFreeLog
     private $id;
 
     /**
-     * @ORM\ManyToOne(targetEntity="Shift", inversedBy="shiftFreeLogs", fetch="EAGER")
+     * @ORM\ManyToOne(targetEntity="Shift", inversedBy="freeLogs")
      * @ORM\JoinColumn(referencedColumnName="id", onDelete="SET NULL")
      */
     private $shift;

--- a/src/AppBundle/Entity/ShiftFreeLog.php
+++ b/src/AppBundle/Entity/ShiftFreeLog.php
@@ -24,10 +24,17 @@ class ShiftFreeLog
     private $id;
 
     /**
-     * @ORM\ManyToOne(targetEntity="Shift", inversedBy="shiftFreeLogs", cascade={"remove"}, fetch="EAGER")
-     * @ORM\JoinColumn(referencedColumnName="id", onDelete="CASCADE")
+     * @ORM\ManyToOne(targetEntity="Shift", inversedBy="shiftFreeLogs", fetch="EAGER")
+     * @ORM\JoinColumn(referencedColumnName="id", onDelete="SET NULL")
      */
     private $shift;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="shift_string", type="text")
+     */
+    private $shiftString;
 
     /**
      * @ORM\ManyToOne(targetEntity="Beneficiary", cascade={"remove"})
@@ -90,6 +97,18 @@ class ShiftFreeLog
     public function setShift(?Shift $shift): self
     {
         $this->shift = $shift;
+
+        return $this;
+    }
+
+    public function getShiftString(): string
+    {
+        return $this->shiftString;
+    }
+
+    public function setShiftString(?string $shiftString): self
+    {
+        $this->shiftString = $shiftString;
 
         return $this;
     }

--- a/src/AppBundle/Service/PeriodPositionFreeLogService.php
+++ b/src/AppBundle/Service/PeriodPositionFreeLogService.php
@@ -22,6 +22,11 @@ class PeriodPositionFreeLogService
         $this->tokenStorage = $tokenStorage;
     }
 
+    public function generatePeriodPositionString(PeriodPosition $periodPosition)
+    {
+        return (string) $periodPosition;
+    }
+
     public function initPeriodPositionFreeLog(PeriodPosition $periodPosition, Beneficiary $beneficiary, $bookedTime = null)
     {
         $current_user = $this->tokenStorage->getToken() ? $this->tokenStorage->getToken()->getUser() : null;
@@ -29,7 +34,7 @@ class PeriodPositionFreeLogService
 
         $log = new PeriodPositionFreeLog;
         $log->setPeriodPosition($periodPosition);
-        $log->setPeriodPositionString($periodPosition);
+        $log->setPeriodPositionString($this->generatePeriodPositionString($periodPosition));
         $log->setBeneficiary($beneficiary);
         if ($bookedTime) {
             $log->setBookedTime($bookedTime);

--- a/src/AppBundle/Service/ShiftFreeLogService.php
+++ b/src/AppBundle/Service/ShiftFreeLogService.php
@@ -22,6 +22,11 @@ class ShiftFreeLogService
         $this->tokenStorage = $tokenStorage;
     }
 
+    public function generateShiftString(Shift $shift)
+    {
+        return $shift->getJob()->getName() . ' - ' . $shift->getDisplayDateSeperateTime();
+    }
+
     public function initShiftFreeLog(Shift $shift, Beneficiary $beneficiary, $fixe = false, $reason = null)
     {
         $current_user = $this->tokenStorage->getToken() ? $this->tokenStorage->getToken()->getUser() : null;
@@ -29,6 +34,7 @@ class ShiftFreeLogService
 
         $log = new ShiftFreeLog;
         $log->setShift($shift);
+        $log->setShiftString($this->generateShiftString($shift));
         $log->setBeneficiary($beneficiary);
         $log->setFixe($fixe);
         if ($reason) {

--- a/src/AppBundle/Twig/Extension/AppExtension.php
+++ b/src/AppBundle/Twig/Extension/AppExtension.php
@@ -182,7 +182,7 @@ class AppExtension extends AbstractExtension
     /**
      * Example: "29/06/22"
      */
-    public function date_short(\DateTime $date)
+    public function date_short($date)  # \DateTime or \DateTimeImmutable
     {
         setlocale(LC_TIME, 'fr_FR.UTF8');
         return strftime("%d/%m/%Y", $date->getTimestamp());


### PR DESCRIPTION
### Quoi ?

Similaire à #840

Nouveau champ `ShiftFreeLog.shiftString` pour stocker les détails du créneau libéré (si jamais il était ensuite modifié ou supprimé)

Homogénéisation des affichages : 
||Image|
|---|---|
|`ShiftFreeLog.shiftString`|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/b10d2c19-8aa3-4b83-80b5-4e879bdfbf4a)|
|`PeriodPositionFreeLog.periodPositionString`|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/5b767e73-4ea3-4480-a768-e4f1d2c2f957)|
|`TimeLog.shift`|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/7cb6cd93-1d02-47e8-9751-a61fcb030533)|