### PR TITLE
Admin : message d'information sur la page qui liste les rôles

### DIFF
--- a/app/Resources/views/admin/user/roles_list.html.twig
+++ b/app/Resources/views/admin/user/roles_list.html.twig
@@ -11,6 +11,14 @@
 {% block content %}
     <h4>Liste des rôles ({{ roles | length }})</h4>
 
+    <div class="card-panel blue lighten-3">
+        <i class="material-icons left">info</i>
+        Cette page liste seulement les rôles donnés <strong>directement</strong> aux utilisateurs.
+        <br />
+        Mais les rôles peuvent aussi être donnés <strong>indirectement</strong> aux utilisateurs
+        via leur association à des <strong>formations</strong> (recommandé !).
+    </div>
+
     <table class="responsive-table">
         <thead>
             <tr>

--- a/src/AppBundle/Controller/AdminController.php
+++ b/src/AppBundle/Controller/AdminController.php
@@ -195,7 +195,7 @@ class AdminController extends Controller
 
         foreach ($roles_list as $role_code) {
             $role = array();
-            $role_icon_key = strtolower($role_code) . "_icon";
+            $role_icon_key = strtolower($role_code) . "_material_icon";
             $role_name_key = strtolower($role_code) . "_name";
             $role["code"] = $role_code;
             $role["icon"] = $this->get("twig")->getGlobals()[strtolower($role_icon_key)] ?? "";


### PR DESCRIPTION
### Quoi ?

Suite à la création de la page avec la liste des rôles (#504), on apporte ici quelques modifications : 
- un message d'information qui explique la différence entre les rôles utilisateurs et les rôles via les formations
- bug fix sur l'affichage des icones

### Capture d'écran

![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/ae41f8ce-882a-404a-9b0a-52dc1aef3cc1)
