### PR TITLE
Refactoring : séparer PeriodController & AdminPeriodController

### DIFF
--- a/app/Resources/views/admin/index.html.twig
+++ b/app/Resources/views/admin/index.html.twig
@@ -68,7 +68,7 @@
 
             {% if is_granted("ROLE_SHIFT_MANAGER") %}
                 <h6><i class="material-icons">date_range</i>&nbsp;Semaine type</h6>
-                <a href="{{ path("period_admin") }}" class="waves-effect waves-light btn white black-text">
+                <a href="{{ path("admin_period_index") }}" class="waves-effect waves-light btn white black-text">
                     <i class="material-icons left orange-text">date_range</i>Gérer la semaine type
                 </a>
                 <a href="{{ path("admin_periodpositionfreelog_list") }}" class="waves-effect waves-light btn orange">

--- a/app/Resources/views/admin/period/copy_periods.html.twig
+++ b/app/Resources/views/admin/period/copy_periods.html.twig
@@ -5,7 +5,7 @@
 {% block breadcrumbs %}
 <a href="{{ path('homepage') }}"><i class="material-icons">home</i></a><i class="material-icons">chevron_right</i>
 <a href="{{ path('admin') }}"><i class="material-icons">build</i>&nbsp;Administration</a><i class="material-icons">chevron_right</i>
-<a href="{{ path('period_admin') }}"><i class="material-icons">date_range</i>&nbsp;Semaine type</a><i class="material-icons">chevron_right</i>
+<a href="{{ path('admin_period_index') }}"><i class="material-icons">date_range</i>&nbsp;Semaine type</a><i class="material-icons">chevron_right</i>
 <i class="material-icons">content_copy</i>&nbsp;Dupliquer les créneaux types d'un jour vers un autre
 {% endblock %}
 

--- a/app/Resources/views/admin/period/edit.html.twig
+++ b/app/Resources/views/admin/period/edit.html.twig
@@ -5,7 +5,7 @@
 {% block breadcrumbs %}
 <a href="{{ path('homepage') }}"><i class="material-icons">home</i></a><i class="material-icons">chevron_right</i>
 <a href="{{ path('admin') }}"><i class="material-icons">build</i>&nbsp;Administration</a><i class="material-icons">chevron_right</i>
-<a href="{{ path('period_admin') }}"><i class="material-icons">date_range</i>&nbsp;Semaine type</a><i class="material-icons">chevron_right</i>
+<a href="{{ path('admin_period_index') }}"><i class="material-icons">date_range</i>&nbsp;Semaine type</a><i class="material-icons">chevron_right</i>
 <i class="material-icons">edit</i>&nbsp;Editer le créneau type
 {% endblock %}
 

--- a/app/Resources/views/admin/period/generate_shifts.html.twig
+++ b/app/Resources/views/admin/period/generate_shifts.html.twig
@@ -5,7 +5,7 @@
 {% block breadcrumbs %}
 <a href="{{ path('homepage') }}"><i class="material-icons">home</i></a><i class="material-icons">chevron_right</i>
 <a href="{{ path('admin') }}"><i class="material-icons">build</i>&nbsp;Administration</a><i class="material-icons">chevron_right</i>
-<a href="{{ path('period_admin') }}"><i class="material-icons">date_range</i>&nbsp;Semaine type</a><i class="material-icons">chevron_right</i>
+<a href="{{ path('admin_period_index') }}"><i class="material-icons">date_range</i>&nbsp;Semaine type</a><i class="material-icons">chevron_right</i>
 <i class="material-icons">add</i>&nbsp;Générer
 {% endblock %}
 

--- a/app/Resources/views/admin/period/index.html.twig
+++ b/app/Resources/views/admin/period/index.html.twig
@@ -90,7 +90,7 @@
                         <div class="row">
                             {{ _self.form_input(filter_form.beneficiary, not use_fly_and_fixed) }}
                         </div>
-                        {{ form_widget(filter_form.filter) }}
+                        {{ form_widget(filter_form.submit) }}
                         {{ form_end(filter_form) }}
                     </div>
                 </li>

--- a/app/Resources/views/admin/period/index.html.twig
+++ b/app/Resources/views/admin/period/index.html.twig
@@ -101,7 +101,7 @@
                     </div>
                     <div class="collapsible-body">
                         <div class="row">
-                            <a href="{{ path("period_new") }}"
+                            <a href="{{ path("admin_period_new") }}"
                                class="btn col m4 waves-effect waves-light tooltipped"
                                data-position="bottom"
                                data-tooltip="Créer un groupe de créneaux type à une heure et un jour donné">
@@ -111,7 +111,7 @@
 
                         {% if is_granted("ROLE_ADMIN") %}
                             <div class="row">
-                                <a href="{{ path("period_copy") }}"
+                                <a href="{{ path("admin_period_copy") }}"
                                    class="btn col m4 waves-effect waves-light tooltipped"
                                    data-position="bottom"
                                    data-tooltip="Dupliquer des créneaux types d'un jour vers un autre">
@@ -119,7 +119,7 @@
                                 </a>
                             </div>
                             <div class="row">
-                                <a href="{{ path("shifts_generation") }}"
+                                <a href="{{ path("admin_shifts_generation") }}"
                                    class="btn col m4 waves-effect waves-light tooltipped"
                                    data-position="bottom"
                                    data-tooltip="Générer automatiquement des créneaux à partir de la semaine type">

--- a/app/Resources/views/admin/period/new.html.twig
+++ b/app/Resources/views/admin/period/new.html.twig
@@ -5,7 +5,7 @@
 {% block breadcrumbs %}
 <a href="{{ path('homepage') }}"><i class="material-icons">home</i></a><i class="material-icons">chevron_right</i>
 <a href="{{ path('admin') }}"><i class="material-icons">build</i>&nbsp;Administration</a><i class="material-icons">chevron_right</i>
-<a href="{{ path('period_admin') }}"><i class="material-icons">date_range</i>&nbsp;Semaine type</a><i class="material-icons">chevron_right</i>
+<a href="{{ path('admin_period_index') }}"><i class="material-icons">date_range</i>&nbsp;Semaine type</a><i class="material-icons">chevron_right</i>
 <i class="material-icons">add</i>&nbsp;Nouveau créneau type
 {% endblock %}
 

--- a/app/Resources/views/default/index.html.twig
+++ b/app/Resources/views/default/index.html.twig
@@ -127,7 +127,7 @@
                     <i class="material-icons left">schedule</i>Planning
                 </a>
                 <br />
-                <a href="{{ path("period") }}" class="waves-effect waves-light btn teal">
+                <a href="{{ path("period_index") }}" class="waves-effect waves-light btn teal">
                     <i class="material-icons left">date_range</i>Semaine type
                 </a>
                 <br />

--- a/app/Resources/views/period/_partial/period_card.html.twig
+++ b/app/Resources/views/period/_partial/period_card.html.twig
@@ -29,7 +29,7 @@
                 {{ _self.period_title(period, show_day_of_week) }}
             </div>
         {% else %}
-            <a href="{{ path("period_edit",{'id': period.id}) }}" class="black-text">
+            <a href="{{ path("admin_period_edit",{'id': period.id}) }}" class="black-text">
                 <div class="black-text editable-box">
                     {{ _self.period_title(period, show_day_of_week) }}
                 </div>

--- a/app/Resources/views/period/index.html.twig
+++ b/app/Resources/views/period/index.html.twig
@@ -60,7 +60,7 @@ It display a page with all the avaible periods (a.k.a the "Semaine type")
                             {{ _self.form_input(filter_form.filling, not use_fly_and_fixed) }}
                         </div>
                         <div class="row">
