### PR TITLE
Admin : améliorer la liste des utilisateurs admin

### DIFF
--- a/app/Resources/views/admin/index.html.twig
+++ b/app/Resources/views/admin/index.html.twig
@@ -162,7 +162,7 @@
                 <a href="{{ path("user_install_admin") }}" class="waves-effect waves-light btn deep-purple">
                     <i class="material-icons left">add</i>Ajouter un admin
                 </a>
-                <a href="{{ path("admins_list") }}" class="waves-effect waves-light btn deep-purple">
+                <a href="{{ path("admin_users_list") }}" class="waves-effect waves-light btn deep-purple">
                     <i class="material-icons left">list</i>Liste des utilisateurs admin
                 </a>
 

--- a/app/Resources/views/admin/index.html.twig
+++ b/app/Resources/views/admin/index.html.twig
@@ -146,6 +146,9 @@
                 <a href="{{ path("roles_list") }}" class="waves-effect waves-light btn deep-purple">
                     <i class="material-icons left">list</i>Liste des roles
                 </a>
+                <a href="{{ path("admin_users_list") }}" class="waves-effect waves-light btn deep-purple">
+                    <i class="material-icons left">list</i>Liste des utilisateurs admin
+                </a>
             {% endif %}
 
             {% if is_granted("ROLE_SUPER_ADMIN") %}
@@ -161,9 +164,6 @@
                 <h6>Admins</h6>
                 <a href="{{ path("user_install_admin") }}" class="waves-effect waves-light btn deep-purple">
                     <i class="material-icons left">add</i>Ajouter un admin
-                </a>
-                <a href="{{ path("admin_users_list") }}" class="waves-effect waves-light btn deep-purple">
-                    <i class="material-icons left">list</i>Liste des utilisateurs admin
                 </a>
 
                 <h6>Divers</h6>

--- a/app/Resources/views/admin/user/admin_list.html.twig
+++ b/app/Resources/views/admin/user/admin_list.html.twig
@@ -14,6 +14,7 @@
     <table class="striped">
         <thead>
         <tr>
+            <th>Etat</th>
             <th data-col="m.member_number">#</th>
             <th data-col="m.username">Username</th>
             <th data-col="m.email">Email</th>
@@ -23,6 +24,11 @@
         <tbody>
         {% for admin in admins %}
             <tr>
+                <td>
+                    {% if admin.beneficiary and admin.beneficiary.membership.withdrawn %}
+                        <i class="material-icons" title="Compte fermé">{{ member_withdrawn_material_icon }}</i>
+                    {% endif %}
+                </td>
                 <td>
                     {% if admin.beneficiary %}
                         <a href="{{ path('member_show', { 'member_number': admin.beneficiary.membership.memberNumber }) }}">
@@ -39,11 +45,10 @@
                         <a href="{{ path('user_remove_role', { 'id': admin.id, 'role': 'ROLE_ADMIN' }) }}" class="orange btn-floating small" title="Enlever le rôle">
                             <i class="material-icons left">arrow_downward</i>
                         </a>
-
                     {% else %}
-                        <button type="submit" class="btn-floating waves-effect waves-light red" title="⚠️ Supprimer l'utilisateur ⚠️">
-                            <i class="material-icons left">close</i>
-                        </button>
+                        <a href="#" class="btn-floating waves-effect waves-light red" onclick="var r = confirm('Etes-vous sûr de vouloir supprimer cet utilisateur ?!'); if (r == true) {$(this).closest('form').submit();}; event.stopPropagation();" title="⚠️ Supprimer l'utilisateur ⚠️">
+                            <i class="material-icons left">delete</i>
+                        </a>
                     {% endif %}
                     {{ form_end(delete_forms[admin.id]) }}
                 </td>

--- a/app/Resources/views/admin/user/admin_list.html.twig
+++ b/app/Resources/views/admin/user/admin_list.html.twig
@@ -15,9 +15,10 @@
         <thead>
         <tr>
             <th>Etat</th>
-            <th data-col="m.member_number">#</th>
-            <th data-col="m.username">Username</th>
-            <th data-col="m.email">Email</th>
+            <th>#</th>
+            <th>Username</th>
+            <th>Email</th>
+            <th>Dernière connexion</th>
             <th>Actions</th>
         </tr>
         </thead>
