### PR TITLE
Pouvoir donner une raison à la fermeture exceptionnelle

### DIFF
--- a/app/DoctrineMigrations/Version20230616093419_closing_exception_reason.php
+++ b/app/DoctrineMigrations/Version20230616093419_closing_exception_reason.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20230616093419 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE closing_exception ADD reason VARCHAR(255) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE closing_exception DROP reason');
+    }
+}

--- a/app/Resources/views/admin/closingexception/_partial/form.html.twig
+++ b/app/Resources/views/admin/closingexception/_partial/form.html.twig
@@ -12,3 +12,14 @@
         </div>
     </div>
 </div>
+<div class="row">
+    <div class="col m4">
+        <div class="errors">
+            {{ form_errors(form.reason) }}
+        </div>
+        <div class="input-field">
+            {{ form_widget(form.reason) }}
+            {{ form_label(form.reason) }}
+        </div>
+    </div>
+</div>

--- a/app/Resources/views/admin/closingexception/index.html.twig
+++ b/app/Resources/views/admin/closingexception/index.html.twig
@@ -14,7 +14,8 @@
 <table class="responsive-table">
     <thead>
         <tr>
-            <th>Jour de fermeture</th>
+            <th>Date de la fermeture</th>
+            <th>Raison</th>
             <th>Auteur</th>
             <th>Date de création</th>
             <th>Actions</th>
@@ -23,7 +24,8 @@
     <tbody>
     {% for closingException in closingExceptions %}
         <tr>
-            <td>{{ closingException.date | date_short }}</td>
+            <td>{{ closingException.date | date_fr_full }}</td>
+            <td>{{ closingException.reason }}</td>
             <td>
                 {% include "admin/member/_partial/member_or_user_link.html.twig" with { user: closingException.createdBy, target_blank: true } %}
             </td>

--- a/src/AppBundle/Entity/ClosingException.php
+++ b/src/AppBundle/Entity/ClosingException.php
@@ -31,6 +31,13 @@ class ClosingException
     private $date;
 
     /**
+     * @var string
+     *
+     * @ORM\Column(type="string", length=255, nullable=true)
+     */
+    private $reason;
+
+    /**
      * @var \DateTime
      * 
      * @ORM\Column(name="created_at", type="datetime")
@@ -83,6 +90,18 @@ class ClosingException
     public function getDate()
     {
         return $this->date;
+    }
+
+    public function setReason(?string $reason): self
+    {
+        $this->reason = $reason;
+
+        return $this;
+    }
+
+    public function getReason(): ?string
+    {
+        return $this->reason;
     }
 
     /**

--- a/src/AppBundle/Form/ClosingExceptionType.php
+++ b/src/AppBundle/Form/ClosingExceptionType.php
@@ -19,7 +19,7 @@ class ClosingExceptionType extends AbstractType
     {
         $builder
             ->add('date', DateType::class, ['html5' => false, 'widget' => 'single_text', 'label' => 'Date de la fermeture exceptionnelle', 'attr' => ['class' => 'datepicker']])
-            ->add('reason', TextareaType::class, array('required' => false));
+            ->add('reason', TextareaType::class, ['label' => 'Raison', 'required' => false, 'attr' => ['class' => 'materialize-textarea']]);
     }
 
     /**

--- a/src/AppBundle/Form/ClosingExceptionType.php
+++ b/src/AppBundle/Form/ClosingExceptionType.php
@@ -6,6 +6,7 @@ use AppBundle\Entity\ClosingException;
 use AppBundle\Entity\Period;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -17,7 +18,8 @@ class ClosingExceptionType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('date', DateType::class, ['html5' => false, 'widget' => 'single_text', 'label' => 'Date de la fermeture exceptionnelle', 'attr' => ['class' => 'datepicker']]);
+            ->add('date', DateType::class, ['html5' => false, 'widget' => 'single_text', 'label' => 'Date de la fermeture exceptionnelle', 'attr' => ['class' => 'datepicker']])
+            ->add('reason', TextareaType::class, array('required' => false));
     }
 
     /**

--- a/src/AppBundle/Repository/ClosingExceptionRepository.php
+++ b/src/AppBundle/Repository/ClosingExceptionRepository.php
@@ -10,4 +10,8 @@ namespace AppBundle\Repository;
  */
 class ClosingExceptionRepository extends \Doctrine\ORM\EntityRepository
 {
+    public function findAll()
+    {
+        return $this->findBy(array(), array('date' => 'DESC'));
+    }
 }


### PR DESCRIPTION
### Quoi ?

- nouveau champ `ClosingException.reason`
- mieux afficher la date de la fermeture
- ordonner les dates par la plus récente

### Capture d'écran

![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/40140a9a-dcf9-4b9a-96cd-b94d6484a7c4)