-                            {{ form_widget(filter_form.filter, { 'attr': {'class': 'btn col m3'} }) }}
+                            {{ form_widget(filter_form.submit, { 'attr': {'class': 'btn col m3'} }) }}
                             {{ form_end(filter_form) }}
                         </div>
                         {% if use_fly_and_fixed %}

--- a/app/Resources/views/user/_partial/period_position_card.html.twig
+++ b/app/Resources/views/user/_partial/period_position_card.html.twig
@@ -35,7 +35,7 @@
             </span>
         </div>
         <div class="card-action">
-            <a href="{{ path("period_edit", { 'id': period_position.period.id }) }}" class="waves-effect waves-light btn white black-text" target="_blank" title="Voir le créneau">
+            <a href="{{ path("admin_period_edit", { 'id': period_position.period.id }) }}" class="waves-effect waves-light btn white black-text" target="_blank" title="Voir le créneau">
                 <i class="material-icons left orange-text">date_range</i>Voir le créneau
             </a>
         </div>

--- a/src/AppBundle/Controller/AdminController.php
+++ b/src/AppBundle/Controller/AdminController.php
@@ -60,7 +60,7 @@ class AdminController extends Controller
      * @Route("/", name="admin", methods={"GET"})
      * @Security("has_role('ROLE_ADMIN_PANEL')")
      */
-    public function indexAction()
+    public function indexAction(Request $request)
     {
         return $this->render('admin/index.html.twig');
     }

