### PR TITLE
Horaires d'ouverture : pouvoir générer un widget

### DIFF
--- a/app/Resources/views/admin/openinghour/_partial/card.html.twig
+++ b/app/Resources/views/admin/openinghour/_partial/card.html.twig
@@ -1,0 +1,5 @@
+{% set openingHourJoinString = "&" %}
+
+<div class="card-panel">
+    {% include "/admin/openinghour/_partial/table.html.twig" with { openingHours: openingHours } %}
+</div>

--- a/app/Resources/views/admin/openinghour/_partial/list.html.twig
+++ b/app/Resources/views/admin/openinghour/_partial/list.html.twig
@@ -1,0 +1,19 @@
+{% set openingHourJoinString = "&" %}
+
+<ul>
+    {% set dayOfWeek = -1 %}
+    {% for openingHour in openingHours %}
+        {% if openingHour.dayOfWeek != dayOfWeek %}
+            {# close previous day #}
+            {% if loop.index > 0 %}</li>{% endif %}
+            {# open new day #}
+            <li>{{ openingHour.dayOfWeekString | capitalize }} :
+            {{ openingHour.start | time_short }}-{{ openingHour.end | time_short }}
+        {% else %}
+            {# continue existing day #}
+            {{ openingHourJoinString | raw }} {{ openingHour.start | time_short }}-{{ openingHour.end | time_short }}
+        {% endif %}
+        {% set dayOfWeek = openingHour.dayOfWeek %}
+    {% endfor %}
+    </li>
+</ul>

--- a/app/Resources/views/admin/openinghour/_partial/table.html.twig
+++ b/app/Resources/views/admin/openinghour/_partial/table.html.twig
@@ -1,0 +1,23 @@
+{% set openingHourJoinString = "&" %}
+
+<table style=" width: max-content; margin-left: auto; margin-right: auto; border-collapse: separate; border-spacing: 10px 0px" class="no-padding">
+    <tbody>
+        {% set dayOfWeek = -1 %}
+        {% for openingHour in openingHours %}
+            {% if openingHour.dayOfWeek != dayOfWeek %}
+                {# close previous day #}
+                {% if loop.index > 0 %}</td></tr>{% endif %}
+                {# open new day #}
+                <tr>
+                    <td class="no-padding" style="text-align:right">{{ openingHour.dayOfWeekString | capitalize }} :</td>
+                    <td class="no-padding">{{ openingHour.start | time_short }}-{{ openingHour.end | time_short }}
+            {% else %}
+                {# continue existing day #}
+                {{ openingHourJoinString | raw }} {{ openingHour.start | time_short }}-{{ openingHour.end | time_short }}
+            {% endif %}
+            {% set dayOfWeek = openingHour.dayOfWeek %}
+        {% endfor %}
+            </td>
+        </tr>
+    </tbody>
+</table>

--- a/app/Resources/views/admin/openinghour/_partial/widget.html.twig
+++ b/app/Resources/views/admin/openinghour/_partial/widget.html.twig
@@ -2,7 +2,11 @@
 
 {% block content %}
 {% if title %}
-    Horaires d'ouverture :
+    <p {% if align != "left" %}style="text-align:center"{% endif %}>Horaires d'ouverture :</p>
 {% endif %}
-{% include "/admin/openinghour/_partial/table.html.twig" with { openingHours: openingHours } %}
+{% if align == "left" %}
+    {% include "/admin/openinghour/_partial/list.html.twig" with { openingHours: openingHours } %}
+{% else %}
+    {% include "/admin/openinghour/_partial/table.html.twig" with { openingHours: openingHours } %}
+{% endif %}
 {% endblock %}

--- a/app/Resources/views/admin/openinghour/_partial/widget.html.twig
+++ b/app/Resources/views/admin/openinghour/_partial/widget.html.twig
@@ -1,25 +1,8 @@
-{% set openingHourJoinString = "&" %}
+{% extends 'layoutlight.html.twig' %}
 
-<div class="card-panel">
-    <table style=" width: max-content; margin-left: auto; margin-right: auto; border-collapse: separate; border-spacing: 10px 0px" class="no-padding">
-        <tbody>
-            {% set dayOfWeek = -1 %}
-            {% for openingHour in openingHours %}
-                {% if openingHour.dayOfWeek != dayOfWeek %}
-                    {# close previous day #}
-                    {% if loop.index > 0 %}</td></tr>{% endif %}
-                    {# open new day #}
-                    <tr>
-                        <td class="no-padding" style="text-align:right">{{ openingHour.dayOfWeekString | capitalize }} :</td>
-                        <td class="no-padding">{{ openingHour.start | time_short }}-{{ openingHour.end | time_short }}
-                {% else %}
-                    {# continue existing day #}
-                    {{ openingHourJoinString | raw }} {{ openingHour.start | time_short }}-{{ openingHour.end | time_short }}
-                {% endif %}
-                {% set dayOfWeek = openingHour.dayOfWeek %}
-            {% endfor %}
-                </td>
-            </tr>
-        </tbody>
-    </table>
-</div>
+{% block content %}
+{% if title %}
+    Horaires d'ouverture :
+{% endif %}
+{% include "/admin/openinghour/_partial/table.html.twig" with { openingHours: openingHours } %}
+{% endblock %}

--- a/app/Resources/views/admin/openinghour/index.html.twig
+++ b/app/Resources/views/admin/openinghour/index.html.twig
@@ -14,7 +14,7 @@
 {% if openingHours %}
     <div class="row">
         <div class="col m6">
-            {% include "/admin/openinghour/_partial/widget.html.twig" with { openingHours: openingHours } %}
+            {% include "/admin/openinghour/_partial/card.html.twig" with { openingHours: openingHours } %}
         </div>
     </div>
 {% else %}

--- a/app/Resources/views/admin/openinghour/index.html.twig
+++ b/app/Resources/views/admin/openinghour/index.html.twig
@@ -54,4 +54,7 @@
 <a href="{{ path('admin_openinghour_new') }}" class="btn">
     <i class="material-icons left">add</i>Ajouter une horaire d'ouverture
 </a>
+<a href="{{ path('admin_openinghour_widget_generator') }}" class="btn">
+    <i class="material-icons left">tune</i>Générer un widget
+</a>
 {% endblock %}

--- a/app/Resources/views/admin/openinghour/widget_generator.html.twig
+++ b/app/Resources/views/admin/openinghour/widget_generator.html.twig
@@ -1,0 +1,35 @@
+{% extends 'layout.html.twig' %}
+
+{% block title %}Générer un widget (horaires d'ouverture) - {{ site_name }}{% endblock %}
+
+{% block breadcrumbs %}
+<a href="{{ path('homepage') }}"><i class="material-icons">home</i></a><i class="material-icons">chevron_right</i>
+<a href="{{ path('admin') }}"><i class="material-icons">build</i>&nbsp;Administration</a><i class="material-icons">chevron_right</i>
+<a href="{{ path('admin_openinghour_index') }}"><i class="material-icons">schedule</i>&nbsp;Horaires d'ouverture</a><i class="material-icons">chevron_right</i>
+<i class="material-icons">tune</i>&nbsp;Générer un widget (horaires d'ouverture)
+{% endblock %}
+
+{% block content %}
+<h4>Générer un widget (horaires d'ouverture)</h4>
+
+{{ form_start(form) }}
+<div class="errors">
+    {{ form_errors(form) }}
+</div>
+<div class="row">
+    <div class="col s12">
+        {{ form.title.vars.label }}
+        <div class="switch">
+            <label>
+                masquer le titre
+                {{ form_widget(form.title) }}
+                <span class="lever"></span>
+                afficher le titre
+            </label>
+        </div>
+    </div>
+</div>
+<br />
+{{ form_widget(form.generate, {'attr': {'class': 'btn waves-effect waves-light'}}) }}
+{{ form_end(form) }}
+{% endblock %}

--- a/app/Resources/views/admin/openinghour/widget_generator.html.twig
+++ b/app/Resources/views/admin/openinghour/widget_generator.html.twig
@@ -17,7 +17,7 @@
     {{ form_errors(form) }}
 </div>
 <div class="row">
-    <div class="col s12">
+    <div class="col m6">
         {{ form.title.vars.label }}
         <div class="switch">
             <label>
@@ -27,6 +27,12 @@
                 afficher le titre
             </label>
         </div>
+    </div>
+</div>
+<div class="row">
+    <div class="col m6">
+        {{ form_label(form.align) }}
+        {{ form_widget(form.align) }}
     </div>
 </div>
 <br />

--- a/app/Resources/views/admin/openinghour/widget_generator.html.twig
+++ b/app/Resources/views/admin/openinghour/widget_generator.html.twig
@@ -32,4 +32,20 @@
 <br />
 {{ form_widget(form.generate, {'attr': {'class': 'btn waves-effect waves-light'}}) }}
 {{ form_end(form) }}
+
+{% if query_string is defined %}
+    <br />
+    <h4>Résultat</h4>
+    <div class="row">
+        <div class="col m4">
+            <iframe src="{{ path('admin_openinghour_widget') }}?{{ query_string }}" frameborder="0" style="border: 2px solid green;"></iframe>
+        </div>
+        <div class="col m8">
+            texte à copier-coller 👇
+            <div class="card-panel" style="overflow:scroll;">
+                <pre>&lt;iframe src="{{ absolute_url(path('admin_openinghour_widget')) }}?{{ query_string }}" frameborder="0"&gt;&lt;/iframe&gt;</pre>
+            </div>
+        </div>
+    </div>
+{% endif %}
 {% endblock %}

--- a/src/AppBundle/Controller/BookingController.php
+++ b/src/AppBundle/Controller/BookingController.php
@@ -212,7 +212,7 @@ class BookingController extends Controller
                 'required' => false,
                 'choices' => array_combine($years, $years),
                 'label' => 'Année',
-                'data' =>  $defaultYear,
+                'data' => $defaultYear,
                 'placeholder' => false,
             ))
             ->add('week', IntegerType::class, array(

--- a/src/AppBundle/Controller/OpeningHourController.php
+++ b/src/AppBundle/Controller/OpeningHourController.php
@@ -8,20 +8,22 @@ use AppBundle\Form\OpeningHourType;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Form\Form;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\HttpFoundation\Request;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Session\Session;
 
 
 /**
- * OpeningHour controller.
+ * OpeningHour controller
  *
  * @Route("admin/openinghours")
  */
 class OpeningHourController extends Controller
 {
     /**
-     * List all opening hours.
+     * List all opening hours
      *
      * @Route("/", name="admin_openinghour_index", methods={"GET"})
      * @Security("has_role('ROLE_ADMIN')")
@@ -37,7 +39,7 @@ class OpeningHourController extends Controller
     }
 
     /**
-     * Add new opening hour.
+     * Add new opening hour
      *
      * @Route("/new", name="admin_openinghour_new", methods={"GET","POST"})
      * @Security("has_role('ROLE_ADMIN')")
@@ -71,7 +73,7 @@ class OpeningHourController extends Controller
     }
 
     /**
-     * Edit opening hour.
+     * Edit opening hour
      *
      * @Route("/edit/{id}", name="admin_openinghour_edit", methods={"GET","POST"})
      * @Security("has_role('ROLE_ADMIN')")
@@ -109,7 +111,7 @@ class OpeningHourController extends Controller
     }
 
     /**
-     * Delete opening hour.
+     * Delete opening hour
      *
      * @Route("/{id}", name="admin_openinghour_delete", methods={"DELETE"})
      * @Security("has_role('ROLE_ADMIN')")
@@ -131,6 +133,35 @@ class OpeningHourController extends Controller
         }
 
         return $this->redirectToRoute('admin_openinghour_index');
+    }
+
+    /**
+     * Opening hour widget generator
+     *
+     * @Route("/widget_generator", name="admin_openinghour_widget_generator", methods={"GET","POST"})
+     * @Security("has_role('ROLE_ADMIN')")
+     */
+    public function widgetGeneratorAction(Request $request)
+    {
+        $form = $this->createFormBuilder()
+            ->add('title', CheckboxType::class, array('required' => false, 'data' => true, 'label' => 'Afficher le titre du widget ?'))
+            ->add('generate', SubmitType::class, array('label' => 'Générer'))
+            ->getForm();
+
+        if ($form->handleRequest($request)->isValid()) {
+            $data = $form->getData();
+
+            $widgetQueryString = 'title='.($data['title'] ? 1 : 0);
+
+            return $this->render('admin/openinghour/widget_generator.html.twig', array(
+                'query_string' => $widgetQueryString,
+                'form' => $form->createView(),
+            ));
+        }
+
+        return $this->render('admin/openinghour/widget_generator.html.twig', array(
+            'form' => $form->createView(),
+        ));
     }
 
     /**

--- a/src/AppBundle/Controller/OpeningHourController.php
+++ b/src/AppBundle/Controller/OpeningHourController.php
@@ -23,6 +23,25 @@ use Symfony\Component\HttpFoundation\Session\Session;
 class OpeningHourController extends Controller
 {
     /**
+     * Opening hours widget display
+     * 
+     * @Route("/widget", name="admin_openinghour_widget", methods={"GET"})
+     */
+    public function widgetAction(Request $request)
+    {
+        $em = $this->getDoctrine()->getManager();
+
+        $filter_title = $request->query->has('title') ? ($request->get('title') == 1) : true;
+
+        $openingHours = $em->getRepository('AppBundle:OpeningHour')->findAll();
+
+        return $this->render('admin/openinghour/_partial/widget.html.twig', [
+            'openingHours' => $openingHours,
+            'title' => $filter_title
+        ]);
+    }
+
+    /**
      * List all opening hours
      *
      * @Route("/", name="admin_openinghour_index", methods={"GET"})
@@ -31,6 +50,7 @@ class OpeningHourController extends Controller
     public function indexAction(Request $request)
     {
         $em = $this->getDoctrine()->getManager();
+
         $openingHours = $em->getRepository('AppBundle:OpeningHour')->findAll();
 
         return $this->render('admin/openinghour/index.html.twig', array(
@@ -136,7 +156,7 @@ class OpeningHourController extends Controller
     }
 
     /**
-     * Opening hour widget generator
+     * Opening hours widget generator
      *
      * @Route("/widget_generator", name="admin_openinghour_widget_generator", methods={"GET","POST"})
      * @Security("has_role('ROLE_ADMIN')")

--- a/src/AppBundle/Controller/OpeningHourController.php
+++ b/src/AppBundle/Controller/OpeningHourController.php
@@ -2,7 +2,6 @@
 
 namespace AppBundle\Controller;
 
-
 use AppBundle\Entity\OpeningHour;
 use AppBundle\Form\OpeningHourType;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
@@ -10,10 +9,10 @@ use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\HttpFoundation\Request;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Session\Session;
-
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 
 /**
  * OpeningHour controller
@@ -32,12 +31,14 @@ class OpeningHourController extends Controller
         $em = $this->getDoctrine()->getManager();
 
         $filter_title = $request->query->has('title') ? ($request->get('title') == 1) : true;
+        $filter_align = $request->query->has('align') ? $request->get('align') : 'center';
 
         $openingHours = $em->getRepository('AppBundle:OpeningHour')->findAll();
 
         return $this->render('admin/openinghour/_partial/widget.html.twig', [
             'openingHours' => $openingHours,
-            'title' => $filter_title
+            'title' => $filter_title,
+            'align' => $filter_align,
         ]);
     }
 
@@ -165,13 +166,18 @@ class OpeningHourController extends Controller
     {
         $form = $this->createFormBuilder()
             ->add('title', CheckboxType::class, array('required' => false, 'data' => true, 'label' => 'Afficher le titre du widget ?'))
+            ->add('align', ChoiceType::class, array(
+                'label' => 'Alignement',
+                'choices'  => array('centré' => 'center', 'gauche' => 'left'),
+                'data' => 'center'
+            ))
             ->add('generate', SubmitType::class, array('label' => 'Générer'))
             ->getForm();
 
         if ($form->handleRequest($request)->isValid()) {
             $data = $form->getData();
 
-            $widgetQueryString = 'title='.($data['title'] ? 1 : 0);
+            $widgetQueryString = 'title='.($data['title'] ? 1 : 0) . '&align=' . $data['align'];
 
             return $this->render('admin/openinghour/widget_generator.html.twig', array(
                 'query_string' => $widgetQueryString,


### PR DESCRIPTION
### Quoi ?

Il est déjà possible de générer des widget pour `Job` & `Event`. Cette PR rajoute la fonctionnalité pour `OpeningHour`.

Il est possible de configurer 2 choses (simple) : 
- si on souhaite afficher le titre "Horaires d'ouverture" ou pas
- si on souhaite que le widget soit centré ou pas

### Captures d'écran

![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/18d73ca1-6a8f-493c-83f8-5c16029d74e9)


|Configuration|Image|
|---|---|
|titre : oui ; align : center|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/46232b5e-36ae-4aba-8915-f89e7c8f2ecf)|
|titre : non ; align : left|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/407675d7-f5b4-404d-80ef-c62f17d4df12)|