### PR TITLE
Bénéficiaire : ne pas cacher les informations qui débordent

### DIFF
--- a/app/Resources/views/admin/user/list.html.twig
+++ b/app/Resources/views/admin/user/list.html.twig
@@ -296,7 +296,7 @@
                     <td class="hide-on-med-and-down">
                         {% for beneficiary in member.beneficiaries %}
                             {% for formation in beneficiary.formations %}
-                                <div class="chip truncate">
+                                <div class="chip">
                                     {{ formation.name }}
                                 </div>
                             {% endfor %}
@@ -305,7 +305,7 @@
                     <td class="hide-on-med-and-down">
                         {% for beneficiary in member.beneficiaries %}
                             {% for commission in beneficiary.commissions %}
-                                <div class="chip truncate">
+                                <div class="chip">
                                     {{ commission.name }}
                                 </div>
                             {% endfor %}

--- a/app/Resources/views/beneficiary/_partial/info.html.twig
+++ b/app/Resources/views/beneficiary/_partial/info.html.twig
@@ -22,17 +22,17 @@
 </div>
 
 <div class="row">
-    <div class="col s12 truncate">
+    <div class="col s12">
         <i class="material-icons tiny">phone</i>
         <span>{{ beneficiary.phone }}</span>
     </div>
     {% if phone_only is not defined %}
-        <div class="col s12 truncate">
+        <div class="col s12">
             <i class="material-icons tiny">mail</i>
             <span>{{ beneficiary.email }}</span>
         </div>
         {% if beneficiary.address %}
-            <div class="col s12 truncate">
+            <div class="col s12">
                 <i class="material-icons tiny">location_on</i>
                 {{ beneficiary.address.street1 }}
                 {% if beneficiary.address.street2 %}
@@ -43,7 +43,7 @@
             </div>
         {% endif %}
     {% endif %}
-    <div class="col s12 truncate">
+    <div class="col s12">
         <i class="material-icons tiny">person</i>&nbsp;{{ beneficiary.user.username }}
         {% if is_granted("ROLE_ADMIN") %}
             (<i class="material-icons tiny" title="dernière connexion">exit_to_app</i>
@@ -55,7 +55,7 @@
         {% endif %}
     </div>
     {% if use_fly_and_fixed %}
-        <div class="col s12 truncate">
+        <div class="col s12">
             <i class="material-icons tiny">accessibility</i>
             {% if beneficiary.flying %}
                 <div class="chip green-text">Equipe volante</div>
@@ -65,7 +65,7 @@
         </div>
     {% endif %}
     {% if beneficiary.formations | length %}
-        <div class="col s12 truncate">
+        <div class="col s12">
             <i class="material-icons tiny">assignment_ind</i>
             {% for formation in beneficiary.formations %}
                 <div class="chip red-text">{{ formation.name }}</div>
@@ -73,7 +73,7 @@
         </div>
     {% endif %}
     {% if beneficiary.commissions | length %}
-        <div class="col s12 truncate">
+        <div class="col s12">
             <i class="material-icons tiny">group</i>
             {% for commission in beneficiary.commissions %}
                 <div class="chip blue-text">{{ commission.name }}</div>
@@ -81,7 +81,7 @@
         </div>
     {% endif %}
     {% if beneficiary.user and beneficiary.user.roles | length %}
-        <div class="col s12 truncate">
+        <div class="col s12">
             <i class="material-icons tiny">settings</i>
             {% for role in beneficiary.user.roles %}
                 <div class="chip purple-text">{{ role }}</div>
@@ -89,7 +89,7 @@
         </div>
     {% endif %}
     {% if beneficiary.membership.lastRegistration %}
-        <div class="col s12 truncate">
+        <div class="col s12">
             <i class="material-icons tiny">perm_contact_calendar</i>
             <span>Adhésion du {{ beneficiary.membership.lastRegistration.date | date_fr_full }} au {{ beneficiary.membership | expire | date_fr_full }}</span>
         </div>


### PR DESCRIPTION
### Quoi ?

Actuellement, dans la fiche bénéficiaire, on cache les données qui débordent (pour éviter les retours à la ligne).
Si le membre a trop de roles / formations / commissions, l'information est parfois cachés.

Cette PR permet d'afficher toutes les informations, avec des retours à la ligne automatiques.

### Captures d'écran

|Avant|Après|
|---|---|
|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/6175ff34-be4f-41b3-841d-4ad36e43a48a)|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/a2892a85-9d6d-4f8b-af4a-d943337ecc97)|