--- a/src/AppBundle/Controller/AdminPeriodController.php
+++ b/src/AppBundle/Controller/AdminPeriodController.php
@@ -1,0 +1,605 @@
+<?php
+
+namespace AppBundle\Controller;
+
+use AppBundle\Entity\Beneficiary;
+use AppBundle\Entity\Job;
+use AppBundle\Entity\Period;
+use AppBundle\Entity\PeriodPosition;
+use AppBundle\Event\PeriodPositionFreedEvent;
+use AppBundle\Form\AutocompleteBeneficiaryType;
+use AppBundle\Form\PeriodPositionType;
+use AppBundle\Form\PeriodType;
+use AppBundle\Repository\JobRepository;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+/**
+ * Admin Period Controller ("semaine type" coté admin)
+ *
+ * @Route("admin/period")
+ */
+class AdminPeriodController extends Controller
+{
+    /**
+     * Build the filter form for the admin main page (route /booking/admin)
+     * and rerun an array with  the form object and the date range and the action
+     *
+     * the return object :
+     * array(
+     *      "form" => FormBuilderInterface
+     *      "from" => DateTime,
+     *      "to" => DateTime,
+     *      "job"=> Job|null,
+     *      "filling" => str|null,
+     *      "beneficiary" => Entity/Beneficiary
+     *      )
+     *
+     * @param Request $request the request sent by the client, used to process the form
+     * @param bool $withBeneficiaryField if true will add a beneficiary and a 'problematic' filter field
+     * @return array
+     */
+    private function filterFormFactory(Request $request, bool $withBeneficiaryField): array
+    {
+        // default values
+        $res = [
+            'beneficiary' => null,
+            'job' => null,
+            'filling' => null,
+            'week' => null,
+        ];
+
+        // filter creation ----------------------
+        $formBuilder = $this->createFormBuilder()
+            ->add('job', EntityType::class, array(
+                'label' => 'Type de créneau',
+                'class' => 'AppBundle:Job',
+                'choice_label' => 'name',
+                'multiple' => false,
+                'required' => false,
+                'query_builder' => function(JobRepository $repository) {
+                    $qb = $repository->createQueryBuilder('j');
+                    return $qb
+                        ->where($qb->expr()->eq('j.enabled', '?1'))
+                        ->setParameter('1', '1')
+                        ->orderBy('j.name', 'ASC');
+                }
+            ))
+            ->add('week', ChoiceType::class, array(
+                'label' => 'Semaine',
+                'required' => false,
+                'choices' => array(
+                    'A' => 'A',
+                    'B' => 'B',
+                    'C' => 'C',
+                    'D' => 'D',
+                ),
+            ))
+            ->add('filter', SubmitType::class, array(
+                'label' => 'Filtrer',
+                'attr' => array('class' => 'btn', 'value' => 'filtrer')
+            ));
+
+        if ($withBeneficiaryField) {
+            $formBuilder
+                ->setAction($this->generateUrl('admin_period_index'))
+                ->add('beneficiary', AutocompleteBeneficiaryType::class, array(
+                    'label' => 'Bénéficiaire',
+                    'required' => false,
+                ))
+                ->add('filling', ChoiceType::class, array(
+                    'label' => 'Remplissage',
+                    'required' => false,
+                    'choices' => array(
+                        'Complet' => 'full',
+                        'Partiel' => 'partial',
+                        'Vide' => 'empty',
+                        'Problématique' => 'problematic'
+                    ),
+                ));
+        }else{
+            $formBuilder
+                ->setAction($this->generateUrl('period_index'))
+                ->add('filling', ChoiceType::class, array(
+                    'label' => 'Remplissage',
+                    'required' => false,
+                    'choices' => array(
+                        'Complet' => 'full',
+                        'Partiel' => 'partial',
+                        'Vide' => 'empty',
+                    ),
+                ));
+        }
+
+        $res["form"] = $formBuilder->getForm();
+        $res["form"]->handleRequest($request);
+
+        if ($res["form"]->isSubmitted() && $res["form"]->isValid()) {
+            if ($withBeneficiaryField) {
+                $res["beneficiary"] = $res["form"]->get("beneficiary")->getData();
+            }
+            $res["job"] = $res["form"]->get("job")->getData();
+            $res["filling"] = $res["form"]->get("filling")->getData();
+            $res["week"] = $res["form"]->get("week")->getData();
+
+        }
+
+        return $res;
+    }
+
+    /**
+     * Display all the periods in a schedule (available and reserved)
+     *
+     * @Route("/", name="admin_period_index", methods={"GET","POST"})
+     * @Security("has_role('ROLE_SHIFT_MANAGER')")
+     */
+    public function indexAction(Request $request)
+    {
+        $em = $this->getDoctrine()->getManager();
+
+        $filter = $this->filterFormFactory($request, true);
+        $periodsByDay = array();
+
+        foreach (Period::DAYS_OF_WEEK as $i => $value) {
+            $findByFilter = array('dayOfWeek' => $i);
+            $periodsByDay[$i] = $em->getRepository('AppBundle:Period')->findAll($i, $filter['job'], true);
+        }
+
+        return $this->render('admin/period/index.html.twig', array(
+            'days_of_week' => Period::DAYS_OF_WEEK,
+            'periods_by_day' => $periodsByDay,
+            'filter_form' => $filter['form']->createView(),
+            'beneficiary_filter' => $filter['beneficiary'],
+            'week_filter' => $filter['week'],
+            'filling_filter' => $filter["filling"]
+        ));
+    }
+
+    /**
+     * @Route("/new", name="admin_period_new", methods={"GET","POST"})
+     * @Security("has_role('ROLE_SHIFT_MANAGER')")
+     */
+    public function newPeriodAction(Request $request)
+    {
+        $session = new Session();
+        $em = $this->getDoctrine()->getManager();
+        $current_user = $this->get('security.token_storage')->getToken()->getUser();
+
+        $period = new Period();
+        $job = $em->getRepository(Job::class)->findOneBy(array());
+
+        if (!$job) {
+            $session->getFlashBag()->add('warning', 'Commençons par créer un poste de bénévolat');
+            return $this->redirectToRoute('job_new');
+        }
+
+        $form = $this->createForm(PeriodType::class, $period);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $start = $form->get('start')->getData();
+            $period->setStart(new \DateTime($start));
+            $end = $form->get('end')->getData();
+            $period->setEnd(new \DateTime($end));
+            $period->setCreatedBy($current_user);
+
+            $em->persist($period);
+            $em->flush();
+
+            $session->getFlashBag()->add('success', 'Le nouveau créneau type ' . $period . ' a bien été créé !');
+            return $this->redirectToRoute('admin_period_edit',array('id'=>$period->getId()));
+        }
+
+        return $this->render('admin/period/new.html.twig',array(
+            "form" => $form->createView()
+        ));
+    }
+
+    /**
+     * @Route("/{id}/edit", name="admin_period_edit", methods={"GET","POST"})
+     * @Security("has_role('ROLE_SHIFT_MANAGER')")
+     */
+    public function editPeriodAction(Request $request, Period $period)
+    {
+        $session = new Session();
+        $em = $this->getDoctrine()->getManager();
+        $current_user = $this->get('security.token_storage')->getToken()->getUser();
+
+        $form = $this->createForm(PeriodType::class, $period);
+        $form->handleRequest($request);
+
+        if ($request->isMethod('GET')) {
+            $form->get('start')->setData($period->getStart()->format('H:i'));
+            $form->get('end')->setData($period->getEnd()->format('H:i'));
+        }
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $start = $form->get('start')->getData();
+            $period->setStart(new \DateTime($start));
+            $end = $form->get('end')->getData();
+            $period->setEnd(new \DateTime($end));
+            $period->setUpdatedBy($current_user);
+
+            $em->persist($period);
+            $em->flush();
+
+            $session->getFlashBag()->add('success', 'Le créneau type ' . $period . ' a bien été édité !');
+            return $this->redirectToRoute('admin_period_index');
+        }
+
+        $beneficiaries = $em->getRepository(Beneficiary::class)->findAllActive();
+
+        $periodDeleteForm = $this->createPeriodDeleteForm($period);
+
+        $positionAddForm = $this->createPeriodPositionAddForm($period);
+
+        $positionsBookForms = [];
+        $positionsFreeForms = [];
+        $positionsDeleteForms = [];
+        foreach ($period->getPositions() as $position) {
+            // book forms
+            if (!$position->getShifter()) {
+                $positionsBookForms[$position->getId()] = $this->createPeriodPositionBookForm($period, $position)->createView();
+            }
+            // free forms
+            else {
+                $positionsFreeForms[$position->getId()] = $this->createPeriodPositionFreeForm($period, $position)->createView();
+            }
+            // delete forms
+            $positionsDeleteForms[$position->getId()] = $this->createPeriodPositionDeleteForm($period, $position)->createView();
+        }
+
+        return $this->render('admin/period/edit.html.twig', array(
+            "form" => $form->createView(),
+            "beneficiaries" => $beneficiaries,
+            "period" => $period,
+            "admin_period_delete_form" => $periodDeleteForm->createView(),
+            "position_add_form" => $positionAddForm->createView(),
+            "positions_book_forms" => $positionsBookForms,
+            "positions_free_forms" => $positionsFreeForms,
+            "positions_delete_forms" => $positionsDeleteForms,
+        ));
+    }
+
+    /**
+     * @Route("/{id}/position/add", name="admin_period_position_new", methods={"POST"})
+     * @Security("has_role('ROLE_SHIFT_MANAGER')")
+     */
+    public function newPeriodPositionAction(Request $request, Period $period)
+    {
+        $session = new Session();
+        $em = $this->getDoctrine()->getManager();
+        $current_user = $this->get('security.token_storage')->getToken()->getUser();
+
+        $position = new PeriodPosition();
+        $form = $this->createForm(PeriodPositionType::class, $position);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $count = $form["nb_of_shifter"]->getData();
+            foreach ($form["week_cycle"]->getData() as $week_cycle) {
+                $position->setWeekCycle($week_cycle);
+                $position->setCreatedBy($current_user);
+                foreach (range(0, $count-1) as $iteration) {
+                    $p = clone($position);
+                    $period->addPosition($p);
+                    $em->persist($p);
+                }
+            }
+            $em->persist($period);
+            $em->flush();
+
+            $session->getFlashBag()->add('success', $count . ' poste' . (($count>1) ? 's':'') . ' ajouté ' . (($count>1) ? 's':'') . ' (pour chaque cycle sélectionné) !');
+        }
+
+        return $this->redirectToRoute('admin_period_edit',array('id'=>$period->getId()));
+    }
+
+    /**
+     * @Route("/{id}/position/{position}", name="admin_period_position_delete", methods={"DELETE"})
+     * @Security("has_role('ROLE_ADMIN')")
+     */
+    public function deletePeriodPositionAction(Request $request, Period $period, PeriodPosition $position)
+    {
+        $session = new Session();
+
+        $form = $this->createPeriodPositionDeleteForm($period, $position);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $em = $this->getDoctrine()->getManager();
+            $em->remove($position);
+            $em->flush();
+
+            $session->getFlashBag()->add('success', 'Le poste ' . $position . ' a bien été supprimé !');
+        }
+
+        return $this->redirectToRoute('admin_period_edit',array('id'=>$period->getId()));
+    }
+
+    /**
+     * Book a period.
+     *
+     * @Route("/{id}/position/{position}/book", name="admin_period_position_book", methods={"POST"})
+     * @Security("has_role('ROLE_SHIFT_MANAGER')")
+     */
+    public function bookPeriodPositionAction(Request $request, Period $period, PeriodPosition $position): Response
+    {
+        $session = new Session();
+        $em = $this->getDoctrine()->getManager();
+
+        $form = $this->createPeriodPositionBookForm($period, $position);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            if ($position->getShifter()) {
+                $session->getFlashBag()->add("error", "Désolé, ce créneau est déjà réservé");
+                return new Response($this->generateUrl('admin_period_edit',array('id'=>$period->getId())), 205);
+            }
+
+            $beneficiary = $form->get("shifter")->getData();
+            if ($position->getFormation() && !$beneficiary->getFormations()->contains($position->getFormation())) {
+                $session
+                    ->getFlashBag()
+                    ->add("error", "Désolé, ce bénévole n'a pas la qualification nécessaire (" . $position->getFormation()->getName() . ")");
+                return new Response($this->generateUrl('admin_period_edit',array('id'=>$period->getId())), 205);
+            }
+
+            if (!$position->getBooker()) {
+                $current_user = $this->get('security.token_storage')->getToken()->getUser();
+                $position->setBooker($current_user);
+                $position->setBookedTime(new \DateTime('now'));
+            }
+
+            $position->setShifter($beneficiary);
+            $em->persist($position);
+            $em->flush();
+
+            $session->getFlashBag()->add('success', 'Créneau fixe réservé avec succès pour ' . $position->getShifter() . ' : ' . $position);
+        }
+
+        return $this->redirectToRoute('admin_period_edit',array('id'=>$period->getId()));
+    }
+
+    /**
+     * Free a position.
+     *
+     * @Route("/{id}/position/{position}/free", name="admin_period_position_free", methods={"POST"})
+     * @Security("has_role('ROLE_SHIFT_MANAGER')")
+     */
+    public function freePeriodPositionAction(Request $request, Period $period, PeriodPosition $position)
+    {
+        $session = new Session();
+        $em = $this->getDoctrine()->getManager();
+
+        $form = $this->createPeriodPositionFreeForm($period, $position);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            // store position beneficiary & bookedTime (before position free())
+            $beneficiary = $position->getShifter();
+            $bookedTime = $position->getBookedTime();
+
+            // free position
+            $position->free();
+
+            $em = $this->getDoctrine()->getManager();
+            $em->persist($position);
+            $em->flush();
+
+            $dispatcher = $this->get('event_dispatcher');
+            $dispatcher->dispatch(PeriodPositionFreedEvent::NAME, new PeriodPositionFreedEvent($position, $beneficiary, $bookedTime));
+
+            $session->getFlashBag()->add('success', 'Le poste ' . $position . ' a bien été libéré !');
+        }
+
+        return $this->redirectToRoute('admin_period_edit',array('id'=>$position->getPeriod()->getId()));
+    }
+
+    /**
+     * Deletes a period entity.
+     *
+     * @Route("/{id}", name="admin_period_delete", methods={"DELETE"})
+     * @Security("has_role('ROLE_ADMIN')")
+     */
+    public function deletePeriodAction(Request $request, Period $period)
+    {
+        $session = new Session();
+        $em = $this->getDoctrine()->getManager();
+
+        $form = $this->createPeriodDeleteForm($period);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $em->remove($period);
+            $em->flush();
+
+            $session->getFlashBag()->add('success', 'Le créneau type ' . $period . ' a bien été supprimé !');
+        }
+
+        return $this->redirectToRoute('admin_period_index');
+    }
+
+    /**
+     * @Route("/copyPeriod/", name="admin_period_copy", methods={"GET","POST"})
+     * @Security("has_role('ROLE_ADMIN')")
+     */
+    public function copyPeriodAction(Request $request)
+    {
+        $form = $this->createFormBuilder()
+            ->setAction($this->generateUrl('admin_period_copy'))
+            ->add('day_of_week_from', ChoiceType::class, array('label' => 'Jour de la semaine référence', 'choices' => Period::DAYS_OF_WEEK_LIST_WITH_INT))
+            ->add('day_of_week_to', ChoiceType::class, array('label' => 'Jour de la semaine destination', 'choices' => Period::DAYS_OF_WEEK_LIST_WITH_INT))
+            ->getForm();
+
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $from = $form->get('day_of_week_from')->getData();
+            $to = $form->get('day_of_week_to')->getData();
+
+            $em = $this->getDoctrine()->getManager();
+            $periods = $em->getRepository('AppBundle:Period')->findBy(array('dayOfWeek'=>$from));
+
+            $count = 0;
+            foreach ($periods as $period){
+                $p = clone $period;
+                $p->setDayOfWeek($to);
+                foreach ($period->getPositions() as $position){
+                    $p->addPosition($position);
+                }
+                $em->persist($p);
+                $count++;
+            }
+            $em->flush();
+
+            $session = new Session();
+            $session->getFlashBag()->add('success', $count . ' creneaux copiés de' . array_search($from, Period::DAYS_OF_WEEK_LIST_WITH_INT) . ' à ' . array_search($to, Period::DAYS_OF_WEEK_LIST_WITH_INT));
+
+            return $this->redirectToRoute('admin_period_index');
+        }
+
+        return $this->render('admin/period/copy_periods.html.twig',array(
+            "form" => $form->createView()
+        ));
+    }
+
+    /**
+     * @Route("/generateShifts/", name="admin_shifts_generation", methods={"GET","POST"})
+     * @Security("has_role('ROLE_ADMIN')")
+     */
+    public function generateShiftsForDateAction(Request $request, KernelInterface $kernel)
+    {
+        $form = $this->createFormBuilder()
+            ->setAction($this->generateUrl('admin_shifts_generation'))
+            ->add('date_from',TextType::class,array('label'=>'du*','attr'=>array('class'=>'datepicker')))
+            ->add('date_to',TextType::class,array('label'=>'au' ,'attr'=>array('class'=>'datepicker','require' => false)))
+            ->getForm();
+
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+
+            $date_from = $form->get('date_from')->getData();
+            $date_to = $form->get('date_to')->getData();
+
+            $application = new Application($kernel);
+            $application->setAutoExit(false);
+
+            $input = new ArrayInput(array(
+                'command' => 'app:shift:generate',
+                'date' => $date_from,
+                '--to' => $date_to
+            ));
+
+            $output = new BufferedOutput();
+            $application->run($input, $output);
+            $content = $output->fetch();
+
+            $session = new Session();
+            $session->getFlashBag()->add('success',$content);
+
+            return $this->redirectToRoute('admin_period_index');
+        }
+
+        return $this->render('admin/period/generate_shifts.html.twig',array(
+            "form" => $form->createView()
+        ));
+    }
+
+    /**
+     * Creates a form to delete a period entity.
+     *
+     * @param Period $period The period entity
+     *
+     * @return \Symfony\Component\Form\Form The form
+     */
+    private function createPeriodDeleteForm(Period $period)
+    {
+        return $this->createFormBuilder()
+            ->setAction($this->generateUrl('admin_period_delete', array('id' => $period->getId())))
+            ->setMethod('DELETE')
+            ->getForm();
+    }
+
+    /**
+     * Creates a form to add a period position entity.
+     *
+     * @param Period $period The period entity
+     *
+     * @return \Symfony\Component\Form\Form The form
+     */
+    private function createPeriodPositionAddForm(Period $period)
+    {
+        return $this->createForm(
+            PeriodPositionType::class,
+            new PeriodPosition(),
+            array(
+                'action' => $this->generateUrl(
+                    'admin_period_position_new',
+                    array('id' => $period->getId())
+                )
+            ));
+    }
+
+    /**
+     * Creates a form to book a period position entity.
+     *
+     * @param Period $period The period entity
+     * @param PeriodPosition $position The period position entity
+     *
+     * @return \Symfony\Component\Form\Form The form
+     */
+    private function createPeriodPositionBookForm(Period $period, PeriodPosition $position)
+    {
+        return $this->get('form.factory')->createNamedBuilder('positions_book_forms_' . $position->getId())
+            ->setAction($this->generateUrl('admin_period_position_book', array('id' => $period->getId(), 'position' => $position->getId())))
+            ->setMethod('POST')
+            ->add('shifter', AutocompleteBeneficiaryType::class, array('label' => 'Numéro d\'adhérent ou nom du membre', 'required' => true))
+            ->getForm();
+    }
+
+    /**
+     * Creates a form to free a period position entity.
+     *
+     * @param Period $period The period entity
+     * @param PeriodPosition $position The period position entity
+     *
+     * @return \Symfony\Component\Form\Form The form
+     */
+    private function createPeriodPositionFreeForm(Period $period, PeriodPosition $position)
+    {
+        return $this->get('form.factory')->createNamedBuilder('positions_free_forms_' . $position->getId())
+            ->setAction($this->generateUrl('admin_period_position_free', array('id' => $period->getId(), 'position' => $position->getId())))
+            ->setMethod('POST')
+            ->getForm();
+    }
+
+    /**
+     * Creates a form to delete a period position entity.
+     *
+     * @param Period $period The period entity
+     * @param PeriodPosition $position The period position entity
+     *
+     * @return \Symfony\Component\Form\Form The form
+     */
+    private function createPeriodPositionDeleteForm(Period $period, PeriodPosition $position)
+    {
+        return $this->get('form.factory')->createNamedBuilder('positions_delete_forms_' . $position->getId())
+            ->setAction($this->generateUrl('admin_period_position_delete', array('id' => $period->getId(), 'position' => $position->getId())))
+            ->setMethod('DELETE')
+            ->getForm();
+    }
+}

