### PR TITLE
Déplacer la notion de volant du beneficiary vers le membership

### DIFF
--- a/app/DoctrineMigrations/Version20230729100654.php
+++ b/app/DoctrineMigrations/Version20230729100654.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20230729100654 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE membership ADD flying TINYINT(1) DEFAULT \'0\' NOT NULL');
+        $this->addSql('UPDATE membership LEFT OUTER JOIN beneficiary ON beneficiary.id = membership.main_beneficiary_id SET membership.flying=beneficiary.flying WHERE beneficiary.flying = 1');
+        $this->addSql('ALTER TABLE beneficiary DROP flying');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE beneficiary ADD flying TINYINT(1) DEFAULT \'0\' NOT NULL');
+        $this->addSql('ALTER TABLE membership DROP flying');
+    }
+}

--- a/app/Resources/views/beneficiary/_partial/info.html.twig
+++ b/app/Resources/views/beneficiary/_partial/info.html.twig
@@ -54,16 +54,6 @@
             {% endif %})
         {% endif %}
     </div>
-    {% if use_fly_and_fixed %}
-        <div class="col s12 truncate">
-            <i class="material-icons tiny">accessibility</i>
-            {% if beneficiary.flying %}
-                <div class="chip green-text">Equipe volante</div>
-            {% else %}
-                <div class="chip green-text">Equipe fixe</div>
-            {% endif %}
-        </div>
-    {% endif %}
     {% if beneficiary.formations | length %}
         <div class="col s12 truncate">
             <i class="material-icons tiny">assignment_ind</i>

--- a/app/Resources/views/member/show.html.twig
+++ b/app/Resources/views/member/show.html.twig
@@ -14,24 +14,49 @@
 {% endblock %}
 
 {% block content %}
-    <h4>
-        {% if member.withdrawn %}<del>{% endif %}
-        Membre #{{ member.memberNumber }}{% if member.withdrawn %}</del>{% endif %}
-        {% if member.mainBeneficiary and not member.mainBeneficiary.user.isEnabled %}
-            <i class="material-icons" title="Compte pas encore activé">{{ user_account_not_enabled_material_icon }}</i>
-        {% endif %}
-        {% if member.isCurrentlyExemptedFromShifts() %}
-            <i class="material-icons" title="Compte exempté">{{member_exempted_material_icon }}</i>
-        {% endif %}
-        {% if member.frozen %}
-            <i class="material-icons" title="Compte gelé">{{ member_frozen_material_icon }}</i>
-        {% endif %}
-        {% if member.withdrawn %}
-            <i class="material-icons" title="Compte fermé">{{ member_withdrawn_material_icon }}</i>
-        {% elseif not member | uptodate %}
-            <i class="material-icons" title="Compte en attente d'adhésion">{{ member_registration_missing_material_icon }}</i>
-        {% endif %}
-    </h4>
+    <div class="row valign-wrapper" style="flex-wrap: wrap;">
+        <div class="col s12 m5">
+            <h4>
+                {% if member.withdrawn %}<del>{% endif %}
+                Membre #{{ member.memberNumber }}{% if member.withdrawn %}</del>{% endif %}
+                {% if member.mainBeneficiary and not member.mainBeneficiary.user.isEnabled %}
+                    <i class="material-icons" title="Compte pas encore activé">{{ user_account_not_enabled_material_icon }}</i>
+                {% endif %}
+                {% if member.isCurrentlyExemptedFromShifts() %}
+                    <i class="material-icons" title="Compte exempté">{{member_exempted_material_icon }}</i>
+                {% endif %}
+                {% if member.frozen %}
+                    <i class="material-icons" title="Compte gelé">{{ member_frozen_material_icon }}</i>
+                {% endif %}
+                {% if member.withdrawn %}
+                    <i class="material-icons" title="Compte fermé">{{ member_withdrawn_material_icon }}</i>
+                {% elseif not member | uptodate %}
+                    <i class="material-icons" title="Compte en attente d'adhésion">{{ member_registration_missing_material_icon }}</i>
+                {% endif %}
+            </h4>
+        </div>
+        <div class="col s12 m7 right-align">
+            <!-- Fermer le compte -->
+            {% if is_granted("ROLE_USER_MANAGER") and ((member.withdrawn and is_granted("open",member)) or (not member.withdrawn and is_granted("close",member))) %}
+                <a href="#withdrawn-member-confirmation-modal" class="modal-trigger waves-effect waves-light btn btn-small {% if not member.withdrawn %}red{% else %}teal{% endif %}">
+                    {% if not member.withdrawn %}
+                        <i class="material-icons left">close</i>Fermer <span class="hide-on-med-and-down">le compte</span>
+                    {% else %}
+                        <i class="material-icons left">check</i>Ré-ouvrir <span class="hide-on-med-and-down">le compte</span>
+                    {% endif %}
+                </a>
+            {% endif %}
+        </div>
+        <div class="col s12">
+            {% if member.withdrawn and member.withdrawnDate  %}
+                Compte fermé le <i>{{ member.withdrawnDate | date_fr }}</i>
+                {% if member.withdrawnBy %}
+                    par {% include "admin/member/_partial/member_or_user_link.html.twig" with { user: member.withdrawnBy, target_blank: true } %}.
+                {% endif %}
+            {% endif %}
+        </div>
+    </div>
+
 
     <!-- Détails sur le(s) bénéficiaire(s) -->
     {% if member.beneficiaries | length %}
