### PR TITLE
Evénements : rendre le champ description facultatif

### DIFF
--- a/app/DoctrineMigrations/Version20230609130341_event_description_nullable.php
+++ b/app/DoctrineMigrations/Version20230609130341_event_description_nullable.php
@@ -30,6 +30,6 @@ final class Version20230609130341 extends AbstractMigration
         // this down() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
-        $this->addSql('ALTER TABLE shiftfreelog CHANGE created_at created_at DATETIME NOT NULL');
+        $this->addSql('ALTER TABLE event CHANGE description LONGTEXT');
     }
 }

--- a/app/DoctrineMigrations/Version20230609130341_event_description_nullable.php
+++ b/app/DoctrineMigrations/Version20230609130341_event_description_nullable.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20230609130341 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE event CHANGE description description LONGTEXT DEFAULT NULL');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE shiftfreelog CHANGE created_at created_at DATETIME NOT NULL');
+    }
+}

--- a/app/Resources/views/event/detail.html.twig
+++ b/app/Resources/views/event/detail.html.twig
@@ -37,9 +37,13 @@
     </div>
 </div>
 
-<div class="card-panel blue lighten-5">
-    {{ event.description | markdown | raw }}
-</div>
+{% if event.description %}
+    <div class="card-panel blue lighten-5">
+        {{ event.description | markdown | raw }}
+    </div>
+{% else %}
+    <i>pas de description</i>
+{% endif %}
 
 {% if event.img %}
     <img src="{{ event|img('imgFile', 'default') }}" class="materialboxed" style="max-width:50%" />

--- a/src/AppBundle/Entity/Event.php
+++ b/src/AppBundle/Entity/Event.php
@@ -42,14 +42,7 @@ class Event
     /**
      * @var string
      *
-     * @Assert\NotBlank()
-     * @Assert\Length(
-     *      min = 1,
-     *      max = 1000,
-     *      minMessage = "La description doit avoir au minimum {{ limit }} caractères",
-     *      maxMessage = "La description ne doit pas dépasser {{ limit }} caractères"
-     * )
-     * @ORM\Column(name="description", type="text")
+     * @ORM\Column(name="description", type="text", nullable=true)
      */
     private $description;
 


### PR DESCRIPTION
### Quoi ?

Pouvoir créer des événements avec une description vide