### PR TITLE
Fix days format in shift renewal email

### DIFF
--- a/src/AppBundle/Command/ShiftGenerateCommand.php
+++ b/src/AppBundle/Command/ShiftGenerateCommand.php
@@ -125,7 +125,7 @@ class ShiftGenerateCommand extends ContainerAwareCommand
         }
         $shiftEmail = $this->getContainer()->getParameter('emails.shift');
         foreach ($reservedShifts as $i => $shift){
-            $d = (date_diff(new \DateTime('now'),$shift->getStart())->format("%d"));
+            $d = (date_diff(new \DateTime('now'),$shift->getStart())->format("%a"));
             $mail = (new \Swift_Message('[ESPACE MEMBRES] Reprends ton créneau du '. $formerShifts[$i]->getStart()->format("d F") .' dans '.$d.' jours'))
                 ->setFrom($shiftEmail['address'], $shiftEmail['from_name'])
                 ->setTo($shift->getLastShifter()->getEmail())


### PR DESCRIPTION
Dans le mail suivant, le nombre de jours n'est pas correct:
![image](https://github.com/elefan-grenoble/gestion-compte/assets/8150907/c00e9307-d5ec-44b2-ac2a-48be74641c82)

Si je comprends bien la [doc](https://www.php.net/manual/fr/dateinterval.format.php), c'est dû au fait que dans le `format` `%d` est utilisé au lieu de `%a`.