### PR TITLE
Evénements : permettre aux ROLE_PROCESS_MANAGER de les créer & modifier

### DIFF
--- a/app/Resources/views/admin/event/index.html.twig
+++ b/app/Resources/views/admin/event/index.html.twig
@@ -27,8 +27,8 @@
     <br />
     <a href="{{ path("admin_event_list") }}" class="btn"><i class="material-icons left">list</i>Tous les événements</a>
     <a href="{{ path("admin_proxies_list") }}" class="btn"><i class="material-icons left">list</i>Toutes les procurations</a>
-    <br />
-    <a href="{{ path('admin_event_new') }}" class="btn"><i class="material-icons left">add</i>Ajouter un événement</a>
 {% endif %}
+<br />
+<a href="{{ path('admin_event_new') }}" class="btn"><i class="material-icons left">add</i>Ajouter un événement</a>
 <a href="{{ path('event_widget_generator') }}" class="btn"><i class="material-icons left">tune</i>Générer un widget</a>
 {% endblock %}

--- a/app/Resources/views/admin/event/kind/edit.html.twig
+++ b/app/Resources/views/admin/event/kind/edit.html.twig
@@ -25,7 +25,7 @@
 </div>
 {{ form_end(form) }}
 
-{% if is_granted("ROLE_SUPER_ADMIN") %}
+{% if is_granted("ROLE_ADMIN") %}
     {{ form_start(delete_form) }}
     {{ form_widget(delete_form) }}
     <div>

--- a/app/Resources/views/admin/index.html.twig
+++ b/app/Resources/views/admin/index.html.twig
@@ -91,11 +91,9 @@
                 <a href="{{ path("admin_event_index") }}" class="waves-effect waves-light btn teal">
                     <i class="material-icons left">event</i>Événements
                 </a>
-                {% if is_granted("ROLE_ADMIN") %}
-                    <a href="{{ path("admin_event_kind_list") }}" class="waves-effect waves-light btn teal">
-                        <i class="material-icons left">event</i>Types d'événements
-                    </a>
-                {% endif %}
+                <a href="{{ path("admin_event_kind_list") }}" class="waves-effect waves-light btn teal">
+                    <i class="material-icons left">event</i>Types d'événements
+                </a>
                 <br />
                 <a href="{{ path("process_update_list") }}" class="waves-effect waves-light btn lime darken-1">
                     <i class="material-icons left">assignment</i>Gérer les nouveautés

--- a/src/AppBundle/Controller/AdminEventController.php
+++ b/src/AppBundle/Controller/AdminEventController.php
@@ -140,7 +140,7 @@ class AdminEventController extends Controller
      * Event new
      *
      * @Route("/new", name="admin_event_new", methods={"GET","POST"})
-     * @Security("has_role('ROLE_ADMIN')")
+     * @Security("has_role('ROLE_PROCESS_MANAGER')")
      */
     public function newAction(Request $request)
     {
@@ -170,7 +170,7 @@ class AdminEventController extends Controller
      * Event edit
      *
      * @Route("/{id}/edit", name="admin_event_edit", methods={"GET","POST"})
-     * @Security("has_role('ROLE_ADMIN')")
+     * @Security("has_role('ROLE_PROCESS_MANAGER')")
      */
     public function editAction(Request $request, Event $event)
     {

--- a/src/AppBundle/Controller/EventKindController.php
+++ b/src/AppBundle/Controller/EventKindController.php
@@ -22,7 +22,7 @@ class EventKindController extends Controller
      * Lists all event kinds
      *
      * @Route("/", name="admin_event_kind_list", methods={"GET"})
-     * @Security("has_role('ROLE_ADMIN')")
+     * @Security("has_role('ROLE_PROCESS_MANAGER')")
      */
     public function listAction()
     {
@@ -39,7 +39,7 @@ class EventKindController extends Controller
      * Add new event kind
      *
      * @Route("/new", name="admin_event_kind_new", methods={"GET","POST"})
-     * @Security("has_role('ROLE_ADMIN')")
+     * @Security("has_role('ROLE_PROCESS_MANAGER')")
      */
     public function newAction(Request $request)
     {
@@ -67,7 +67,7 @@ class EventKindController extends Controller
      * Edit event kind
      *
      * @Route("/{id}/edit", name="admin_event_kind_edit", methods={"GET","POST"})
-     * @Security("has_role('ROLE_ADMIN')")
+     * @Security("has_role('ROLE_PROCESS_MANAGER')")
      */
     public function editAction(Request $request, EventKind $eventKind)
     {
@@ -96,7 +96,7 @@ class EventKindController extends Controller
      * Delete event kind
      *
      * @Route("/{id}", name="admin_event_kind_delete", methods={"DELETE"})
-     * @Security("has_role('ROLE_SUPER_ADMIN')")
+     * @Security("has_role('ROLE_ADMIN')")
      */
     public function deleteAction(Request $request, EventKind $eventKind)
     {


### PR DESCRIPTION
### Quoi ?

Suite aux modifications récentes sur la brique "Evénements", on souhaite permettre à d'avantage de membres de créer des événements.

|Action|Avant|Après|
|---|---|---|
|Créer un événement|ROLE_ADMIN|ROLE_PROCESS_MANAGER|
|Modifier un événement|ROLE_ADMIN|ROLE_PROCESS_MANAGER|
|Supprimer un événement|ROLE_ADMIN|ROLE_ADMIN (pas de changement)|
||||
|Créer un type d'événement|ROLE_ADMIN|ROLE_PROCESS_MANAGER|
|Modifier un type d'événement|ROLE_ADMIN|ROLE_PROCESS_MANAGER|
|Supprimer un type d'événement|ROLE_SUPER_ADMIN|ROLE_ADMIN|