--- a/src/AppBundle/Controller/FormationController.php
+++ b/src/AppBundle/Controller/FormationController.php
@@ -25,9 +25,12 @@ class FormationController extends Controller
      * @Route("/", name="formation_list", methods={"GET"})
      * @Security("has_role('ROLE_ADMIN')")
      */
-    public function indexAction()
+    public function indexAction(Request $request)
     {
-        $formations = $this->getDoctrine()->getManager()->getRepository('AppBundle:Formation')->findAll();
+        $em = $this->getDoctrine()->getManager();
+
+        $formations = $em->getRepository('AppBundle:Formation')->findAll();
+
         return $this->render('admin/formation/list.html.twig',array('formations'=>$formations));
     }
 

--- a/src/AppBundle/Controller/PeriodController.php
+++ b/src/AppBundle/Controller/PeriodController.php
@@ -6,29 +6,20 @@ use AppBundle\Entity\Beneficiary;
 use AppBundle\Entity\Job;
 use AppBundle\Entity\Period;
 use AppBundle\Entity\PeriodPosition;
-use AppBundle\Event\PeriodPositionFreedEvent;
 use AppBundle\Form\AutocompleteBeneficiaryType;
-use AppBundle\Form\PeriodPositionType;
-use AppBundle\Form\PeriodType;
 use AppBundle\Repository\JobRepository;
