### PR TITLE
Admin : nouveau filtre des membres par "a un créneau fixe"

### DIFF
--- a/app/Resources/views/admin/user/list.html.twig
+++ b/app/Resources/views/admin/user/list.html.twig
@@ -172,6 +172,12 @@
                             {{ form_widget(form.flying) }}
                             {{ form_label(form.flying) }}
                         </div>
+                        {% if use_fly_and_fixed %}
+                            <div class="input-field">
+                                {{ form_widget(form.has_period_position) }}
+                                {{ form_label(form.has_period_position) }}
+                            </div>
+                        {% endif %}
                     </div>
                     <div class="col s12 m4">
                         <h5>Formations / Commissions</h5>

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -256,6 +256,8 @@ services:
     search_user_form_helper:
             class: AppBundle\Service\SearchUserFormHelper
             public: true
+            arguments:
+                - "%use_fly_and_fixed%"
 
     logger.user_processor:
             class: AppBundle\Monolog\MonologUserProcessor

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -15,6 +15,7 @@ services:
         public: false
         bind:
             $localCurrency: '%local_currency_name%'
+            $use_fly_and_fixed: '%use_fly_and_fixed%'
 
     # makes classes in src/AppBundle available to be used as services
     # this creates a service per class whose id is the fully-qualified class name

--- a/src/AppBundle/Entity/Beneficiary.php
+++ b/src/AppBundle/Entity/Beneficiary.php
@@ -77,23 +77,28 @@ class Beneficiary
     /**
      * @var Membership
      * @ORM\ManyToOne(targetEntity="Membership", inversedBy="beneficiaries")
-     * @ORM\JoinColumn(name="membership_id", referencedColumnName="id",onDelete="CASCADE")
+     * @ORM\JoinColumn(name="membership_id", referencedColumnName="id", onDelete="CASCADE")
      */
     private $membership;
 
     /**
-     * @ORM\OneToMany(targetEntity="Shift", mappedBy="shifter",cascade={"remove"})
+     * @ORM\OneToMany(targetEntity="Shift", mappedBy="shifter", cascade={"remove"})
      * @OrderBy({"start" = "DESC"})
      */
     private $shifts;
 
     /**
-     * @ORM\OneToMany(targetEntity="Shift", mappedBy="lastShifter",cascade={"remove"})
+     * @ORM\OneToMany(targetEntity="Shift", mappedBy="lastShifter", cascade={"remove"})
      */
     private $reservedShifts;
 
     /**
-     * @ORM\OneToMany(targetEntity="SwipeCard", mappedBy="beneficiary",cascade={"remove"})
+     * @ORM\OneToMany(targetEntity="PeriodPosition", mappedBy="shifter", cascade={"persist"})
+     */
+    private $periodPositions;
+
+    /**
+     * @ORM\OneToMany(targetEntity="SwipeCard", mappedBy="beneficiary", cascade={"remove"})
      * @OrderBy({"number" = "DESC"})
      */
     private $swipe_cards;

--- a/src/AppBundle/Entity/PeriodPosition.php
+++ b/src/AppBundle/Entity/PeriodPosition.php
@@ -42,7 +42,7 @@ class PeriodPosition
     private $weekCycle;
 
     /**
-     * @ORM\ManyToOne(targetEntity="Beneficiary")
+     * @ORM\ManyToOne(targetEntity="Beneficiary", inversedBy="periodPositions")
      * @ORM\JoinColumn(name="shifter_id", referencedColumnName="id")
      */
     private $shifter;

--- a/src/AppBundle/Service/SearchUserFormHelper.php
+++ b/src/AppBundle/Service/SearchUserFormHelper.php
@@ -23,7 +23,7 @@ class SearchUserFormHelper {
     private $container;
     private $use_fly_and_fixed;
 
-    public function __construct(ContainerInterface $container, bool $use_fly_and_fixed = false)
+    public function __construct(ContainerInterface $container, $use_fly_and_fixed)
     {
         $this->container = $container;
         $this->use_fly_and_fixed = $use_fly_and_fixed;


### PR DESCRIPTION
### Quoi ?

Dans la page de filtres des membres, pouvoir filtrer les membres qui ont (ou n'ont pas) de créneau fixe.

S'applique aux épiceries qui ont `use_fly_and_fixed`

### Capture d'écran

![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/1a7a1667-aceb-4976-81da-c7e712aca824)

### Information supplémentaire

https://stackoverflow.com/a/54902115