@@ -38,6 +39,11 @@
                 </td>
                 <td>{{ admin.username }}</td>
                 <td>{{ admin.email }}</td>
+                {% if admin.lastLogin %}
+                    <td title="{{ admin.lastLogin | date_fr_full_with_time }}">{{ admin.lastLogin | date_short }}</td>
+                {% else %}
+                    <td></td>
+                {% endif %}
                 <td>
                     {{ form_start(delete_forms[admin.id]) }}
                     {{ form_widget(delete_forms[admin.id]) }}

--- a/app/Resources/views/admin/user/admin_list.html.twig
+++ b/app/Resources/views/admin/user/admin_list.html.twig
@@ -13,53 +13,51 @@
 
     <table class="striped">
         <thead>
-        <tr>
-            <th>Etat</th>
-            <th>#</th>
-            <th>Username</th>
-            <th>Email</th>
-            <th>Dernière connexion</th>
-            <th>Actions</th>
-        </tr>
+            <tr>
+                <th>Etat</th>
+                <th>Utilisateur</th>
+                <th>Email</th>
+                <th>Dernière connexion</th>
+                {% if is_granted("ROLE_SUPER_ADMIN") %}
+                    <th>Actions</th>
+                {% endif %}
+            </tr>
         </thead>
         <tbody>
-        {% for admin in admins %}
-            <tr>
-                <td>
-                    {% if admin.beneficiary and admin.beneficiary.membership.withdrawn %}
-                        <i class="material-icons" title="Compte fermé">{{ member_withdrawn_material_icon }}</i>
-                    {% endif %}
-                </td>
-                <td>
-                    {% if admin.beneficiary %}
-                        <a href="{{ path('member_show', { 'member_number': admin.beneficiary.membership.memberNumber }) }}">
-                            {{ admin.beneficiary.membership.memberNumber }}
-                        </a>
-                    {% endif %}
-                </td>
-                <td>{{ admin.username }}</td>
-                <td>{{ admin.email }}</td>
-                {% if admin.lastLogin %}
-                    <td title="{{ admin.lastLogin | date_fr_full_with_time }}">{{ admin.lastLogin | date_short }}</td>
-                {% else %}
-                    <td></td>
-                {% endif %}
-                <td>
-                    {{ form_start(delete_forms[admin.id]) }}
-                    {{ form_widget(delete_forms[admin.id]) }}
-                    {% if admin.beneficiary %}
-                        <a href="{{ path('user_remove_role', { 'id': admin.id, 'role': 'ROLE_ADMIN' }) }}" class="orange btn-floating small" title="Enlever le rôle">
-                            <i class="material-icons left">arrow_downward</i>
-                        </a>
+            {% for admin in admins %}
+                <tr>
+                    <td>
+                        {% if admin.beneficiary and admin.beneficiary.membership.withdrawn %}
+                            <i class="material-icons" title="Compte fermé">{{ member_withdrawn_material_icon }}</i>
+                        {% endif %}
+                    </td>
+                    <td>
+                        {% include "admin/member/_partial/member_or_user_link.html.twig" with { user: admin, target_blank: true } %}
+                    </td>
+                    <td>{{ admin.email }}</td>
+                    {% if admin.lastLogin %}
+                        <td title="{{ admin.lastLogin | date_fr_full_with_time }}">{{ admin.lastLogin | date_short }}</td>
                     {% else %}
-                        <a href="#" class="btn-floating waves-effect waves-light red" onclick="var r = confirm('Etes-vous sûr de vouloir supprimer cet utilisateur ?!'); if (r == true) {$(this).closest('form').submit();}; event.stopPropagation();" title="⚠️ Supprimer l'utilisateur ⚠️">
-                            <i class="material-icons left">delete</i>
-                        </a>
+                        <td></td>
                     {% endif %}
