### PR TITLE
Prendre en compte les fermetures exceptionnelles au moment de la génération des créneaux

### DIFF
--- a/src/AppBundle/Command/ShiftGenerateCommand.php
+++ b/src/AppBundle/Command/ShiftGenerateCommand.php
@@ -1,8 +1,9 @@
 <?php
-// src/AppBundle/Command/ShiftGenerateCommand.php
+
 namespace AppBundle\Command;
 
 use AppBundle\Entity\Shift;
+use AppBundle\Entity\ClosingException;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -19,59 +20,59 @@ class ShiftGenerateCommand extends ContainerAwareCommand
             ->setDescription('Generate shift from period')
             ->setHelp('This command allows you to generate shift using period')
             ->addArgument('date', InputArgument::REQUIRED, 'The date format yyyy-mm-dd')
-            ->addOption('to','t',InputOption::VALUE_OPTIONAL,'Every day until this date','')
-        ;
+            ->addOption('to', 't', InputOption::VALUE_OPTIONAL, 'Every day until this date (not included)', '');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $em = $this->getContainer()->get('doctrine')->getManager();
+        $mailer = $this->getContainer()->get('mailer');
+        $router = $this->getContainer()->get('router');
+
+        $admin = $em->getRepository('AppBundle:User')->findSuperAdminAccount();
         $use_fly_and_fixed = $this->getContainer()->getParameter('use_fly_and_fixed');
+        $reserve_new_shift_to_prior_shifter = $this->getContainer()->getParameter('reserve_new_shift_to_prior_shifter');
 
         $from_given = $input->getArgument('date');
         $to_given = $input->getOption('to');
