### PR TITLE
Profil : améliorer la modale d'association de son badge

### DIFF
--- a/app/Resources/views/member/_partial/swipe_card.html.twig
+++ b/app/Resources/views/member/_partial/swipe_card.html.twig
@@ -48,7 +48,7 @@
     </a>
     <div id="swipe_add" class="modal">
         <div class="modal-content">
-            <h5>Entrez votre numéro de badge</h5>
+            <h4>Entrez votre numéro de badge</h4>
             <div class="swiftcard_exemple">
                 {{ ("421234567890" | barcode | raw) }}
                 <canvas id="badge_canvas" class="focus" width="300" height="60"></canvas>

--- a/app/Resources/views/member/_partial/swipe_card.html.twig
+++ b/app/Resources/views/member/_partial/swipe_card.html.twig
@@ -48,7 +48,7 @@
     </a>
     <div id="swipe_add" class="modal">
         <div class="modal-content">
-            <h3>Entrez votre numéro de badge</h3>
+            <h5>Entrez votre numéro de badge</h5>
             <div class="swiftcard_exemple">
                 {{ ("421234567890" | barcode | raw) }}
                 <canvas id="badge_canvas" class="focus" width="300" height="60"></canvas>
@@ -75,16 +75,16 @@
                 context.strokeStyle = 'red';
                 context.stroke();
             </script>
+            <br />
             <form action="{{ path('active_swipe')}}" method="post">
                 <div class="row">
-                    <div class="input-field col s6">
-                        <input pattern=".{13,13}" type="text" name="code" autocomplete="off" />
+                    <div class="input-field col s12 m6">
                         <label for="code">Code du badge à 13 chiffres</label>
+                        <input pattern=".{13,13}" type="text" name="code" autocomplete="off" />
                     </div>
-                    <div class="col s6">
-                        <br>
-                        <button type="submit" class="waves-effect waves-light btn-flat green white-text"><i class="material-icons left">check</i>Associer mon badge</button>
-                    </div>
+                </div>
+                <div>
+                    <button type="submit" class="btn green"><i class="material-icons left">check</i>Associer mon badge</button>
                 </div>
             </form>
         </div>

--- a/app/Resources/views/member/show.html.twig
+++ b/app/Resources/views/member/show.html.twig
@@ -189,13 +189,12 @@
                                                 <div class="row">
                                                     <div class="col s12 m6 input-field">
                                                         <input type="hidden" name="beneficiary" value="{{ beneficiary.id }}" />
-                                                        <input pattern=".{13,13}" type="text" name="code" autocomplete="off" />
                                                         <label for="code">Code du badge à 13 chiffres</label>
+                                                        <input pattern=".{13,13}" type="text" name="code" autocomplete="off" />
                                                     </div>
-                                                    <div class="col s12 m6">
-                                                        <br />
-                                                        <button type="submit" class="waves-effect waves-light btn-flat green white-text"><i class="material-icons left">check</i>Associer le badge</button>
-                                                    </div>
+                                                </div>
+                                                <div>
+                                                    <button type="submit" class="btn green"><i class="material-icons left">check</i>Associer le badge</button>
                                                 </div>
                                             </form>
                                         </div>


### PR DESCRIPTION
### Quoi ?

Dans son profil, la modale pour associer son badge ne rend pas très bien sur petits écrans (même inutilisable sur très petits écrans comme des smartphones)

Modifications apportées :
- amélioré le rendu du formulaire d'ajout coté profil
- amélioré le rendu du formulaire d'ajout coté admin > membre

### Captures d'écran

||Avant|Après|
|---|---|---|
|profil : grand écran|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/4319af5e-ba7d-43c2-8d35-945996aa4304)|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/a074981b-15e3-425e-baae-d66c67d80793)|
|profil : petit écran|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/d23ac531-786b-4fc4-87b8-b69005819619)|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/6ed97a7a-2657-4f50-a4e6-d4a4964b7393)|