### PR TITLE
Admin : nouvelle page avec la liste des utilisateurs non-membres

### DIFF
--- a/app/Resources/views/admin/index.html.twig
+++ b/app/Resources/views/admin/index.html.twig
@@ -149,6 +149,9 @@
                 <a href="{{ path("admin_users_list") }}" class="waves-effect waves-light btn deep-purple">
                     <i class="material-icons left">list</i>Liste des utilisateurs admin
                 </a>
+                <a href="{{ path("non_member_users_list") }}" class="waves-effect waves-light btn deep-purple">
+                    <i class="material-icons left">list</i>Liste des utilisateurs non-membres
+                </a>
             {% endif %}
 
             {% if is_granted("ROLE_SUPER_ADMIN") %}

--- a/app/Resources/views/admin/user/admin_list.html.twig
+++ b/app/Resources/views/admin/user/admin_list.html.twig
@@ -61,9 +61,3 @@
         </tbody>
     </table>
 {% endblock %}
-
-{% block stylesheets %}
-{% endblock %}
-
-{% block javascripts %}
-{% endblock %}

--- a/app/Resources/views/admin/user/admin_list.html.twig
+++ b/app/Resources/views/admin/user/admin_list.html.twig
@@ -29,6 +29,8 @@
                     <td>
                         {% if admin.beneficiary and admin.beneficiary.membership.withdrawn %}
                             <i class="material-icons" title="Compte fermé">{{ member_withdrawn_material_icon }}</i>
+                        {% elseif not admin.enabled %}
+                            <i class="material-icons" title="Utilisateur désactivé">{{ member_withdrawn_material_icon }}</i>
                         {% endif %}
                     </td>
                     <td>

--- a/app/Resources/views/admin/user/non_member_list.html.twig
+++ b/app/Resources/views/admin/user/non_member_list.html.twig
@@ -13,24 +13,30 @@
 
     <table class="striped">
         <thead>
-        <tr>
-            <th>Etat</th>
-            <th>Username</th>
-            <th>Email</th>
-        </tr>
+            <tr>
+                <th>Etat</th>
+                <th>Utilisateur</th>
+                <th>Email</th>
+                <th>Dernière connexion</th>
+            </tr>
         </thead>
         <tbody>
-        {% for non_member in non_members %}
-            <tr>
-                <td>
-                    {% if not non_member.enabled %}
-                        <i class="material-icons" title="Compte fermé">{{ member_withdrawn_material_icon }}</i>
+            {% for non_member in non_members %}
+                <tr>
+                    <td>
+                        {% if not non_member.enabled %}
+                            <i class="material-icons" title="Utilisateur désactivé">{{ member_withdrawn_material_icon }}</i>
+                        {% endif %}
+                    </td>
+                    <td>{{ non_member.username }}</td>
+                    <td>{{ non_member.email }}</td>
+                    {% if non_member.lastLogin %}
+                        <td title="{{ non_member.lastLogin | date_fr_full_with_time }}">{{ non_member.lastLogin | date_short }}</td>
+                    {% else %}
+                        <td></td>
                     {% endif %}
-                </td>
-                <td>{{ non_member.username }}</td>
-                <td>{{ non_member.email }}</td>
-            </tr>
-        {% endfor %}
+                </tr>
+            {% endfor %}
         </tbody>
     </table>
 {% endblock %}

--- a/app/Resources/views/admin/user/non_member_list.html.twig
+++ b/app/Resources/views/admin/user/non_member_list.html.twig
@@ -1,0 +1,36 @@
+{% extends 'layout.html.twig' %}
+
+{% block title %}Liste des utilisateurs non-membres - {{ site_name }}{% endblock %}
+
+{% block breadcrumbs %}
+<a href="{{ path('homepage') }}"><i class="material-icons">home</i></a><i class="material-icons">chevron_right</i>
+<a href="{{ path('admin') }}"><i class="material-icons">build</i>&nbsp;Administration</a><i class="material-icons">chevron_right</i>
+<i class="material-icons">list</i>&nbsp;Liste des utilisateurs non-membres
+{% endblock %}
+
+{% block content %}
+    <h4>Liste des utilisateurs non-membres ({{ non_members | length }})</h4>
+
+    <table class="striped">
+        <thead>
+        <tr>
+            <th>Etat</th>
+            <th>Username</th>
+            <th>Email</th>
+        </tr>
+        </thead>
+        <tbody>
+        {% for non_member in non_members %}
+            <tr>
+                <td>
+                    {% if not non_member.enabled %}
+                        <i class="material-icons" title="Compte fermé">{{ member_withdrawn_material_icon }}</i>
+                    {% endif %}
+                </td>
+                <td>{{ non_member.username }}</td>
+                <td>{{ non_member.email }}</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+{% endblock %}