@@ -314,72 +339,6 @@
             </li>
         {% endif %}
 
-        <!-- Fermer le compte -->
-        {% if is_granted("ROLE_USER_MANAGER") and is_granted("close",member) %}
-            <li id="close">
-                <div class="collapsible-header {% if frontend_cookie and frontend_cookie.user_show is defined and frontend_cookie.user_show.close_open is defined and frontend_cookie.user_show.close_open %}active{% endif %}">
-                    <i class="material-icons">close</i>{% if member.withdrawn %}Ré-ouvrir le compte{% else %}Fermer le compte{% endif %}
-                </div>
-                <div class="collapsible-body white">
-                    {% if not member.withdrawn %}
-                        <a href="#close-member-confirmation-modal" class="modal-trigger waves-effect waves-light btn red">
-                            <i class="material-icons left">close</i>Fermer le compte
-                        </a>
-                        {{ form_start(close_form) }}
-                        <div id="close-member-confirmation-modal" class="modal">
-                            <div class="modal-content">
-                                <h5>
-                                    <i class="material-icons left small">remove_circle_outline</i>Fermeture du compte membre
-                                </h5>
-                                <p>Attention, vous êtes sur le point de fermer le compte du membre.</p>
-                                <ul>
-                                    {% if use_fly_and_fixed %}
-                                        <li>Ce membre a {{ period_positions | length }} créneau{% if period_positions | length > 1 %}x{% endif %} fixe.</li>
-                                    {% endif %}
-                                    <li>Ce membre a {{ in_progress_and_upcoming_shifts | length }} créneau{% if in_progress_and_upcoming_shifts | length > 1 %}x{% endif %} réservé à venir.</li>
-                                </ul>
-                            </div>
-                            <div class="modal-footer">
-                                <a href="#!" class="modal-action modal-close waves-effect waves-green btn-flat green-text">Retour à la raison</a>
-                                <button type="submit" class="btn waves-effect waves-light orange">
-                                    <i class="material-icons left">check</i>Je sais ce que je fais !
-                                </button>
-                            </div>
-                        </div>
-                        {{ form_end(close_form) }}
-                    {% else %}
-                        {% if member.withdrawnDate %}
-                            <p>
-                                Compte fermé le <i>{{ member.withdrawnDate | date_fr }}</i>
-                                {% if member.withdrawnBy %}
-                                    par {% include "admin/member/_partial/member_or_user_link.html.twig" with { user: member.withdrawnBy, target_blank: true } %}.
-                                {% endif %}
-                            </p>
-                        {% endif %}
-                        <a href="#open-member-confirmation-modal" class="modal-trigger waves-effect waves-light btn teal">
-                            <i class="material-icons left">check</i>Ré-ouvrir le compte
-                        </a>
-                        {{ form_start(open_form) }}
-                        <div id="open-member-confirmation-modal" class="modal">
-                            <div class="modal-content">
-                                <h5>
-                                    <i class="material-icons left small">info_outline</i>Ré-ouverture du compte membre
-                                </h5>
-                                <p>Attention, vous êtes sur le point de ré-ouvrir le compte du membre.</p>
-                            </div>
-                            <div class="modal-footer">
-                                <a href="#!" class="modal-action modal-close waves-effect waves-green btn-flat green-text">Retour à la raison</a>
-                                <button type="submit" class="btn waves-effect waves-light orange">
-                                    <i class="material-icons left">check</i>Je sais ce que je fais !
-                                </button>
-                            </div>
-                        </div>
-                        {{ form_end(open_form) }}
-                    {% endif %}
-                </div>
-            </li>
-        {% endif %}
-
         <!-- Rôles -->
         {% if is_granted("ROLE_ADMIN") %}
             <li id="super">