-use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Symfony\Bundle\FrameworkBundle\Console\Application;
-use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
-use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
-use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
- * Controller to manage the period shift (a.k.a. "semaine type")
+ * Period Controller ("semaine type" anonyme)
  *
  * @Route("period")
  */
@@ -95,7 +86,7 @@ class PeriodController extends Controller
 
         if ($withBeneficiaryField) {
             $formBuilder
-                ->setAction($this->generateUrl('period_admin'))
+                ->setAction($this->generateUrl('admin_period_index'))
                 ->add('beneficiary', AutocompleteBeneficiaryType::class, array(
                     'label' => 'Bénéficiaire',
                     'required' => false,
@@ -112,7 +103,7 @@ class PeriodController extends Controller
                 ));
         }else{
             $formBuilder
-                ->setAction($this->generateUrl('period'))
+                ->setAction($this->generateUrl('period_index'))
                 ->add('filling', ChoiceType::class, array(
                     'label' => 'Remplissage',
                     'required' => false,
@@ -143,11 +134,13 @@ class PeriodController extends Controller
     /**
      * Display all the period (available and reserved) anonymized
      *
-     * @Route("/", name="period", methods={"GET","POST"})
+     * @Route("/", name="period_index", methods={"GET","POST"})
      * @Security("has_role('ROLE_USER')")
      */
-    public function indexAction(Request $request, EntityManagerInterface $em): Response
+    public function indexAction(Request $request)
     {
+        $em = $this->getDoctrine()->getManager();
+
         $filter = $this->filterFormFactory($request, false);
         $sort = 'start';
         $order = 'ASC';
@@ -165,467 +158,5 @@ class PeriodController extends Controller
             'week_filter' => $filter['week'],
             'filling_filter' => $filter["filling"]
         ));
-    }
-
-    /**
-     * Display all the periods in a schedule (available and reserved)
-     *
-     * @Route("/admin", name="period_admin", methods={"GET","POST"})
-     * @Security("has_role('ROLE_SHIFT_MANAGER')")
-     */
-    public function adminIndexAction(Request $request, EntityManagerInterface $em): Response
-    {
-        $filter = $this->filterFormFactory($request, true);
-        $periodsByDay = array();
-
-        foreach (Period::DAYS_OF_WEEK as $i => $value) {
-            $findByFilter = array('dayOfWeek' => $i);
-            $periodsByDay[$i] = $em->getRepository('AppBundle:Period')->findAll($i, $filter['job'], true);
-        }
-
-        return $this->render('admin/period/index.html.twig', array(
-            'days_of_week' => Period::DAYS_OF_WEEK,
-            'periods_by_day' => $periodsByDay,
-            'filter_form' => $filter['form']->createView(),
-            'beneficiary_filter' => $filter['beneficiary'],
-            'week_filter' => $filter['week'],
-            'filling_filter' => $filter["filling"]
-        ));
-    }
-
-    /**
-     * @Route("/new", name="period_new", methods={"GET","POST"})
-     * @Security("has_role('ROLE_SHIFT_MANAGER')")
-     */
-    public function newPeriodAction(Request $request)
-    {
-        $session = new Session();
-        $em = $this->getDoctrine()->getManager();
-        $current_user = $this->get('security.token_storage')->getToken()->getUser();
-
-        $period = new Period();
-        $job = $em->getRepository(Job::class)->findOneBy(array());
-
-        if (!$job) {
-            $session->getFlashBag()->add('warning', 'Commençons par créer un poste de bénévolat');
-            return $this->redirectToRoute('job_new');
-        }
-
-        $form = $this->createForm(PeriodType::class, $period);
-        $form->handleRequest($request);
-
-        if ($form->isSubmitted() && $form->isValid()) {
-            $start = $form->get('start')->getData();
-            $period->setStart(new \DateTime($start));
-            $end = $form->get('end')->getData();
-            $period->setEnd(new \DateTime($end));
-            $period->setCreatedBy($current_user);
-
-            $em->persist($period);
-            $em->flush();
-
-            $session->getFlashBag()->add('success', 'Le nouveau créneau type ' . $period . ' a bien été créé !');
-            return $this->redirectToRoute('period_edit',array('id'=>$period->getId()));
-        }
-
-        return $this->render('admin/period/new.html.twig',array(
-            "form" => $form->createView()
-        ));
-    }
-
-    /**
-     * @Route("/{id}/edit", name="period_edit", methods={"GET","POST"})
-     * @Security("has_role('ROLE_SHIFT_MANAGER')")
-     */
-    public function editPeriodAction(Request $request, Period $period)
-    {
-        $session = new Session();
-        $em = $this->getDoctrine()->getManager();
-        $current_user = $this->get('security.token_storage')->getToken()->getUser();
-
-        $form = $this->createForm(PeriodType::class, $period);
-        $form->handleRequest($request);
-
-        if ($request->isMethod('GET')) {
-            $form->get('start')->setData($period->getStart()->format('H:i'));
-            $form->get('end')->setData($period->getEnd()->format('H:i'));
-        }
-
-        if ($form->isSubmitted() && $form->isValid()) {
-            $start = $form->get('start')->getData();
-            $period->setStart(new \DateTime($start));
-            $end = $form->get('end')->getData();
-            $period->setEnd(new \DateTime($end));
-            $period->setUpdatedBy($current_user);
-
-            $em->persist($period);
-            $em->flush();
-
-            $session->getFlashBag()->add('success', 'Le créneau type ' . $period . ' a bien été édité !');
-            return $this->redirectToRoute('period_admin');
-        }
-
-        $beneficiaries = $em->getRepository(Beneficiary::class)->findAllActive();
-
-        $periodDeleteForm = $this->createPeriodDeleteForm($period);
-
-        $positionAddForm = $this->createPeriodPositionAddForm($period);
-
-        $positionsBookForms = [];
-        $positionsFreeForms = [];
-        $positionsDeleteForms = [];
-        foreach ($period->getPositions() as $position) {
-            // book forms
-            if (!$position->getShifter()) {
-                $positionsBookForms[$position->getId()] = $this->createPeriodPositionBookForm($period, $position)->createView();
-            }
-            // free forms
-            else {
-                $positionsFreeForms[$position->getId()] = $this->createPeriodPositionFreeForm($period, $position)->createView();
-            }
-            // delete forms
-            $positionsDeleteForms[$position->getId()] = $this->createPeriodPositionDeleteForm($period, $position)->createView();
-        }
-
-        return $this->render('admin/period/edit.html.twig', array(
-            "form" => $form->createView(),
-            "beneficiaries" => $beneficiaries,
-            "period" => $period,
-            "period_delete_form" => $periodDeleteForm->createView(),
-            "position_add_form" => $positionAddForm->createView(),
-            "positions_book_forms" => $positionsBookForms,
-            "positions_free_forms" => $positionsFreeForms,
-            "positions_delete_forms" => $positionsDeleteForms,
-        ));
-    }
-
-    /**
-     * @Route("/{id}/position/add", name="period_position_new", methods={"POST"})
-     * @Security("has_role('ROLE_SHIFT_MANAGER')")
-     */
-    public function newPeriodPositionAction(Request $request, Period $period)
-    {
-        $session = new Session();
-        $em = $this->getDoctrine()->getManager();
-        $current_user = $this->get('security.token_storage')->getToken()->getUser();
-
-        $position = new PeriodPosition();
-        $form = $this->createForm(PeriodPositionType::class, $position);
-        $form->handleRequest($request);
-
-        if ($form->isSubmitted() && $form->isValid()) {
-            $count = $form["nb_of_shifter"]->getData();
-            foreach ($form["week_cycle"]->getData() as $week_cycle) {
-                $position->setWeekCycle($week_cycle);
-                $position->setCreatedBy($current_user);
-                foreach (range(0, $count-1) as $iteration) {
-                    $p = clone($position);
-                    $period->addPosition($p);
-                    $em->persist($p);
-                }
-            }
-            $em->persist($period);
-            $em->flush();
-
-            $session->getFlashBag()->add('success', $count . ' poste' . (($count>1) ? 's':'') . ' ajouté ' . (($count>1) ? 's':'') . ' (pour chaque cycle sélectionné) !');
-        }
-
-        return $this->redirectToRoute('period_edit',array('id'=>$period->getId()));
-    }
-
-    /**
-     * @Route("/{id}/position/{position}", name="period_position_delete", methods={"DELETE"})
-     * @Security("has_role('ROLE_ADMIN')")
-     */
-    public function deletePeriodPositionAction(Request $request, Period $period, PeriodPosition $position)
-    {
-        $session = new Session();
-
-        $form = $this->createPeriodPositionDeleteForm($period, $position);
-        $form->handleRequest($request);
-
-        if ($form->isSubmitted() && $form->isValid()) {
-            $em = $this->getDoctrine()->getManager();
-            $em->remove($position);
-            $em->flush();
-
-            $session->getFlashBag()->add('success', 'Le poste ' . $position . ' a bien été supprimé !');
-        }
-
-        return $this->redirectToRoute('period_edit',array('id'=>$period->getId()));
-    }
-
-    /**
-     * Book a period.
-     *
-     * @Route("/{id}/position/{position}/book", name="period_position_book", methods={"POST"})
-     * @Security("has_role('ROLE_SHIFT_MANAGER')")
-     */
-    public function bookPeriodPositionAction(Request $request, Period $period, PeriodPosition $position): Response
-    {
-        $session = new Session();
-        $em = $this->getDoctrine()->getManager();
-
-        $form = $this->createPeriodPositionBookForm($period, $position);
-        $form->handleRequest($request);
-
-        if ($form->isSubmitted() && $form->isValid()) {
-            if ($position->getShifter()) {
-                $session->getFlashBag()->add("error", "Désolé, ce créneau est déjà réservé");
-                return new Response($this->generateUrl('period_edit',array('id'=>$period->getId())), 205);
-            }
-
-            $beneficiary = $form->get("shifter")->getData();
-            if ($position->getFormation() && !$beneficiary->getFormations()->contains($position->getFormation())) {
-                $session
-                    ->getFlashBag()
-                    ->add("error", "Désolé, ce bénévole n'a pas la qualification nécessaire (" . $position->getFormation()->getName() . ")");
-                return new Response($this->generateUrl('period_edit',array('id'=>$period->getId())), 205);
-            }
-
-            if (!$position->getBooker()) {
-                $current_user = $this->get('security.token_storage')->getToken()->getUser();
-                $position->setBooker($current_user);
-                $position->setBookedTime(new \DateTime('now'));
-            }
-
-            $position->setShifter($beneficiary);
-            $em->persist($position);
-            $em->flush();
-
-            $session->getFlashBag()->add('success', 'Créneau fixe réservé avec succès pour ' . $position->getShifter() . ' : ' . $position);
-        }
-
-        return $this->redirectToRoute('period_edit',array('id'=>$period->getId()));
-    }
-
-    /**
-     * Free a position.
-     *
-     * @Route("/{id}/position/{position}/free", name="period_position_free", methods={"POST"})
-     * @Security("has_role('ROLE_SHIFT_MANAGER')")
-     */
-    public function freePeriodPositionAction(Request $request, Period $period, PeriodPosition $position)
-    {
-        $session = new Session();
-        $em = $this->getDoctrine()->getManager();
-
-        $form = $this->createPeriodPositionFreeForm($period, $position);
-        $form->handleRequest($request);
-
-        if ($form->isSubmitted() && $form->isValid()) {
-            // store position beneficiary & bookedTime (before position free())
-            $beneficiary = $position->getShifter();
-            $bookedTime = $position->getBookedTime();
-
-            // free position
-            $position->free();
-
-            $em = $this->getDoctrine()->getManager();
-            $em->persist($position);
-            $em->flush();
-
-            $dispatcher = $this->get('event_dispatcher');
-            $dispatcher->dispatch(PeriodPositionFreedEvent::NAME, new PeriodPositionFreedEvent($position, $beneficiary, $bookedTime));
-
-            $session->getFlashBag()->add('success', 'Le poste ' . $position . ' a bien été libéré !');
-        }
-
-        return $this->redirectToRoute('period_edit',array('id'=>$position->getPeriod()->getId()));
-    }
-
-    /**
-     * Deletes a period entity.
-     *
-     * @Route("/{id}", name="period_delete", methods={"DELETE"})
-     * @Security("has_role('ROLE_ADMIN')")
-     */
-    public function deletePeriodAction(Request $request, Period $period)
-    {
-        $session = new Session();
-        $em = $this->getDoctrine()->getManager();
-
-        $form = $this->createPeriodDeleteForm($period);
-        $form->handleRequest($request);
-
-        if ($form->isSubmitted() && $form->isValid()) {
-            $em->remove($period);
-            $em->flush();
-
-            $session->getFlashBag()->add('success', 'Le créneau type ' . $period . ' a bien été supprimé !');
-        }
-
-        return $this->redirectToRoute('period_admin');
-    }
-
-    /**
-     * @Route("/copyPeriod/", name="period_copy", methods={"GET","POST"})
-     * @Security("has_role('ROLE_ADMIN')")
-     */
-    public function copyPeriodAction(Request $request)
-    {
-        $form = $this->createFormBuilder()
-            ->setAction($this->generateUrl('period_copy'))
-            ->add('day_of_week_from', ChoiceType::class, array('label' => 'Jour de la semaine référence', 'choices' => Period::DAYS_OF_WEEK_LIST_WITH_INT))
-            ->add('day_of_week_to', ChoiceType::class, array('label' => 'Jour de la semaine destination', 'choices' => Period::DAYS_OF_WEEK_LIST_WITH_INT))
-            ->getForm();
-
-        $form->handleRequest($request);
-
-        if ($form->isSubmitted() && $form->isValid()) {
-            $from = $form->get('day_of_week_from')->getData();
-            $to = $form->get('day_of_week_to')->getData();
-
-            $em = $this->getDoctrine()->getManager();
-            $periods = $em->getRepository('AppBundle:Period')->findBy(array('dayOfWeek'=>$from));
-
-            $count = 0;
-            foreach ($periods as $period){
-                $p = clone $period;
-                $p->setDayOfWeek($to);
-                foreach ($period->getPositions() as $position){
-                    $p->addPosition($position);
-                }
-                $em->persist($p);
-                $count++;
-            }
-            $em->flush();
-
-            $session = new Session();
-            $session->getFlashBag()->add('success', $count . ' creneaux copiés de' . array_search($from, Period::DAYS_OF_WEEK_LIST_WITH_INT) . ' à ' . array_search($to, Period::DAYS_OF_WEEK_LIST_WITH_INT));
-
-            return $this->redirectToRoute('period_admin');
-        }
-
-        return $this->render('admin/period/copy_periods.html.twig',array(
-            "form" => $form->createView()
-        ));
-    }
-
-    /**
-     * @Route("/generateShifts/", name="shifts_generation", methods={"GET","POST"})
-     * @Security("has_role('ROLE_ADMIN')")
-     */
-    public function generateShiftsForDateAction(Request $request, KernelInterface $kernel)
-    {
-        $form = $this->createFormBuilder()
-            ->setAction($this->generateUrl('shifts_generation'))
-            ->add('date_from',TextType::class,array('label'=>'du*','attr'=>array('class'=>'datepicker')))
-            ->add('date_to',TextType::class,array('label'=>'au' ,'attr'=>array('class'=>'datepicker','require' => false)))
-            ->getForm();
-
-        $form->handleRequest($request);
-
-        if ($form->isSubmitted() && $form->isValid()) {
-
-            $date_from = $form->get('date_from')->getData();
-            $date_to = $form->get('date_to')->getData();
-
-            $application = new Application($kernel);
-            $application->setAutoExit(false);
-
-            $input = new ArrayInput(array(
-                'command' => 'app:shift:generate',
-                'date' => $date_from,
-                '--to' => $date_to
-            ));
-
-            $output = new BufferedOutput();
-            $application->run($input, $output);
-            $content = $output->fetch();
-
-            $session = new Session();
-            $session->getFlashBag()->add('success',$content);
-
-            return $this->redirectToRoute('period_admin');
-        }
-
-        return $this->render('admin/period/generate_shifts.html.twig',array(
-            "form" => $form->createView()
-        ));
-    }
-
-    /**
-     * Creates a form to delete a period entity.
-     *
-     * @param Period $period The period entity
-     *
-     * @return \Symfony\Component\Form\Form The form
-     */
-    private function createPeriodDeleteForm(Period $period)
-    {
-        return $this->createFormBuilder()
-            ->setAction($this->generateUrl('period_delete', array('id' => $period->getId())))
-            ->setMethod('DELETE')
-            ->getForm();
-    }
-
-    /**
-     * Creates a form to add a period position entity.
-     *
-     * @param Period $period The period entity
-     *
-     * @return \Symfony\Component\Form\Form The form
-     */
-    private function createPeriodPositionAddForm(Period $period)
-    {
-        return $this->createForm(
-            PeriodPositionType::class,
-            new PeriodPosition(),
-            array(
-                'action' => $this->generateUrl(
-                    'period_position_new',
-                    array('id' => $period->getId())
-                )
-            ));
-    }
-
-    /**
-     * Creates a form to book a period position entity.
-     *
-     * @param Period $period The period entity
-     * @param PeriodPosition $position The period position entity
-     *
-     * @return \Symfony\Component\Form\Form The form
-     */
-    private function createPeriodPositionBookForm(Period $period, PeriodPosition $position)
-    {
-        return $this->get('form.factory')->createNamedBuilder('positions_book_forms_' . $position->getId())
-            ->setAction($this->generateUrl('period_position_book', array('id' => $period->getId(), 'position' => $position->getId())))
-            ->setMethod('POST')
-            ->add('shifter', AutocompleteBeneficiaryType::class, array('label' => 'Numéro d\'adhérent ou nom du membre', 'required' => true))
-            ->getForm();
-    }
-
-    /**
-     * Creates a form to free a period position entity.
-     *
-     * @param Period $period The period entity
-     * @param PeriodPosition $position The period position entity
-     *
-     * @return \Symfony\Component\Form\Form The form
-     */
-    private function createPeriodPositionFreeForm(Period $period, PeriodPosition $position)
-    {
-        return $this->get('form.factory')->createNamedBuilder('positions_free_forms_' . $position->getId())
-            ->setAction($this->generateUrl('period_position_free', array('id' => $period->getId(), 'position' => $position->getId())))
-            ->setMethod('POST')
-            ->getForm();
-    }
-
-    /**
-     * Creates a form to delete a period position entity.
-     *
-     * @param Period $period The period entity
-     * @param PeriodPosition $position The period position entity
-     *
-     * @return \Symfony\Component\Form\Form The form
-     */
-    private function createPeriodPositionDeleteForm(Period $period, PeriodPosition $position)
-    {
-        return $this->get('form.factory')->createNamedBuilder('positions_delete_forms_' . $position->getId())
-            ->setAction($this->generateUrl('period_position_delete', array('id' => $period->getId(), 'position' => $position->getId())))
-            ->setMethod('DELETE')
-            ->getForm();
     }
 }