-                    {{ form_end(delete_forms[admin.id]) }}
-                </td>
-            </tr>
-        {% endfor %}
+                    {% if is_granted("ROLE_SUPER_ADMIN") %}
+                        <td>
+                            {{ form_start(delete_forms[admin.id]) }}
+                            {{ form_widget(delete_forms[admin.id]) }}
+                            {% if admin.beneficiary %}
+                                <a href="{{ path('user_remove_role', { 'id': admin.id, 'role': 'ROLE_ADMIN' }) }}" class="orange btn-floating small" title="Enlever le rôle">
+                                    <i class="material-icons left">arrow_downward</i>
+                                </a>
+                            {% else %}
+                                <a href="#" class="btn-floating waves-effect waves-light red" onclick="var r = confirm('Etes-vous sûr de vouloir supprimer cet utilisateur ?!'); if (r == true) {$(this).closest('form').submit();}; event.stopPropagation();" title="⚠️ Supprimer l'utilisateur ⚠️">
+                                    <i class="material-icons left">delete</i>
+                                </a>
+                            {% endif %}
+                            {{ form_end(delete_forms[admin.id]) }}
+                        </td>
+                    {% endif %}
+                </tr>
+            {% endfor %}
         </tbody>
     </table>
 {% endblock %}

--- a/src/AppBundle/Controller/AdminController.php
+++ b/src/AppBundle/Controller/AdminController.php
@@ -152,13 +152,12 @@ class AdminController extends Controller
     /**
      * Lists all users with ROLE_ADMIN.
      *
-     * @param Request $request , SearchUserFormHelper $formHelper
-     * @param SearchUserFormHelper $formHelper
+     * @param Request $request
      * @return Response
-     * @Route("/admin_users", name="admins_list", methods={"GET","POST"})
+     * @Route("/admin_users", name="admin_users_list", methods={"GET","POST"})
      * @Security("has_role('ROLE_ADMIN')")
      */
-    public function adminUsersAction(Request $request, SearchUserFormHelper $formHelper)
+    public function adminUsersAction(Request $request)
     {
         $em = $this->getDoctrine()->getManager();
 

--- a/src/AppBundle/Controller/AdminController.php
+++ b/src/AppBundle/Controller/AdminController.php
@@ -154,7 +154,7 @@ class AdminController extends Controller
      *
      * @param Request $request
      * @return Response
-     * @Route("/admin_users", name="admin_users_list", methods={"GET","POST"})
+     * @Route("/admin_users", name="admin_users_list", methods={"GET"})
      * @Security("has_role('ROLE_ADMIN')")
      */
     public function adminUsersAction(Request $request)

--- a/src/AppBundle/Controller/UserController.php
+++ b/src/AppBundle/Controller/UserController.php
@@ -305,7 +305,7 @@ class UserController extends Controller
     /**
      * Deletes a user entity
      *
-     * @Route("/delete/{id}", name="user_delete", methods={"DELETE"})
+     * @Route("/{id}/delete", name="user_delete", methods={"DELETE"})
      * @Security("has_role('ROLE_SUPER_ADMIN')")
      * @param Request $request
      * @param User $user
@@ -313,12 +313,13 @@ class UserController extends Controller
      */
     public function deleteAction(Request $request, User $user)
     {
+        $session = new Session();
+        $em = $this->getDoctrine()->getManager();
+
         $form = $this->createDeleteForm($user);
         $form->handleRequest($request);
 
-        $session = new Session();
         if ($form->isSubmitted() && $form->isValid()) {
-            $em = $this->getDoctrine()->getManager();
             $em->remove($user);
             $em->flush();
 

--- a/src/AppBundle/Entity/User.php
+++ b/src/AppBundle/Entity/User.php
@@ -356,4 +356,12 @@ class User extends BaseUser
     {
         return $this->processUpdates;
     }
+
+    /**
+     * @return DateTime
+     */
+    public function getLastLogin()
+    {
+        return $this->lastLogin;
+    }
 }


### PR DESCRIPTION
### Quoi ?

Améliorations sur la page "Liste des utilisateurs admin" : 
- rendu visible la page aux ADMIN (mais les actions sont réservés aux SUPER_ADMIN)
- ajout d'une colonne "Etat" (pour savoir si le compte-membre de l'utilisateur est cloturé)
- regroupé les colonnes "#" et "Username" en "Utilisateur" (en utilisant `member_or_user_link`)
- améliorations sur l'action de suppression (pour les utilisateurs sans compte-membre) : changement d'icone, ajout d'un popup de confirmation
- renommé l'url de suppression d'un utilisateur

### Capture d'écran

![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/9ed2aa1e-9380-4d05-a3b8-e4b5c68af59a)
