### PR TITLE
Evénements : améliorer l'affichage du titre lorsqu'il y a une image

### DIFF
--- a/app/Resources/views/admin/event/_partial/card.html.twig
+++ b/app/Resources/views/admin/event/_partial/card.html.twig
@@ -4,13 +4,10 @@
     {% if event.img %}
         <div class="card-image">
             <img src="{{ event|img('imgFile', 'card') }}" />
-            <span class="card-title">{{ event.title }}</span>
         </div>
     {% endif %}
     <div class="card-content {% if from_admin %}white-text{% endif %}">
-        {% if not event.img %}
-            <span class="card-title">{{ event.title }}</span>
-        {% endif %}
+        <span class="card-title">{{ event.title }}</span>
         <p>
             <i class="material-icons tiny">event</i>
             {{ event.date | date_fr_full_with_time }}


### PR DESCRIPTION
### Quoi ?

Tout est dans le titre

### Pourquoi ?

Le titre est parfois illisible si l'image est trop claire.

### Capture d'écran

|Avant|Après|
|---|---|
|![Screenshot from 2023-07-04 13-06-06](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/f39079e4-5be4-4740-9820-490296d49d02)|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/1c6d7e56-7e7a-4304-8b50-16b5fb988e6f)|