### PR TITLE
Adhésion : nouveau paramètre pour afficher/cacher le bouton 'Nouvelle adhésion'

### DIFF
--- a/app/Resources/views/default/tools/office_tools.html.twig
+++ b/app/Resources/views/default/tools/office_tools.html.twig
@@ -17,7 +17,9 @@
 <h4>Adhésion et ré-adhésion</h4>
 
 <div class="row">
-    <a href="{{ path('member_new') }}" class="waves-effect waves-light green btn {% if not is_granted("ROLE_SUPER_ADMIN") %}title='Utiliser l\'autre bouton' disabled{% endif %}"><i class="material-icons left">person_add</i>Nouvelle adhésion</a>
+    {% if registration_manual_enabled %}
+        <a href="{{ path('member_new') }}" class="waves-effect waves-light green btn"><i class="material-icons left">person_add</i>Nouvelle adhésion</a>
+    {% endif %}
     <a href="{{ path('user_quick_new') }}" class="waves-effect waves-light green btn"><i class="material-icons left">person_add</i>Nouvelle adhésion réunion info</a>
     <a href="{{ path('member_edit_firewall') }}" class="waves-effect waves-light btn"><i class="material-icons left">edit</i>Editer un adhérent</a>
 </div>

--- a/app/Resources/views/member/_partial/member_form.html.twig
+++ b/app/Resources/views/member/_partial/member_form.html.twig
@@ -24,16 +24,14 @@
 {% if form.lastRegistration is defined %}
     <h4>Première adhésion</h4>
     <div class="row">
-        <div class="amount col s2">
+        <div class="amount col s3">
             {{ form_row(form.lastRegistration.amount) }}
         </div>
         <div class="type col s3">
             {{ form_row(form.lastRegistration.mode) }}
         </div>
         <div class="date col s3">
-            <div class="row">
-                <div class="col s4">{{ form_row(form.lastRegistration.date) }}</div>
-            </div>
+            {{ form_row(form.lastRegistration.date) }}
         </div>
         <div class="col s3">
             {{ form_row(form.lastRegistration.registrar) }}

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -51,6 +51,7 @@ twig:
     helloasso_registration_campaign_url: "%helloasso_registration_campaign_url%"
     due_duration_by_cycle: '%due_duration_by_cycle%'
     registration_duration: '%registration_duration%'
+    registration_manual_enabled: '%registration_manual_enabled%'
     support_email: '%transactional_mailer_user%'
     images_tmp_dir: '%images_tmp_dir%'
     maximum_nb_of_beneficiaries_in_membership: '%maximum_nb_of_beneficiaries_in_membership%'

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -84,6 +84,7 @@ parameters:
     # Registration
     registration_duration: '1 year'
     registration_every_civil_year: false
+    registration_manual_enabled: true
     helloasso_registration_campaign_url: https://www.helloasso.com/associations/my-local-coop/adhesions/re-adhesion
     helloasso_campaign_id:
     helloasso_api_key:

--- a/src/AppBundle/Form/RegistrationType.php
+++ b/src/AppBundle/Form/RegistrationType.php
@@ -54,14 +54,14 @@ class RegistrationType extends AbstractType
 
             if (!is_object($user) || !$user->hasRole('ROLE_SUPER_ADMIN')) {
                 if ($registration){
-                    if (!$registration->getAmount()){
+                    if (!$registration->getAmount()) {
                         $form->add('amount', TextType::class, array('label' => 'Montant','attr'=>array('placeholder'=>'15'),
                             'constraints' => [ new GreaterThan(0) ]));
-                    }else{
+                    } else {
                         $form->add('amount', TextType::class, array('label' => 'Montant','attr'=>array('disabled'=>'true')));
                     }
                     $form->add('registrar', EntityType::class, array(
-                        'label' => 'Enregistré par',
+                        'label' => 'Enregistrée par',
                         'class' => 'AppBundle:User',
                         'query_builder' => function (EntityRepository $er) {
                             return $er->createQueryBuilder('u')
@@ -89,8 +89,8 @@ class RegistrationType extends AbstractType
                 }
             } else {
                 $form->add('amount', TextType::class, array('label' => 'Montant','attr'=>array('placeholder'=>'15')));
-                $form->add('registrar',EntityType::class,array(
-                    'label' => 'Enregistré par',
+                $form->add('registrar', EntityType::class, array(
+                    'label' => 'Enregistrée par',
                     'class' => 'AppBundle:User',
                     'query_builder' => function (EntityRepository $er) {
                         return $er->createQueryBuilder('u')
@@ -104,7 +104,7 @@ class RegistrationType extends AbstractType
                     'Espèce' => Registration::TYPE_CASH,
                     'Chèque' => Registration::TYPE_CHECK,
                     $this->localCurrency => Registration::TYPE_LOCAL,
-//                    'CB' => Registration::TYPE_CREDIT_CARD,
+                    // 'CB' => Registration::TYPE_CREDIT_CARD,
                 ),'label' => 'Mode de réglement')); //todo, make it dynamic
             }
 


### PR DESCRIPTION
### Quoi ?

Certaines épiceries n'utilisent pas le bouton "Nouvelle adhésion", ce nouveau paramètre `registration_manual_enabled` permet de le cacher.

Cela permet aussi de ne pas limiter cette page aux seuls `ROLE_SUPER_ADMIN` (depuis #507)

### Captures d'écran

|Paramètre|Image|
|---|---|
|`registration_manual_enabled: true`|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/b5da6f62-8198-4554-8570-9b260f50d3e2)|
|`registration_manual_enabled: false`|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/5563be80-5827-4c1f-9971-ce9ee032e74a)|