### PR TITLE
MaterializeCSS : améliorer l'affichage de l'autocomplete 

### DIFF
--- a/app/Resources/views/admin/mail/send.html.twig
+++ b/app/Resources/views/admin/mail/send.html.twig
@@ -53,8 +53,11 @@
                     data: [],
                     autocompleteOptions: {
                         data: {{ non_members | json_encode(constant('JSON_UNESCAPED_UNICODE')) | raw }},
-                        limit: Infinity,
-                        minLength: 1
+                        minLength: 1,  // default
+                        limit: 5,
+                        dropdownOptions: {
+                            constrainWidth: false
+                        }
                     },
                     onChipAdd: updateNonMembers,
                     onChipDelete: updateNonMembers

--- a/app/Resources/views/form/fields.html.twig
+++ b/app/Resources/views/form/fields.html.twig
@@ -81,7 +81,11 @@
                     {% else %}
                     data: [],
                     {% endif %}
-                    limit: 6,
+                    minLength: 1,  // default
+                    limit: 5,
+                    dropdownOptions: {
+                        constrainWidth: false
+                    }
                 },
                 onChipAdd: updateInput{{ id }}Forms,
                 onChipDelete: updateInput{{ id }}Forms,


### PR DESCRIPTION
### Quoi ?

Sur certaines pages (comme celles d'envoi d'e-mail), il y a un autocomplete sur les membres.
Mais il prend la largeur par défaut des `chips`, donc 120 px.

Ajout d'un paramètre pour élargir le dropdown.

https://materializeweb.com/autocomplete.html

### Capture d'écran

|Avant|Après|
|---|---|
|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/6fc672a3-2fc4-4b0e-86b8-949b80506509)|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/9ad48c31-8475-479e-bb8a-0be85da60597)|