@@ -429,6 +388,31 @@
             </li>
         {% endif %}
     </ul>
+
+    <div id="withdrawn-member-confirmation-modal" class="modal">
+        <div class="modal-content">
+            <h5>
+                <i class="material-icons left small">remove_circle_outline</i>{% if member.withdrawn %}Ré-ouverture{% else %}Fermeture{% endif %} du compte membre
+            </h5>
+            <p>Attention, vous êtes sur le point de {% if member.withdrawn %}ré-ouvrir{% else %}fermer{% endif %} le compte du membre.</p>
+            {% if not member.withdrawn %}
+            <ul>
+                {% if use_fly_and_fixed %}
+                    <li>Ce membre a {{ period_positions | length }} créneau{% if period_positions | length > 1 %}x{% endif %} fixe.</li>
+                {% endif %}
+                <li>Ce membre a {{ in_progress_and_upcoming_shifts | length }} créneau{% if in_progress_and_upcoming_shifts | length > 1 %}x{% endif %} réservé à venir.</li>
+            </ul>
+            {% endif %}
+        </div>
+        <div class="modal-footer">
+            {{ form_start(withdrawn_form) }}
+            <a href="#!" class="modal-action modal-close waves-effect waves-green btn-flat green-text">Retour à la raison</a>
+            <button type="submit" class="btn waves-effect waves-light orange">
+                <i class="material-icons left">check</i>Je sais ce que je fais !
+            </button>
+            {{ form_end(withdrawn_form) }}
+        </div>
+    </div>
 {% endblock %}
 
 {% block javascripts %}

--- a/app/Resources/views/member/show.html.twig
+++ b/app/Resources/views/member/show.html.twig
@@ -46,6 +46,16 @@
                     {% endif %}
                 </a>
             {% endif %}
+            <!-- Passer fixe ou volant -->
+            {% if not member.withdrawn and is_granted("ROLE_USER_MANAGER") and is_granted("flying",member) %}
+                <a href="#flying-member-confirmation-modal" class="modal-trigger waves-effect waves-light btn btn-small teal">
+                    {% if not member.flying %}
+                        <i class="material-icons left">cached</i><span class="hide-on-med-and-down">Passer en</span> volant
+                    {% else %}
+                        <i class="material-icons left">cached</i><span class="hide-on-med-and-down">Passer en</span> fixe
+                    {% endif %}
+                </a>
+            {% endif %}
         </div>
         <div class="col s12">
             {% if member.withdrawn and member.withdrawnDate  %}
@@ -53,6 +63,8 @@
                 {% if member.withdrawnBy %}
                     par {% include "admin/member/_partial/member_or_user_link.html.twig" with { user: member.withdrawnBy, target_blank: true } %}.
                 {% endif %}
+            {% elseif use_fly_and_fixed and not member.withdrawn %}
+                Compte {% if member.flying %}volant{% else %}fixe{% endif %}
             {% endif %}
         </div>
     </div>
@@ -411,6 +423,28 @@
                 <i class="material-icons left">check</i>Je sais ce que je fais !
             </button>
             {{ form_end(withdrawn_form) }}
