### PR TITLE
Evénements : améliorations sur la création de widgets

### DIFF
--- a/app/Resources/views/admin/event/widget/generate.html.twig
+++ b/app/Resources/views/admin/event/widget/generate.html.twig
@@ -24,6 +24,12 @@
 </div>
 <div class="row">
     <div class="col m6">
+        {{ form_label(form.date_max) }}
+        {{ form_widget(form.date_max) }}
+    </div>
+</div>
+<div class="row">
+    <div class="col m6">
         {{ form_label(form.limit) }}
         {{ form_widget(form.limit) }}
     </div>

--- a/app/Resources/views/admin/event/widget/generate.html.twig
+++ b/app/Resources/views/admin/event/widget/generate.html.twig
@@ -17,9 +17,15 @@
     {{ form_errors(form) }}
 </div>
 <div class="row">
-    <div class="col s12">
+    <div class="col m6">
         {{ form_label(form.kind) }}
         {{ form_widget(form.kind) }}
+    </div>
+</div>
+<div class="row">
+    <div class="col m6">
+        {{ form_label(form.limit) }}
+        {{ form_widget(form.limit) }}
     </div>
 </div>
 <div class="row">

--- a/app/Resources/views/admin/event/widget/widget.html.twig
+++ b/app/Resources/views/admin/event/widget/widget.html.twig
@@ -1,13 +1,16 @@
 {% extends 'layoutlight.html.twig' %}
 
 {% block content %}
-{% if title %}liste des prochains événements <strong>{{ eventKind.name }}</strong> :{% endif %}
+{% if title %}
+    liste des prochains événements{% if eventKind %}<strong>{{ eventKind.name }}</strong>{% endif %} :
+{% endif %}
 <ul>
     {% for event in events %}
         <li>
             - <strong>{{ event.title }}</strong>
             {{ event.date | date_fr_full_with_time }}
             {% if event.end %}<i>({{ event.duration }})</i>{% endif %}
+            {# {% if not eventKind %}[{{ event.kind }}] {% endif %} #}
         </li>
     {% endfor %}
 </ul>

--- a/app/Resources/views/admin/event/widget/widget.html.twig
+++ b/app/Resources/views/admin/event/widget/widget.html.twig
@@ -2,7 +2,10 @@
 
 {% block content %}
 {% if title %}
-    liste des prochains événements{% if eventKind %}<strong>{{ eventKind.name }}</strong>{% endif %} :
+    liste des prochains événements
+    {% if eventKind %}<strong>{{ eventKind.name }}</strong>{% endif %}
+    {% if maxDate %}(jusqu'au {{ maxDate | date_short }}){% endif %}
+    :
 {% endif %}
 <ul>
     {% for event in events %}

--- a/src/AppBundle/Controller/EventController.php
+++ b/src/AppBundle/Controller/EventController.php
@@ -784,16 +784,16 @@ class EventController extends Controller
                 'class' => 'AppBundle:EventKind',
                 'choice_label' => 'name',
                 'multiple' => false,
-                'required' => true
+                'required' => false
             ))
-            ->add('title', CheckboxType::class, array('required' => false, 'data' => true, 'label' => 'Afficher le titre du widget ?'))
+            ->add('title', CheckboxType::class, array('label' => 'Afficher le titre du widget ?', 'data' => true, 'required' => false))
             ->add('generate', SubmitType::class, array('label' => 'Générer'))
             ->getForm();
 
         if ($form->handleRequest($request)->isValid()) {
             $data = $form->getData();
 
-            $widgetQueryString = 'event_kind_id='.$data['kind']->getId().'&title='.($data['title'] ? 1 : 0);
+            $widgetQueryString = 'event_kind_id=' . ($data['kind'] ? $data['kind']->getId() : '') . '&title=' . ($data['title'] ? 1 : 0);
 
             return $this->render('admin/event/widget/generate.html.twig', array(
                 'query_string' => $widgetQueryString,
@@ -813,19 +813,20 @@ class EventController extends Controller
      */
     public function widgetAction(Request $request)
     {
+        $em = $this->getDoctrine()->getManager();
+
         $buckets = array();
         $eventKind = null;
 
         $event_kind_id = $request->get('event_kind_id');
         $title = $request->query->has('title') ? ($request->get('title') == 1) : true;
 
+        $eventKind = null;
         if ($event_kind_id) {
-            $em = $this->getDoctrine()->getManager();
             $eventKind = $em->getRepository('AppBundle:EventKind')->find($event_kind_id);
-            if ($eventKind) {
-                $events = $em->getRepository('AppBundle:Event')->findFutures(null, $eventKind);
-            }
         }
+
+        $events = $em->getRepository('AppBundle:Event')->findFutures(null, $eventKind);
 
         return $this->render('admin/event/widget/widget.html.twig', [
             'events' => $events,

--- a/src/AppBundle/Repository/EventRepository.php
+++ b/src/AppBundle/Repository/EventRepository.php
@@ -17,7 +17,7 @@ class EventRepository extends \Doctrine\ORM\EntityRepository
         return $this->findBy(array(), array('date' => 'DESC'));
     }
 
-    public function findFutures(\DateTime $max = null, EventKind $eventKind = null)
+    public function findFutures(EventKind $eventKind = null, \DateTime $max = null, int $limit = null)
     {
         $qb = $this->createQueryBuilder('e')
             ->leftJoin('e.kind', 'ek')
@@ -25,16 +25,20 @@ class EventRepository extends \Doctrine\ORM\EntityRepository
             ->where('e.date > :now')
             ->setParameter('now', new \Datetime('now'));
 
+        if ($eventKind) {
+            $qb
+                ->andwhere('e.kind = :kind')
+                ->setParameter('kind', $eventKind);
+        }
+
         if ($max) {
             $qb
                 ->andWhere('e.date < :max')
                 ->setParameter('max', $max);
         }
 
-        if ($eventKind) {
-            $qb
-                ->andwhere('e.kind = :kind')
-                ->setParameter('kind', $eventKind);
+        if ($limit) {
+            $qb->setMaxResults($limit);
         }
 
         $qb->orderBy('e.date', 'ASC');
@@ -44,7 +48,7 @@ class EventRepository extends \Doctrine\ORM\EntityRepository
             ->getResult();
     }
 
-    public function findPast(int $limit = null, EventKind $eventKind = null)
+    public function findPast(EventKind $eventKind = null, int $limit = null)
     {
         $qb = $this->createQueryBuilder('e')
             ->leftJoin('e.kind', 'ek')
@@ -52,14 +56,14 @@ class EventRepository extends \Doctrine\ORM\EntityRepository
             ->where('e.date < :now')
             ->setParameter('now', new \Datetime('now'));
 
-        if ($limit) {
-            $qb->setMaxResults($limit);
-        }
-
         if ($eventKind) {
             $qb
                 ->andwhere('e.kind = :kind')
                 ->setParameter('kind', $eventKind);
+        }
+
+        if ($limit) {
+            $qb->setMaxResults($limit);
         }
 
         $qb->orderBy('e.date', 'DESC');


### PR DESCRIPTION
Suite de #837

### Quoi ?

Nouvelles options dans le générateur de widget : 
- la type d'événement devient optionnel
- nouveau filtre par date max
- nouveau filtre pour limiter le nombre d'événements retournés

### Captures d'écran

|Avant|Après|
|---|---|
|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/19f38604-210c-4322-9762-7c16a6ff6253)|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/8c2e2003-a3cd-4952-aded-a0adb25b8b81)|