### PR TITLE
Profile : pouvoir afficher son historique de créneaux annulés

### DIFF
--- a/app/Resources/views/Profile/show_content.html.twig
+++ b/app/Resources/views/Profile/show_content.html.twig
@@ -35,7 +35,7 @@
                 <i class="material-icons">delete_sweep</i>Historique des créneaux annulés
             </div>
             <div class="collapsible-body">
-                {% include "member/_partial/shift_free_logs.html.twig" with { shiftFreeLogs: membership_service.getShiftFreeLogs(member) } %}
+                {% include "member/_partial/shift_free_logs.html.twig" with { shiftFreeLogs: membership_service.getShiftFreeLogs(member), custom_styles: "max-height:500px;overflow:scroll;" } %}
             </div>
         </li>
 

--- a/app/Resources/views/Profile/show_content.html.twig
+++ b/app/Resources/views/Profile/show_content.html.twig
@@ -30,14 +30,16 @@
             </li>
         {% endif %}
 
-        <li>
-            <div class="collapsible-header">
-                <i class="material-icons">delete_sweep</i>Historique des créneaux annulés
-            </div>
-            <div class="collapsible-body">
-                {% include "member/_partial/shift_free_logs.html.twig" with { shiftFreeLogs: membership_service.getShiftFreeLogs(member), custom_styles: "max-height:500px;overflow:scroll;" } %}
-            </div>
-        </li>
+        {% if profile_display_shift_free_log %}
+            <li>
+                <div class="collapsible-header">
+                    <i class="material-icons">delete_sweep</i>Historique des créneaux annulés
+                </div>
+                <div class="collapsible-body">
+                    {% include "member/_partial/shift_free_logs.html.twig" with { shiftFreeLogs: membership_service.getShiftFreeLogs(member), custom_styles: "max-height:500px;overflow:scroll;" } %}
+                </div>
+            </li>
+        {% endif %}
 
         <li>
             <div class="collapsible-header">

--- a/app/Resources/views/Profile/show_content.html.twig
+++ b/app/Resources/views/Profile/show_content.html.twig
@@ -32,6 +32,15 @@
 
         <li>
             <div class="collapsible-header">
+                <i class="material-icons">delete_sweep</i>Historique des créneaux annulés
+            </div>
+            <div class="collapsible-body">
+                {% include "member/_partial/shift_free_logs.html.twig" with { shiftFreeLogs: membership_service.getShiftFreeLogs(member) } %}
+            </div>
+        </li>
+
+        <li>
+            <div class="collapsible-header">
                 <i class="material-icons">ac_unit</i>Gel du compte
             </div>
             <div class="collapsible-body">

--- a/app/Resources/views/admin/shiftfreelog/index.html.twig
+++ b/app/Resources/views/admin/shiftfreelog/index.html.twig
@@ -81,7 +81,6 @@
                 <th>Raison</th>
             </tr>
         </thead>
-
         <tbody>
         {% for shiftFreeLog in shiftFreeLogs %}
             <tr>

--- a/app/Resources/views/admin/shiftfreelog/index.html.twig
+++ b/app/Resources/views/admin/shiftfreelog/index.html.twig
@@ -65,56 +65,7 @@
         </li>
     </ul>
 
