### PR TITLE
Horaires d'ouverture : améliorer l'affichage des heures rondes

### DIFF
--- a/app/Resources/views/admin/openinghour/_partial/widget.html.twig
+++ b/app/Resources/views/admin/openinghour/_partial/widget.html.twig
@@ -4,14 +4,14 @@
             {% set dayOfWeek = -1 %}
             {% for openingHour in openingHours %}
                 {% if openingHour.dayOfWeek == dayOfWeek %}
-                    & {{ openingHour.start | date('G\\hi') }}-{{ openingHour.end | date('G\\hi') }}
+                    & {{ openingHour.start | time_short }}-{{ openingHour.end | time_short }}
                 {% else %}
                     {# close previous day #}
                     {% if loop.index > 0 %}</td></tr>{% endif %}
                     {# open new day #}
                     <tr>
                         <td class="no-padding" style="text-align:right">{{ openingHour.dayOfWeekString | capitalize }} : </td>
-                        <td class="no-padding">{{ openingHour.start | date('G\\hi') }}-{{ openingHour.end | date('G\\hi') }}
+                        <td class="no-padding">{{ openingHour.start | time_short }}-{{ openingHour.end | time_short }}
                 {% endif %}
                 {% set dayOfWeek = openingHour.dayOfWeek %}
             {% endfor %}

--- a/app/Resources/views/admin/openinghour/_partial/widget.html.twig
+++ b/app/Resources/views/admin/openinghour/_partial/widget.html.twig
@@ -1,17 +1,20 @@
+{% set openingHourJoinString = "&" %}
+
 <div class="card-panel">
-    <table style=" width: max-content; margin-top: 10px; margin-left: auto; margin-right: auto; border-collapse: separate; border-spacing: 10px 0px" class="no-padding">
+    <table style=" width: max-content; margin-left: auto; margin-right: auto; border-collapse: separate; border-spacing: 10px 0px" class="no-padding">
         <tbody>
             {% set dayOfWeek = -1 %}
             {% for openingHour in openingHours %}
-                {% if openingHour.dayOfWeek == dayOfWeek %}
-                    & {{ openingHour.start | time_short }}-{{ openingHour.end | time_short }}
-                {% else %}
+                {% if openingHour.dayOfWeek != dayOfWeek %}
                     {# close previous day #}
                     {% if loop.index > 0 %}</td></tr>{% endif %}
                     {# open new day #}
                     <tr>
-                        <td class="no-padding" style="text-align:right">{{ openingHour.dayOfWeekString | capitalize }} : </td>
+                        <td class="no-padding" style="text-align:right">{{ openingHour.dayOfWeekString | capitalize }} :</td>
                         <td class="no-padding">{{ openingHour.start | time_short }}-{{ openingHour.end | time_short }}
+                {% else %}
+                    {# continue existing day #}
+                    {{ openingHourJoinString | raw }} {{ openingHour.start | time_short }}-{{ openingHour.end | time_short }}
                 {% endif %}
                 {% set dayOfWeek = openingHour.dayOfWeek %}
             {% endfor %}

--- a/app/Resources/views/admin/openinghour/index.html.twig
+++ b/app/Resources/views/admin/openinghour/index.html.twig
@@ -38,11 +38,11 @@
     {% for openingHour in openingHours %}
         <tr>
             <td>{{ openingHour.dayOfWeekString | capitalize }}</td>
-            <td>{{ openingHour.start | date('G\\hi') }}</td>
-            <td>{{ openingHour.end | date('G\\hi') }}</td>
+            <td>{{ openingHour.start | time_short }}</td>
+            <td>{{ openingHour.end | time_short }}</td>
             <td>
                 <a href="{{ path("admin_openinghour_edit", { 'id': openingHour.id }) }}">
-                    <i class="material-icons">edit</i>Editer
+                    <i class="material-icons">edit</i>&nbsp;Editer
                 </a>
             </td>
         </tr>

--- a/app/Resources/views/default/tools/_postit.html.twig
+++ b/app/Resources/views/default/tools/_postit.html.twig
@@ -64,9 +64,7 @@
         </div>
 {% endif %}
 
-
 <div id="post-it_edit{{ note.id }}" class="modal modal-fixed-footer post-it_edit">
-
     <div class="modal-content">
         <h4>Editer ce post-it</h4>
         {{ form_start(notes_form[note.id], {'attr': {'id': 'form_note_edit_'~note.id,'class': 'edit-post-it' }}) }}
@@ -86,5 +84,4 @@
             <a href="#!" class="modal-action modal-close waves-effect waves-red btn red" onclick="document.getElementById('form_note_delete_{{ note.id }}').submit();"><i class="material-icons left">delete</i>Supprimer</a>
         {% endif %}
     </div>
-
 </div>

--- a/src/AppBundle/Twig/Extension/AppExtension.php
+++ b/src/AppBundle/Twig/Extension/AppExtension.php
@@ -47,6 +47,7 @@ class AppExtension extends AbstractExtension
             new TwigFilter('date_short', array($this, 'date_short')),
             new TwigFilter('date_time', array($this, 'date_time')),
             new TwigFilter('date_w3c', array($this, 'date_w3c')),
+            new TwigFilter('time_short', array($this, 'time_short')),
             new TwigFilter('duration_from_minutes', array($this, 'duration_from_minutes')),
             new TwigFilter('qr', array($this, 'qr')),
             new TwigFilter('barcode', array($this, 'barcode')),
@@ -210,7 +211,20 @@ class AppExtension extends AbstractExtension
      */
     public function date_w3c(\DateTime $date)
     {
-        return $date->format( \DateTimeInterface::W3C);
+        return $date->format(\DateTimeInterface::W3C);
+    }
+
+    /**
+     * Example: "9h30" ; "10h"
+     */
+    public function time_short(\DateTime $date)
+    {
+        setlocale(LC_TIME, 'fr_FR.UTF8');
+        $time_minutes = $date->format('i');
+        if ($time_minutes == "00") {
+            return strftime("%kh", $date->getTimestamp());
+        }
+        return strftime("%kh%M", $date->getTimestamp());
     }
 
     public function payment_mode_devise(int $value)


### PR DESCRIPTION
### Quoi ?

Afficher `10h` au lieu de `10h00`
- nouveau filtre twig `time_short`
- amélioré l'affichage du widget

### Capture d'écran

|Avant|Après|
|---|---|
|![Screenshot from 2023-06-11 23-28-20](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/d2786156-59cd-47be-9a62-50c7d423efef)|![Screenshot from 2023-06-11 23-28-02](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/818e63d3-0b4a-4cb3-a983-e4c351947cb0)|