--- a/src/AppBundle/Controller/PeriodController.php
+++ b/src/AppBundle/Controller/PeriodController.php
@@ -5,16 +5,10 @@ namespace AppBundle\Controller;
 use AppBundle\Entity\Beneficiary;
 use AppBundle\Entity\Job;
 use AppBundle\Entity\Period;
-use AppBundle\Entity\PeriodPosition;
-use AppBundle\Form\AutocompleteBeneficiaryType;
-use AppBundle\Repository\JobRepository;
+use AppBundle\Service\PeriodFormHelper;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
-use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 
@@ -26,137 +20,44 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 class PeriodController extends Controller
 {
     /**
-     * Build the filter form for the admin main page (route /booking/admin)
-     * and rerun an array with  the form object and the date range and the action
-     *
-     * the return object :
-     * array(
-     *      "form" => FormBuilderInterface
-     *      "from" => DateTime,
-     *      "to" => DateTime,
-     *      "job"=> Job|null,
-     *      "filling" => str|null,
-     *      "beneficiary" => Entity/Beneficiary
-     *      )
-     *
-     * @param Request $request the request sent by the client, used to process the form
-     * @param bool $withBeneficiaryField if true will add a beneficiary and a 'problematic' filter field
-     * @return array
-     */
-    private function filterFormFactory(Request $request, bool $withBeneficiaryField): array
-    {
-        // default values
-        $res = [
-            'beneficiary' => null,
-            'job' => null,
-            'filling' => null,
-            'week' => null,
-        ];
-
-        // filter creation ----------------------
-        $formBuilder = $this->createFormBuilder()
-            ->add('job', EntityType::class, array(
-                'label' => 'Type de créneau',
-                'class' => 'AppBundle:Job',
-                'choice_label' => 'name',
-                'multiple' => false,
-                'required' => false,
-                'query_builder' => function(JobRepository $repository) {
-                    $qb = $repository->createQueryBuilder('j');
-                    return $qb
-                        ->where($qb->expr()->eq('j.enabled', '?1'))
-                        ->setParameter('1', '1')
-                        ->orderBy('j.name', 'ASC');
-                }
-            ))
-            ->add('week', ChoiceType::class, array(
-                'label' => 'Semaine',
-                'required' => false,
-                'choices' => array(
-                    'A' => 'A',
-                    'B' => 'B',
-                    'C' => 'C',
-                    'D' => 'D',
-                ),
-            ))
-            ->add('filter', SubmitType::class, array(
-                'label' => 'Filtrer',
-                'attr' => array('class' => 'btn', 'value' => 'filtrer')
-            ));
-
-        if ($withBeneficiaryField) {
-            $formBuilder
-                ->setAction($this->generateUrl('admin_period_index'))
-                ->add('beneficiary', AutocompleteBeneficiaryType::class, array(
-                    'label' => 'Bénéficiaire',
-                    'required' => false,
-                ))
-                ->add('filling', ChoiceType::class, array(
-                    'label' => 'Remplissage',
-                    'required' => false,
-                    'choices' => array(
-                        'Complet' => 'full',
-                        'Partiel' => 'partial',
-                        'Vide' => 'empty',
-                        'Problématique' => 'problematic'
-                    ),
-                ));
-        }else{
-            $formBuilder
-                ->setAction($this->generateUrl('period_index'))
-                ->add('filling', ChoiceType::class, array(
-                    'label' => 'Remplissage',
-                    'required' => false,
-                    'choices' => array(
-                        'Complet' => 'full',
-                        'Partiel' => 'partial',
-                        'Vide' => 'empty',
-                    ),
-                ));
-        }
-
-        $res["form"] = $formBuilder->getForm();
-        $res["form"]->handleRequest($request);
-
-        if ($res["form"]->isSubmitted() && $res["form"]->isValid()) {
-            if ($withBeneficiaryField) {
-                $res["beneficiary"] = $res["form"]->get("beneficiary")->getData();
-            }
-            $res["job"] = $res["form"]->get("job")->getData();
-            $res["filling"] = $res["form"]->get("filling")->getData();
-            $res["week"] = $res["form"]->get("week")->getData();
-
-        }
-
-        return $res;
-    }
-
-    /**
      * Display all the period (available and reserved) anonymized
      *
      * @Route("/", name="period_index", methods={"GET","POST"})
      * @Security("has_role('ROLE_USER')")
      */
-    public function indexAction(Request $request)
+    public function indexAction(Request $request, PeriodFormHelper $formHelper)
     {
         $em = $this->getDoctrine()->getManager();
 
-        $filter = $this->filterFormFactory($request, false);
-        $sort = 'start';
-        $order = 'ASC';
-        $periodsByDay = array();
+        $defaults = [
+            'job' => null,
+            'filling' => null,
+            'week' => null,
+        ];
+        $form = $formHelper->createFilterForm($this->createFormBuilder(), $defaults);
+        $form->handleRequest($request);
 
+        if ($form->isSubmitted() && $form->isValid()) {
+            $job_filter = $form->get("job")->getData();
+            $week_filter = $form->get("week")->getData();
+            $filling_filter = $form->get("filling")->getData();
+        } else {
+            $job_filter = null;
+            $week_filter = null;
+            $filling_filter = null;
+        }
+
+        $periodsByDay = array();
         foreach (Period::DAYS_OF_WEEK as $i => $value) {
-            $findByFilter = array('dayOfWeek' => $i);
-            $periodsByDay[$i] = $em->getRepository('AppBundle:Period')->findAll($i, $filter['job'], false);
+            $periodsByDay[$i] = $em->getRepository('AppBundle:Period')->findAll($i, $job_filter, false);
         }
 
         return $this->render('period/index.html.twig', array(
             'days_of_week' => Period::DAYS_OF_WEEK,
             'periods_by_day' => $periodsByDay,
-            'filter_form' => $filter['form']->createView(),
-            'week_filter' => $filter['week'],
-            'filling_filter' => $filter["filling"]
+            'filter_form' => $form->createView(),
+            'week_filter' => $week_filter,
+            'filling_filter' => $filling_filter,
         ));
     }
 }