-    <table class="responsive-table">
-        <thead>
-            <tr>
-                <th>Date</th>
-                <th>Bénéficiaire</th>
-                <th>Créneau</th>
-                {% if use_fly_and_fixed %}
-                    <th>Fixe</th>
-                {% endif %}
-                <th>Auteur</th>
-                {% if is_granted("ROLE_ADMIN") %}
-                    <th>Route</th>
-                {% endif %}
-                <th>Raison</th>
-            </tr>
-        </thead>
-        <tbody>
-        {% for shiftFreeLog in shiftFreeLogs %}
-            <tr>
-                <td title="{{ shiftFreeLog.createdAt | date_fr_full_with_time }}">
-                    {{ shiftFreeLog.createdAt | date_short }}
-                </td>
-                <td>
-                    <a href="{{ path("member_show",{'member_number': shiftFreeLog.beneficiary.membership.memberNumber}) }}">
-                        {{ shiftFreeLog.beneficiary }}
-                    </a>
-                </td>
-                <td>
-                    {{ shiftFreeLog.shiftString }}
-                </td>
-                {% if use_fly_and_fixed %}
-                    <td>{{ shiftFreeLog.fixe }}</td>
-                {% endif %}
-                <td>
-                    {% if shiftFreeLog.createdBy and shiftFreeLog.createdBy.beneficiary %}
-                        <a href="{{ path("member_show",{'member_number': shiftFreeLog.createdBy.beneficiary.membership.memberNumber}) }}">
-                            {{ shiftFreeLog.createdBy.beneficiary }}
-                        </a>
-                    {% else %}
-                        {{ shiftFreeLog.createdBy }}
-                    {% endif %}
-                </td>
-                {% if is_granted("ROLE_ADMIN") %}
-                    <td>{{ shiftFreeLog.requestRoute }}</td>
-                {% endif %}
-                <td>{{ shiftFreeLog.reason }}</td>
-            </tr>
-        {% endfor %}
-        </tbody>
-    </table>
+    {% include "member/_partial/shift_free_logs.html.twig" with { shiftFreeLogs: shiftFreeLogs, from_admin: true } %}
 
     <ul class="pagination">
         <li class="{% if(current_page==1) %}disabled{% else %}waves-effect{% endif %}">

--- a/app/Resources/views/member/_partial/shift_free_logs.html.twig
+++ b/app/Resources/views/member/_partial/shift_free_logs.html.twig
@@ -1,0 +1,35 @@
+
+<div style="max-height:500px;overflow:scroll;">
+    <table>
+        <thead>
+            <tr class="grey lighten-2">
+                <th>Date</th>
+                <th>Bénéficiaire</th>
+                <th>Créneau</th>
+                {% if use_fly_and_fixed %}
+                    <th>Fixe</th>
+                {% endif %}
+                <th>Raison</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for shiftFreeLog in shiftFreeLogs %}
+                <tr>
+                    <td title="{{ shiftFreeLog.createdAt | date_fr_full_with_time }}">
+                        {{ shiftFreeLog.createdAt | date_short }}
+                    </td>
+                    <td>
+                        {{ shiftFreeLog.beneficiary }}
+                    </td>
+                    <td>
+                        {{ shiftFreeLog.shiftString }}
+                    </td>
+                    {% if use_fly_and_fixed %}
+                        <td>{{ shiftFreeLog.fixe }}</td>
+                    {% endif %}
+                    <td>{{ shiftFreeLog.reason }}</td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>

--- a/app/Resources/views/member/_partial/shift_free_logs.html.twig
+++ b/app/Resources/views/member/_partial/shift_free_logs.html.twig
@@ -1,13 +1,22 @@
 
-<div style="max-height:500px;overflow:scroll;">
-    <table>
+{% set from_admin = from_admin ?? false %}
+{% set custom_styles = custom_styles ?? null %}
+
+<div {% if custom_styles %}style="{{ custom_styles }}"{% endif %}>
+    <table class="responsive-table">
         <thead>
-            <tr class="grey lighten-2">
+            <tr>
                 <th>Date</th>
                 <th>Bénéficiaire</th>
                 <th>Créneau</th>
                 {% if use_fly_and_fixed %}
                     <th>Fixe</th>
+                {% endif %}
+                {% if from_admin %}
+                    <th>Auteur</th>
+                    {% if is_granted("ROLE_ADMIN") %}
+                        <th>Route</th>
+                    {% endif %}
                 {% endif %}
                 <th>Raison</th>
             </tr>
@@ -19,13 +28,33 @@
                         {{ shiftFreeLog.createdAt | date_short }}
                     </td>
                     <td>
-                        {{ shiftFreeLog.beneficiary }}
+                        {% if from_admin %}
+                            <a href="{{ path("member_show",{'member_number': shiftFreeLog.beneficiary.membership.memberNumber}) }}">
+                                {{ shiftFreeLog.beneficiary }}
+                            </a>
+                        {% else %}
+                            {{ shiftFreeLog.beneficiary }}
+                        {% endif %}
                     </td>
                     <td>
                         {{ shiftFreeLog.shiftString }}
                     </td>
                     {% if use_fly_and_fixed %}
                         <td>{{ shiftFreeLog.fixe }}</td>