-        $from = date_create_from_format('Y-m-d',$from_given);
-        if (!$from || $from->format('Y-m-d') != $from_given){
+        $from = date_create_from_format('Y-m-d', $from_given);
+        $one_day_interval = \DateInterval::createFromDateString('1 day');
+
+        if (!$from || $from->format('Y-m-d') != $from_given) {
             $output->writeln('<fg=red;> wrong date format. Use Y-m-d </>');
             return;
         }
-        if ($to_given){
-            $to = date_create_from_format('Y-m-d',$to_given);
+        if ($to_given) {
+            $to = date_create_from_format('Y-m-d', $to_given);
             $output->writeln('<fg=yellow;>'.'Shift generation from <fg=cyan;>'.$from->format('d M Y').'</><fg=yellow;> to </><fg=cyan;>'.$to->format('d M Y').'</>');
-        }else{
+        } else {
             $to = clone $from;
-            $to->add(\DateInterval::createFromDateString('+1 Day'));
+            $to->add($one_day_interval);
             $output->writeln('<fg=yellow;>'.'Shift generation for </><fg=cyan;>'.$from->format('d M Y').'</>');
         }
-        $interval = \DateInterval::createFromDateString('1 day');
-        $period = new \DatePeriod($from, $interval, $to);
 
-        $count = 0;
-        $count2 = 0;
-
+        $period = new \DatePeriod($from, $one_day_interval, $to);
+        $count_new_all = 0;
+        $count_existing_all = 0;
         $reservedShifts = array();
         $formerShifts = array();
-
-        $router = $this->getContainer()->get('router');
-
-        $em = $this->getContainer()->get('doctrine')->getManager();
-        $mailer = $this->getContainer()->get('mailer');
-        $periodRepository = $em->getRepository('AppBundle:Period');
-        $admin = $em->getRepository('AppBundle:User')->findSuperAdminAccount();
-
         $weekCycle = array("A", "B", "C", "D");
-        foreach ( $period as $date ) {
-            $output->writeln('<fg=cyan;>'.$date->format('d M Y').'</>');
-            ////////////////////////
-            $dayOfWeek = $date->format('N') - 1; //0 = 1-1 (for Monday) through 6=7-1 (for Sunday)
 
-            $qb = $periodRepository
-                ->createQueryBuilder('p');
-            $qb->where('p.dayOfWeek = :dow')
+        foreach ($period as $date) {
+            $count_new_period = 0;
+            $count_existing_period = 0;
+            $output->writeln('<fg=cyan;>'.$date->format('D d M Y').'</>');
+
+            $dayOfWeek = $date->format('N') - 1; // 0 = 1-1 (for Monday) through 6=7-1 (for Sunday)
+
+            $periods = $em->getRepository('AppBundle:Period')->createQueryBuilder('p')
+                ->where('p.dayOfWeek = :dow')
                 ->setParameter('dow', $dayOfWeek)
-                ->orderBy('p.start');
-            $periods = $qb->getQuery()->getResult();
-            foreach ($periods as $period) {
+                ->orderBy('p.start')
+                ->getQuery()
+                ->getResult();
 
+            foreach ($periods as $period) {
                 $shift = new Shift();
                 $start = date_create_from_format('Y-m-d H:i', $date->format('Y-m-d') . ' ' . $period->getStart()->format('H:i'));
                 $shift->setStart($start);
@@ -96,18 +97,15 @@ class ShiftGenerateCommand extends ContainerAwareCommand
                         $current_shift->setFormation($position->getFormation());
                         $current_shift->setPosition($position);
                         // si c'est un créneau fixe
-                        if ($use_fly_and_fixed && $position->getShifter() != null &&
-                            !$position->getShifter()->getMembership()->isCurrentlyExemptedFromShifts($current_shift->getStart())) {
+                        if ($use_fly_and_fixed && $position->getShifter() != null && !$position->getShifter()->getMembership()->isCurrentlyExemptedFromShifts($current_shift->getStart())) {
                             $current_shift->setFixe(True);
                             $current_shift->setShifter($position->getShifter());
                             $current_shift->setBookedTime(new \DateTime('now'));
                             $current_shift->setBooker($admin);
-                        } else if ($last_cycle_shift &&
-                            $last_cycle_shift->getShifter() &&
-                            $this->getContainer()->getParameter('reserve_new_shift_to_prior_shifter')) {
+                        } else if ($last_cycle_shift && $last_cycle_shift->getShifter() && $reserve_new_shift_to_prior_shifter) {
                             $current_shift->setLastShifter($last_cycle_shift->getShifter());
-                            $reservedShifts[$count] = $current_shift;
-                            $formerShifts[$count] = $last_cycle_shift;
+                            $reservedShifts[$count_new_all] = $current_shift;
+                            $formerShifts[$count_new_all] = $last_cycle_shift;
                         } else {
                             $current_shift->setShifter(null);
                             $current_shift->setBookedTime(null);
@@ -115,16 +113,21 @@ class ShiftGenerateCommand extends ContainerAwareCommand
                         }
 
                         $em->persist($current_shift);
-                        $count++;
+                        $count_new_period++;
+                        $count_new_all++;
                     } else {
-                        $count2++;
+                        $count_existing_period++;
+                        $count_existing_all++;
                     }
                 }
             }
             $em->flush();
+
+            $this->printRecapMessage($output, $count_new_period, $count_existing_period);
         }
+
         $shiftEmail = $this->getContainer()->getParameter('emails.shift');
-        foreach ($reservedShifts as $i => $shift){
+        foreach ($reservedShifts as $i => $shift) {
             $d = (date_diff(new \DateTime('now'),$shift->getStart())->format("%a"));
             $mail = (new \Swift_Message('[ESPACE MEMBRES] Reprends ton créneau du '. $formerShifts[$i]->getStart()->format("d F") .' dans '.$d.' jours'))
                 ->setFrom($shiftEmail['address'], $shiftEmail['from_name'])
@@ -145,10 +148,8 @@ class ShiftGenerateCommand extends ContainerAwareCommand
             $mailer->send($mail);
         }
 
-        $message = $count.' créneau'.(($count>1) ? 'x':'').' généré'.(($count>1) ? 's':'');
-        $output->writeln('<fg=cyan;>>>></><fg=green;> '.$message.' </>');
-        $message = $count2.' créneau'.(($count2>1) ? 'x':'').' existe'.(($count2>1) ? 'nt':'');
-        $output->writeln('<fg=cyan;>>>></><fg=red;> '.$message.' déjà </>');
+        $output->writeln('<fg=yellow;>=== Recap ===</>');
+        $this->printRecapMessage($output, $count_new_all, $count_existing_all);
     }
 
     protected function lastCycleDate(\DateTime $date)
@@ -156,5 +157,13 @@ class ShiftGenerateCommand extends ContainerAwareCommand
         $lastCycleDate = clone($date);
         $lastCycleDate->modify("-28 days");
         return $lastCycleDate;
+    }
+
+    protected function printRecapMessage($output, $count_new, $count_existing)
+    {
+        $message = $count_new.' créneau'.(($count_new>1) ? 'x':'').' généré'.(($count_new>1) ? 's':'');
+        $output->writeln('<fg=cyan;>>>></><fg=green;> '.$message.' </>');
+        $message = $count_existing.' créneau'.(($count_existing>1) ? 'x':'').' existe'.(($count_existing>1) ? 'nt':'');
+        $output->writeln('<fg=cyan;>>>></><fg=red;> '.$message.' déjà </>');
     }
 }


### PR DESCRIPTION
### Quoi ?

Grâce à la nouvelle entité `ClosingException` (#889) on peut maintenant définir des jours de fermetures.
Du coup pour ces jours là les créneaux ne doivent pas être générés.

On modifie donc ici la commande `ShiftGenerateCommand` pour prendre en compte ces jours de fermetures exceptionnelles (si il y a qui correspondent au jour à générer)

### Captures d'écran

||Image|
|---|---|
|Jour fermé|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/a631f857-410f-4461-8ce3-fb1495f0d437)|
|Jour normal|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/8f7ba700-016a-40ac-8500-92bc9fd687e7)|
|Jour normal déjà généré|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/7c05e17a-7b2c-4262-a978-ed35d862bf16)|