--- a/src/AppBundle/Controller/ShiftExemptionController.php
+++ b/src/AppBundle/Controller/ShiftExemptionController.php
@@ -22,7 +22,7 @@ class ShiftExemptionController extends Controller
      * @Route("/", name="admin_shiftexemption_index", methods={"GET"})
      * @Security("has_role('ROLE_ADMIN')")
      */
-    public function indexAction()
+    public function indexAction(Request $request)
     {
         $em = $this->getDoctrine()->getManager();
 

--- a/src/AppBundle/Service/PeriodFormHelper.php
+++ b/src/AppBundle/Service/PeriodFormHelper.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace AppBundle\Service;
+
+use AppBundle\Form\AutocompleteBeneficiaryType;
+use AppBundle\Repository\JobRepository;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+
+class PeriodFormHelper
+{
+    public function getFilterForm($formBuilder, $withBeneficiaryField = false)
+    {
+        $formBuilder
+            ->add('job', EntityType::class, array(
+                'label' => 'Type de créneau',
+                'class' => 'AppBundle:Job',
+                'choice_label' => 'name',
+                'multiple' => false,
+                'required' => false,
+                'query_builder' => function(JobRepository $repository) {
+                    $qb = $repository->createQueryBuilder('j');
+                    return $qb
+                        ->where($qb->expr()->eq('j.enabled', '?1'))
+                        ->setParameter('1', '1')
+                        ->orderBy('j.name', 'ASC');
+                }
+            ))
+            ->add('week', ChoiceType::class, array(
+                'label' => 'Semaine',
+                'required' => false,
+                'choices' => array(
+                    'A' => 'A',
+                    'B' => 'B',
+                    'C' => 'C',
+                    'D' => 'D',
+                ),
+            ));
+
+        // admin filter form has beneficiary field + more complex filling field
+        if ($withBeneficiaryField) {
+            $formBuilder
+                ->add('beneficiary', AutocompleteBeneficiaryType::class, array(
+                    'label' => 'Bénéficiaire',
+                    'required' => false,
+                ))
+                ->add('filling', ChoiceType::class, array(
+                    'label' => 'Remplissage',
+                    'required' => false,
+                    'choices' => array(
+                        'Complet' => 'full',
+                        'Partiel' => 'partial',
+                        'Vide' => 'empty',
+                        'Problématique' => 'problematic'  // additional
+                    ),
+                ));
+        } else {
+            $formBuilder
+                ->add('filling', ChoiceType::class, array(
+                    'label' => 'Remplissage',
+                    'required' => false,
+                    'choices' => array(
+                        'Complet' => 'full',
+                        'Partiel' => 'partial',
+                        'Vide' => 'empty',
+                    ),
+                ));
+        }
+
+        $formBuilder
+            ->add('submit', SubmitType::class, array(
+                'label' => 'Filtrer',
+                'attr' => array('class' => 'btn', 'value' => 'Filtrer')
+            ));
+
+        return $formBuilder->getForm();
+    }
+
+    public function createFilterForm($formBuilder, $defaults, $withBeneficiaryField = false) {
+        $form = $this->getFilterForm($formBuilder, $withBeneficiaryField);
+        foreach ($defaults as $k => $v) {
+            $form->get($k)->setData($v);
+        }
+        return $form;
+    }
+}


### PR DESCRIPTION
Similaire à #875

### Quoi ?

Créer un nouveau controlleur `AdminPeriodController`, pour y mettre les actions admin.
J'en ai profité pour mettre le filtre commun dans un nouveau fichier `PeriodFormHelper` (similaire à `SearchUserFormHelper`)

|Controlleur|Route|
|---|---|
|PeriodController|`/period`|
|AdminPeriodController|`/admin/period`|

### Pourquoi ?

- pour séparer les vues de la semaine type admin, des vues de la semaine type anonyme (depuis #791)
- pour améliorer les urls