--- a/src/AppBundle/Command/SendMassMailCommand.php
+++ b/src/AppBundle/Command/SendMassMailCommand.php
@@ -100,7 +100,7 @@ class SendMassMailCommand extends ContainerAwareCommand
                 $to[] = $beneficiary->getEmail();
         }
         if (!$exclude_non_member){
-            $non_members = $em->getRepository("AppBundle:User")->findActiveNonMembers();
+            $non_members = $em->getRepository("AppBundle:User")->findNonMembers(true);
             foreach ($non_members as $user){
                 $to[] = $user->getEmail();
             }

--- a/src/AppBundle/Controller/AdminController.php
+++ b/src/AppBundle/Controller/AdminController.php
@@ -150,6 +150,25 @@ class AdminController extends Controller
     }
 
     /**
+     * Lists all non-member users.
+     *
+     * @param Request $request
+     * @return Response
+     * @Route("/non_member_users", name="non_member_users_list", methods={"GET"})
+     * @Security("has_role('ROLE_ADMIN')")
+     */
+    public function nonMemberUsersAction(Request $request)
+    {
+        $em = $this->getDoctrine()->getManager();
+
+        $non_members = $em->getRepository("AppBundle:User")->findNonMembers();
+
+        return $this->render('admin/user/non_member_list.html.twig', array(
+            'non_members' => $non_members,
+        ));
+    }
+
+    /**
      * Lists all users with ROLE_ADMIN.
      *
      * @param Request $request

--- a/src/AppBundle/Controller/MailController.php
+++ b/src/AppBundle/Controller/MailController.php
@@ -210,7 +210,7 @@ class MailController extends Controller
 
     private function getNonMemberEmails() {
         $em = $this->getDoctrine()->getManager();
-        $non_members = $em->getRepository("AppBundle:User")->findActiveNonMembers();
+        $non_members = $em->getRepository("AppBundle:User")->findNonMembers(true);
         $list = [];
         foreach ($non_members as $non_member){
             $list[$non_member->getEmail()] = '';

--- a/src/AppBundle/Entity/User.php
+++ b/src/AppBundle/Entity/User.php
@@ -62,6 +62,9 @@ class User extends BaseUser
      */
     private $processUpdates;
 
+    // other fields
+    // username, email, enabled, last_login, roles
+
     public function __toString()
     {
         if (!$this->getBeneficiary())

--- a/src/AppBundle/Repository/UserRepository.php
+++ b/src/AppBundle/Repository/UserRepository.php
@@ -27,14 +27,17 @@ class UserRepository extends \Doctrine\ORM\EntityRepository
         return $qb->getQuery()->getResult();
     }
 
-    public function findActiveNonMembers()
+    public function findNonMembers($active = false)
     {
         $qb = $this->_em->createQueryBuilder();
         $qb->select('u')
             ->from($this->_entityName, 'u')
             ->leftJoin('u.beneficiary', 'b')
-            ->where('b.id is NULL')
-            ->andWhere("u.enabled = 1");
+            ->where('b.id is NULL');
+
+        if ($active) {
+            $qb->andWhere("u.enabled = 1");
+        }
 
         return $qb->getQuery()->getResult();
     }


### PR DESCRIPTION
### Quoi ?

Nouvelle page qui liste les utilisateurs non-membres = utilisateurs qui n'ont pas de bénéficiaires rattachés. Par exemple des salariés.

### Capture d'écran

![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/2279c6b5-ad3f-444e-9925-8a3b10a90713)

![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/0e0817a5-c1c4-4711-b96f-63d0ab3e8fa5)