+        </div>
+    </div>
+
+    <div id="flying-member-confirmation-modal" class="modal">
+        <div class="modal-content">
+            <h5>
+                <i class="material-icons left small">remove_circle_outline</i>Passage du compte en {% if member.flying %}fixe{% else %}volant{% endif %}
+            </h5>
+            <p>Attention, vous êtes sur le point de passer le compte du membre en {% if member.flying %}fixe{% else %}volant{% endif %}.</p>
+            {% if not member.flying %}
+            <ul>
+                <li>Ce membre a {{ period_positions | length }} créneau{% if period_positions | length > 1 %}x{% endif %} fixe.</li>
+            </ul>
+            {% endif %}
+        </div>
+        <div class="modal-footer">
+            {{ form_start(flying_form) }}
+            <a href="#!" class="modal-action modal-close waves-effect waves-green btn-flat green-text">Retour à la raison</a>
+            <button type="submit" class="btn waves-effect waves-light orange">
+                <i class="material-icons left">check</i>OK
+            </button>
+            {{ form_end(flying_form) }}
         </div>
     </div>
 {% endblock %}

--- a/app/Resources/views/member/show.html.twig
+++ b/app/Resources/views/member/show.html.twig
@@ -47,7 +47,7 @@
                 </a>
             {% endif %}
             <!-- Passer fixe ou volant -->
-            {% if not member.withdrawn and is_granted("ROLE_USER_MANAGER") and is_granted("flying",member) %}
+            {% if use_fly_and_fixed and not member.withdrawn and is_granted("ROLE_USER_MANAGER") and is_granted("flying",member) %}
                 <a href="#flying-member-confirmation-modal" class="modal-trigger waves-effect waves-light btn btn-small teal">
                     {% if not member.flying %}
                         <i class="material-icons left">cached</i><span class="hide-on-med-and-down">Passer en</span> volant

--- a/app/Resources/views/period/_partial/position_shifter_display.html.twig
+++ b/app/Resources/views/period/_partial/position_shifter_display.html.twig
@@ -17,7 +17,7 @@
             Réservé
         </div>
     {% else %}
-        {% set warning = beneficiary_service.hasWarningStatus(shifter) %}
+        {% set warning = membership_service.hasWarningStatus(shifter.membership) %}
         <a href="{{ path('member_show', { 'member_number': shifter.membership.memberNumber }) }}" target="_blank"
            class="black-text tooltipped editable-box truncate" data-position="bottom"
            data-tooltip="{{ shifter | print_with_number_and_status_icon | raw }} &#013;&#010; ({{ formation }})">

--- a/src/AppBundle/Command/ImportUsersCommand.php
+++ b/src/AppBundle/Command/ImportUsersCommand.php
@@ -168,7 +168,6 @@ class ImportUsersCommand extends CsvCommand
                         $dispatcher->dispatch(BeneficiaryCreatedEvent::NAME, new BeneficiaryCreatedEvent($beneficiary));
 
                         $beneficiary->setEmail($email);
-                        $beneficiary->setFlying(false);
 
                         $em->persist($beneficiary);
                     }