+                    {% endif %}
+                    {% if from_admin %}
+                        <td>
+                            {% if shiftFreeLog.createdBy and shiftFreeLog.createdBy.beneficiary %}
+                                <a href="{{ path("member_show",{'member_number': shiftFreeLog.createdBy.beneficiary.membership.memberNumber}) }}">
+                                    {{ shiftFreeLog.createdBy.beneficiary }}
+                                </a>
+                            {% else %}
+                                {{ shiftFreeLog.createdBy }}
+                            {% endif %}
+                        </td>
+                        {% if is_granted("ROLE_ADMIN") %}
+                            <td>{{ shiftFreeLog.requestRoute }}</td>
+                        {% endif %}
                     {% endif %}
                     <td>{{ shiftFreeLog.reason }}</td>
                 </tr>

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -66,6 +66,7 @@ twig:
     max_nb_of_past_cycles_to_display: '%max_nb_of_past_cycles_to_display%'
     profile_display_task_list: '%profile_display_task_list%'
     profile_display_time_log: '%profile_display_time_log%'
+    profile_display_shift_free_log: '%profile_display_shift_free_log%'
     # user
     user_account_not_enabled_material_icon: '%user_account_not_enabled_material_icon%'
     user_account_enabled_material_icon: '%user_account_enabled_material_icon%'

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -120,6 +120,7 @@ parameters:
     # Profile configuration
     profile_display_task_list: true
     profile_display_time_log: true
+    profile_display_shift_free_log: true
 
     # User configuration
     user_account_not_enabled_material_icon: 'phonelink_off'

--- a/src/AppBundle/Repository/ShiftFreeLogRepository.php
+++ b/src/AppBundle/Repository/ShiftFreeLogRepository.php
@@ -38,7 +38,23 @@ class ShiftFreeLogRepository extends \Doctrine\ORM\EntityRepository
             ->getSingleScalarResult();
     }
 
-    public function getMemberShiftFreedCount(Membership $membership, \DateTime $start_after, \DateTime $end_before, $less_than_min_time_in_advance_days = null) {
+    public function getMemberShiftFreed(Membership $member)
+    {
+        $qb = $this->createQueryBuilder('sfl')
+            ->leftJoin('sfl.shift', 's')
+            ->addSelect('s')
+            ->where('sfl.beneficiary IN (:beneficiaries)')
+            ->setParameter('beneficiaries', $member->getBeneficiaries());
+
+        $qb->orderBy('sfl.createdAt', 'DESC');
+
+        return $qb
+            ->getQuery()
+            ->getResult();
+    }
+
+    public function getMemberShiftFreedCount(Membership $member, \DateTime $start_after, \DateTime $end_before, $less_than_min_time_in_advance_days = null)
+    {
         $qb = $this->createQueryBuilder('sfl')
             ->leftJoin('sfl.shift', 's')
             ->addSelect('s')
@@ -46,7 +62,7 @@ class ShiftFreeLogRepository extends \Doctrine\ORM\EntityRepository
             ->where('sfl.beneficiary IN (:beneficiaries)')
             ->andwhere('s.start > :start_after')
             ->andwhere('s.end < :end_before')
-            ->setParameter('beneficiaries', $membership->getBeneficiaries())
+            ->setParameter('beneficiaries', $member->getBeneficiaries())
             ->setParameter('start_after', $start_after)
             ->setParameter('end_before', $end_before);
 

--- a/src/AppBundle/Service/MembershipService.php
+++ b/src/AppBundle/Service/MembershipService.php
@@ -199,4 +199,9 @@ class MembershipService
             $member->isCurrentlyExemptedFromShifts() ||
             !$this->isUptodate($member);
     }
+
+    public function getShiftFreeLogs(Membership $member)
+    {
+        return $this->em->getRepository('AppBundle:ShiftFreeLog')->getMemberShiftFreed($member);
+    }
 }


### PR DESCRIPTION
Similaire à #569

### Quoi ?

Maintenant qu'on a un historique des créneaux annulés, on peut l'afficher aux membres (dans la page "Gérer mon compte")
- nouveau paramètre `profile_display_shift_free_log` pour permettre aux coop d'afficher (ou pas) cette section dans le profil des membres
- s'assurer que les actions "admin" ne soient pas disponibles coté profil

### Capture d'écran

![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/7398a8e9-6bac-467b-9aeb-50dcbd0906e2)