--- a/src/AppBundle/Controller/MailController.php
+++ b/src/AppBundle/Controller/MailController.php
@@ -119,7 +119,6 @@ class MailController extends Controller
                 $user = $em->getRepository(User::class)->findOneBy(array('email' => $nonMember));
                 if (is_object($user)) {
                     $fake_beneficiary = new Beneficiary();
-                    $fake_beneficiary->setFlying(false);
                     $fake_beneficiary->setUser($user);
                     $fake_beneficiary->setFirstname($user->getUsername());
                     $fake_beneficiary->setLastname(' ');

--- a/src/AppBundle/Controller/NoteController.php
+++ b/src/AppBundle/Controller/NoteController.php
@@ -11,7 +11,6 @@ use AppBundle\Entity\Registration;
 use AppBundle\Entity\Shift;
 use AppBundle\Entity\TimeLog;
 use AppBundle\Entity\User;
-use AppBundle\Form\BeneficiaryType;
 use AppBundle\Form\NoteType;
 use Symfony\Component\Form\Form;
 use Symfony\Component\HttpFoundation\Session\Session;

--- a/src/AppBundle/Controller/RegistrationsController.php
+++ b/src/AppBundle/Controller/RegistrationsController.php
@@ -12,7 +12,6 @@ use AppBundle\Entity\Registration;
 use AppBundle\Entity\Formation;
 use AppBundle\Entity\User;
 use AppBundle\Event\HelloassoEvent;
-use AppBundle\Form\BeneficiaryType;
 use AppBundle\Form\RegistrationType;
 use Doctrine\ORM\Query\ResultSetMappingBuilder;
 use Doctrine\ORM\QueryBuilder;

--- a/src/AppBundle/Controller/UserController.php
+++ b/src/AppBundle/Controller/UserController.php
@@ -14,7 +14,6 @@ use AppBundle\Entity\User;
 use AppBundle\Event\AnonymousBeneficiaryCreatedEvent;
 use AppBundle\Event\AnonymousBeneficiaryRecallEvent;
 use AppBundle\Form\AnonymousBeneficiaryType;
-use AppBundle\Form\BeneficiaryType;
 use AppBundle\Form\NoteType;
 use AppBundle\Form\UserAdminType;
 use FOS\UserBundle\Event\UserEvent;

--- a/src/AppBundle/Entity/Beneficiary.php
+++ b/src/AppBundle/Entity/Beneficiary.php
@@ -60,13 +60,6 @@ class Beneficiary
     private $address;
 
     /**
-     * @var bool
-     *
-     * @ORM\Column(name="flying", type="boolean", options={"default" : 0}, nullable=false)
-     */
-    private $flying;
-
-    /**
      * @ORM\OneToOne(targetEntity="User", inversedBy="beneficiary", cascade={"persist", "remove"})
      * @ORM\JoinColumn(name="user_id", referencedColumnName="id",nullable=false)
      * @Assert\NotNull
@@ -654,20 +647,6 @@ class Beneficiary
     public function setAddress($address)
     {
         $this->address = $address;
-    }
-
-    /**
-     * @return bool
-     */
-    public function isFlying(): ?bool {
-        return $this->flying;
-    }
-
-    /**
-     * @param bool $flying
-     */
-    public function setFlying(?bool $flying): void {
-        $this->flying = $flying;
     }
 
     /**

--- a/src/AppBundle/Entity/Membership.php
+++ b/src/AppBundle/Entity/Membership.php
@@ -71,6 +71,13 @@ class Membership
     private $frozen_change;
 
     /**
+     * @var bool
+     *
+     * @ORM\Column(name="flying", type="boolean", options={"default" : 0}, nullable=false)
+     */
+    private $flying;
+
+    /**
      * @ORM\OneToMany(targetEntity="Registration", mappedBy="membership",cascade={"persist", "remove"})
      * @OrderBy({"date" = "DESC"})
      */
@@ -482,6 +489,20 @@ class Membership
     public function getFrozenChange()
     {
         return $this->frozen_change;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isFlying(): ?bool {
+        return $this->flying;
+    }
+
+    /**
+     * @param bool $flying
+     */
+    public function setFlying(?bool $flying): void {
+        $this->flying = $flying;
     }
 
     /**

--- a/src/AppBundle/Entity/Period.php
+++ b/src/AppBundle/Entity/Period.php
@@ -392,7 +392,7 @@ class Period
         foreach ($this->positions as $position) {
             if($shifter = $position->getShifter()){
                 if((($weekFilter && $position->getWeekCycle()==$weekFilter) or !$weekFilter)
-                    and ($shifter->isFlying()
+                    and ($shifter->getMembership()->isFlying()
                     or $shifter->getMembership()->isFrozen()
                     or $shifter->getMembership()->isWithdrawn())){
                     return true;

--- a/src/AppBundle/Form/BeneficiaryType.php
+++ b/src/AppBundle/Form/BeneficiaryType.php
@@ -66,14 +66,6 @@ class BeneficiaryType extends AbstractType
         $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) use ($user) {
             $form = $event->getForm();
             if (is_object($user)&&($user->hasRole('ROLE_USER_MANAGER') || $user->hasRole('ROLE_ADMIN') || $user->hasRole('ROLE_SUPER_ADMIN'))) {
-                $form->add('flying', ChoiceType::class, array(
-                    'choices'  => array(
-                        'Oui' => true,
-                        'Non' => false,
-                    ),
-                    'required' => true,
-                    'label' => 'Equipe volante'
-                ));
                 $form->add('commissions', EntityType::class, array(
                     'class' => 'AppBundle:Commission',
                     'choice_label' => 'name',

--- a/src/AppBundle/Security/MembershipVoter.php
+++ b/src/AppBundle/Security/MembershipVoter.php
@@ -20,6 +20,7 @@ class MembershipVoter extends Voter
     const CLOSE = 'close';
     const FREEZE = 'freeze';
     const FREEZE_CHANGE = 'freeze_change';
+    const FLYING = "flying";
     const ROLE_REMOVE = 'role_remove';
     const ROLE_ADD = 'role_add';
     const ANNOTATE = 'annotate';
@@ -46,6 +47,7 @@ class MembershipVoter extends Voter
                 self::ROLE_ADD,
                 self::FREEZE,
                 self::FREEZE_CHANGE,
+                self::FLYING,
                 self::CREATE,
                 self::ANNOTATE,
                 self::ACCESS_TOOLS,
@@ -103,6 +105,7 @@ class MembershipVoter extends Voter
             case self::ROLE_ADD:
             case self::ROLE_REMOVE:
             case self::EDIT:
+            case self::FLYING:
                 return $this->canEdit($subject, $token);
         }
 

--- a/src/AppBundle/Service/BeneficiaryService.php
+++ b/src/AppBundle/Service/BeneficiaryService.php
@@ -65,20 +65,6 @@ class BeneficiaryService
     }
 
     /**
-     * Return true if the beneficiary is in a "warning" status
-     */
-    public function hasWarningStatus(Beneficiary $beneficiary): bool
-    {
-        $hasWarningStatus = $this->membershipService->hasWarningStatus($beneficiary->getMembership());
-
-        if ($this->container->getParameter('use_fly_and_fixed')) {
-            $hasWarningStatus = $hasWarningStatus || $beneficiary->isFlying();
-        }
-        
-        return $hasWarningStatus;
-    }
-
-    /**
      * Return a string with emoji between brackets depending on the
      * beneficiary status, if she/he is inactive (withdrawn), frozen or flying
      * or an empty string if none of those
@@ -96,7 +82,7 @@ class BeneficiaryService
         if ($beneficiary->getMembership()->getFrozen()) {
             $symbols[] = $this->container->getParameter('member_frozen_icon');
         }
-        if ($beneficiary->isFlying()) {
+        if ($beneficiary->getMembership()->isFlying()) {
             $symbols[] = $this->container->getParameter('beneficiary_flying_icon');;
         }
         if ($beneficiary->getMembership()->isCurrentlyExemptedFromShifts()) {

--- a/src/AppBundle/Service/MembershipService.php
+++ b/src/AppBundle/Service/MembershipService.php
@@ -194,10 +194,16 @@ class MembershipService
      */
     public function hasWarningStatus(Membership $member): bool
     {
-        return $member->getWithdrawn() ||
+        $hasWarningStatus = $member->getWithdrawn() ||
             $member->getFrozen() ||
             $member->isCurrentlyExemptedFromShifts() ||
             !$this->isUptodate($member);
+
+        if ($this->container->getParameter('use_fly_and_fixed')) {
+            $hasWarningStatus = $hasWarningStatus || $member->isFlying();
+        }
+
+        return $hasWarningStatus;
     }
 
     public function getShiftFreeLogs(Membership $member)

--- a/src/AppBundle/Service/SearchUserFormHelper.php
+++ b/src/AppBundle/Service/SearchUserFormHelper.php
@@ -657,7 +657,7 @@ class SearchUserFormHelper
             }
         }
         if ($form->get('flying')->getData() > 0) {
-            $qb = $qb->andWhere('b.flying = :flying')
+            $qb = $qb->andWhere('m.flying = :flying')
                      ->setParameter('flying', $form->get('flying')->getData()-1);
         }
         return $qb;


### PR DESCRIPTION
Cette PR : 
- déplace la notion de volant du beneficiary vers le membership
- déplacer le bouton "Fermer le compte" / "Ré-ouvrir le compte" en haut à droite de la page du membre
- rajoute un bouton en haut à droite de la page du membre pour le passer en fixe ou en volant

Note : la migration du statut de volant de beneficiary vers le membership récupére le status du main beneficiary et l'applique au membership.