### PR TITLE
Semaine type : pouvoir créer des créneaux type même si cycle_type est null

### DIFF
--- a/app/Resources/views/admin/period/edit.html.twig
+++ b/app/Resources/views/admin/period/edit.html.twig
@@ -158,10 +158,12 @@
                         {{ form_label(position_add_form.nb_of_shifter) }}
                         {{ form_widget(position_add_form.nb_of_shifter) }}
                     </div>
-                    <div class="col s3">
-                        {{ form_label(position_add_form.week_cycle) }}
-                        {{ form_widget(position_add_form.week_cycle) }}
-                    </div>
+                    {% if cycle_type == 'abcd' %}
+                        <div class="col s3">
+                            {{ form_label(position_add_form.week_cycle) }}
+                            {{ form_widget(position_add_form.week_cycle) }}
+                        </div>
+                    {% endif %}
                     <div class="col s6">
                         {{ form_label(position_add_form.formation) }}
                         {{ form_widget(position_add_form.formation) }}
@@ -170,7 +172,8 @@
                         <button type="submit" class="btn waves-effect waves-light teal"><i class="material-icons left">add</i>Ajouter</button>
                     </div>
                 </div>
-                {{ form_end(position_add_form) }}
+                {{ form_row(position_add_form._token) }}
+                {{ form_end(position_add_form, {'render_rest': false}) }}
             </div>
         </li>
         <li>

--- a/app/Resources/views/admin/period/edit.html.twig
+++ b/app/Resources/views/admin/period/edit.html.twig
@@ -41,7 +41,9 @@
             Aucun poste n'existe pour ce créneau
         {% endif %}
         {% for week, positions in period.positionsperweekcycle %}
-            <h6>Semaine {{ week }}</h6>
+            {% if cycle_type == 'abcd' %}
+                <h6>Semaine {{ week }}</h6>
+            {% endif %}
             <ul class="collapsible">
                 {% for position in positions %}
                     {% if position.shifter %}

--- a/app/Resources/views/period/_partial/period_card.html.twig
+++ b/app/Resources/views/period/_partial/period_card.html.twig
@@ -40,7 +40,9 @@
             {# if display by job/training #}
             <div id="training" style="margin-top:1em;">
                 {% for week, positions in period.groupedpositionsperweekcycle(week_filter) %}
-                    <h6>Semaine {{ week }}</h6>
+                    {% if cycle_type == 'abcd' %}
+                        <h6>Semaine {{ week }}</h6>
+                    {% endif %}
                     {% for training, nb_shifters in positions %}
                         <i class="material-icons">person</i>{{ nb_shifters }} x {{ training }}
                         <br/>
@@ -53,7 +55,9 @@
                 <div id="shifter" style="margin-top:1em;">
                     {% for week, positions in period.positionsperweekcycle %}
                         {% if (week in week_filter) or not week_filter %}
-                            <h6>Semaine {{ week }}</h6>
+                            {% if cycle_type == 'abcd' %}
+                                <h6>Semaine {{ week }}</h6>
+                            {% endif %}
                             {% for position in positions %}
                                 {% include 'period/_partial/position_shifter_display.html.twig' with { 'position': position, 'anonymized': anonymized } %}
                             {% endfor %}

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -14,7 +14,7 @@ services:
         # if you need to do this, you can override this setting on individual services
         public: false
         bind:
-            $localCurrency: '%local_currency_name%'
+            $local_currency_name: '%local_currency_name%'
             $use_fly_and_fixed: '%use_fly_and_fixed%'
 
     # makes classes in src/AppBundle available to be used as services

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -16,6 +16,7 @@ services:
         bind:
             $local_currency_name: '%local_currency_name%'
             $use_fly_and_fixed: '%use_fly_and_fixed%'
+            $cycle_type: '%cycle_type%'
 
     # makes classes in src/AppBundle available to be used as services
     # this creates a service per class whose id is the fully-qualified class name

--- a/src/AppBundle/Controller/AdminController.php
+++ b/src/AppBundle/Controller/AdminController.php
@@ -13,7 +13,6 @@ use AppBundle\Entity\Formation;
 use AppBundle\Entity\User;
 use AppBundle\Event\HelloassoEvent;
 use AppBundle\Form\BeneficiaryType;
-use AppBundle\Form\RegistrationType;
 use AppBundle\Service\SearchUserFormHelper;
 use Doctrine\ORM\Query\ResultSetMappingBuilder;
 use Doctrine\ORM\QueryBuilder;

--- a/src/AppBundle/Controller/AdminPeriodController.php
+++ b/src/AppBundle/Controller/AdminPeriodController.php
@@ -31,6 +31,13 @@ use Symfony\Component\HttpKernel\KernelInterface;
  */
 class AdminPeriodController extends Controller
 {
+    private $cycle_type;
+
+    public function __construct($cycle_type)
+    {
+        $this->cycle_type = $cycle_type;
+    }
+
     /**
      * Display all the periods in a schedule (available and reserved)
      *
@@ -198,7 +205,8 @@ class AdminPeriodController extends Controller
 
         if ($form->isSubmitted() && $form->isValid()) {
             $count = $form["nb_of_shifter"]->getData();
-            foreach ($form["week_cycle"]->getData() as $week_cycle) {
+            $week_cycles = ($this->cycle_type == "abcd") ? $form["week_cycle"]->getData() : [Period::WEEK_A];
+            foreach ($week_cycles as $week_cycle) {
                 $position->setWeekCycle($week_cycle);
                 $position->setCreatedBy($current_user);
                 foreach (range(0, $count-1) as $iteration) {
@@ -207,6 +215,7 @@ class AdminPeriodController extends Controller
                     $em->persist($p);
                 }
             }
+
             $em->persist($period);
             $em->flush();
 

--- a/src/AppBundle/Controller/HelloassoController.php
+++ b/src/AppBundle/Controller/HelloassoController.php
@@ -4,7 +4,6 @@ namespace AppBundle\Controller;
 
 use AppBundle\Entity\HelloassoPayment;
 use AppBundle\Event\HelloassoEvent;
-use AppBundle\Form\RegistrationType;
 use AppBundle\Form\AutocompleteBeneficiaryType;
 use Doctrine\ORM\Tools\Pagination\Paginator;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;

--- a/src/AppBundle/Entity/Period.php
+++ b/src/AppBundle/Entity/Period.php
@@ -21,6 +21,7 @@ class Period
     const WEEK_C = "C";
     const WEEK_D = "D";
     const WEEK_CYCLE = [Period::WEEK_A, Period::WEEK_B, Period::WEEK_C, Period::WEEK_D];
+    const WEEK_CYCLE_CHOICE_LIST = ["Semaine A" => Period::WEEK_A, "Semaine B" => Period::WEEK_B, "Semaine C" => Period::WEEK_C, "Semaine D" => Period::WEEK_D];
 
     /**
      * @var int

--- a/src/AppBundle/Entity/Period.php
+++ b/src/AppBundle/Entity/Period.php
@@ -16,7 +16,11 @@ class Period
 {
     const DAYS_OF_WEEK = ["Lundi", "Mardi", "Mercredi", "Jeudi", "Vendredi", "Samedi", "Dimanche"];
     const DAYS_OF_WEEK_LIST_WITH_INT = ["Lundi" => 0, "Mardi" => 1, "Mercredi" => 2, "Jeudi" => 3, "Vendredi" => 4, "Samedi" => 5, "Dimanche" => 6];
-    const WEEK_CYCLE = ["A", "B", "C", "D"];
+    const WEEK_A = "A";
+    const WEEK_B = "B";
+    const WEEK_C = "C";
+    const WEEK_D = "D";
+    const WEEK_CYCLE = [Period::WEEK_A, Period::WEEK_B, Period::WEEK_C, Period::WEEK_D];
 
     /**
      * @var int

--- a/src/AppBundle/Form/AnonymousBeneficiaryType.php
+++ b/src/AppBundle/Form/AnonymousBeneficiaryType.php
@@ -17,12 +17,12 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
 
 class AnonymousBeneficiaryType extends AbstractType
 {
-    private $localCurrency;
+    private $local_currency_name;
     private $tokenStorage;
 
-    public function __construct(string $localCurrency, TokenStorageInterface $tokenStorage)
+    public function __construct(string $local_currency_name, TokenStorageInterface $tokenStorage)
     {
-        $this->localCurrency = $localCurrency;
+        $this->local_currency_name = $local_currency_name;
         $this->tokenStorage = $tokenStorage;
     }
 
@@ -60,7 +60,7 @@ class AnonymousBeneficiaryType extends AbstractType
                 'choices' => array(
                     'Espèce' => Registration::TYPE_CASH,
                     'Chèque' => Registration::TYPE_CHECK,
-                    $this->localCurrency => Registration::TYPE_LOCAL,
+                    $this->local_currency_name => Registration::TYPE_LOCAL,
                     'Helloasso' => Registration::TYPE_HELLOASSO,
                 )
             ));

--- a/src/AppBundle/Form/PeriodPositionType.php
+++ b/src/AppBundle/Form/PeriodPositionType.php
@@ -21,19 +21,22 @@ use Symfony\Component\Form\FormEvents;
 
 class PeriodPositionType extends AbstractType
 {
+    private $cycle_type;
+
+    public function __construct($cycle_type)
+    {
+        $this->cycle_type = $cycle_type;
+    }
+
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
             ->add('week_cycle', ChoiceType::class, array(
-                'label' => 'Cycle', 'choices' => array(
-                    "Semaine A" => Period::WEEK_A,
-                    "Semaine B" => Period::WEEK_B,
-                    "Semaine C" => Period::WEEK_C,
-                    "Semaine D" => Period::WEEK_D,
-                ),
+                'label' => 'Cycle',
+                'choices' => ($this->cycle_type == 'abcd') ? Period::WEEK_CYCLE_CHOICE_LIST : [],
                 'expanded' => false,
                 'multiple' => true,
-                'empty_data' => Period::WEEK_CYCLE
+                // 'data' => ($this->cycle_type == 'abcd') ? null : [Period::WEEK_A]
             ))
             ->add('formation', EntityType::class, array(
                 'label'=>'Formation necessaire',

--- a/src/AppBundle/Form/PeriodPositionType.php
+++ b/src/AppBundle/Form/PeriodPositionType.php
@@ -3,6 +3,7 @@
 namespace AppBundle\Form;
 
 use AppBundle\Entity\Formation;
+use AppBundle\Entity\Period;
 use AppBundle\Entity\PeriodPosition;
 use AppBundle\Entity\PeriodRoom;
 use AppBundle\Entity\Role;
@@ -20,27 +21,19 @@ use Symfony\Component\Form\FormEvents;
 
 class PeriodPositionType extends AbstractType
 {
-    const WEEKA = 'A';
-    const WEEKB = 'B';
-    const WEEKC = 'C';
-    const WEEKD = 'D';
-
-    /**
-     * {@inheritdoc}
-     */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
             ->add('week_cycle', ChoiceType::class, array(
                 'label' => 'Cycle', 'choices' => array(
-                    "Semaine A" => self::WEEKA,
-                    "Semaine B" => self::WEEKB,
-                    "Semaine C" => self::WEEKC,
-                    "Semaine D" => self::WEEKD,
+                    "Semaine A" => Period::WEEK_A,
+                    "Semaine B" => Period::WEEK_B,
+                    "Semaine C" => Period::WEEK_C,
+                    "Semaine D" => Period::WEEK_D,
                 ),
-                'expanded'  => false,
-                'multiple'  => true,
-                'empty_data' => [self::WEEKA, self::WEEKB, self::WEEKC, self::WEEKD]
+                'expanded' => false,
+                'multiple' => true,
+                'empty_data' => Period::WEEK_CYCLE
             ))
             ->add('formation', EntityType::class, array(
                 'label'=>'Formation necessaire',
@@ -55,7 +48,6 @@ class PeriodPositionType extends AbstractType
             $form = $event->getForm();
 
             // checks if the PeriodPosition object is "new"
-            // If no data is passed to the form, the data is "null".
            if (!$period_position || null === $period_position->getId()) {
                 $form->add('nb_of_shifter', IntegerType::class, [
                     'label' => 'Nombre de postes disponibles',
@@ -87,6 +79,4 @@ class PeriodPositionType extends AbstractType
     {
         return 'appbundle_period_position';
     }
-
-
 }

--- a/src/AppBundle/Form/PeriodType.php
+++ b/src/AppBundle/Form/PeriodType.php
@@ -13,7 +13,6 @@ use AppBundle\Repository\JobRepository;
 
 class PeriodType extends AbstractType
 {
-
     /**
      * {@inheritdoc}
      */
@@ -27,7 +26,7 @@ class PeriodType extends AbstractType
                 'label' => 'Poste',
                 'class' => 'AppBundle:Job',
                 'choice_label'=> 'name',
-                'multiple'     => false,
+                'multiple' => false,
                 'required' => true,
                 'query_builder' => function(JobRepository $repository) {
                     $qb = $repository->createQueryBuilder('j');
@@ -56,6 +55,4 @@ class PeriodType extends AbstractType
     {
         return 'appbundle_period';
     }
-
-
 }

--- a/src/AppBundle/Form/RegistrationType.php
+++ b/src/AppBundle/Form/RegistrationType.php
@@ -1,5 +1,4 @@
 <?php
-// src/AppBundle/Form/RegistrationType.php
 
 namespace AppBundle\Form;
 
@@ -18,12 +17,12 @@ use Symfony\Component\Validator\Constraints\GreaterThan;
 
 class RegistrationType extends AbstractType
 {
-    private $localCurrency;
+    private $local_currency_name;
     private $tokenStorage;
 
-    public function __construct(string $localCurrency, TokenStorageInterface $tokenStorage)
+    public function __construct(string $local_currency_name, TokenStorageInterface $tokenStorage)
     {
-        $this->localCurrency = $localCurrency;
+        $this->local_currency_name = $local_currency_name;
         $this->tokenStorage = $tokenStorage;
     }
 
@@ -78,7 +77,7 @@ class RegistrationType extends AbstractType
                         'choices' => array(
                             'Espèce' => Registration::TYPE_CASH,
                             'Chèque' => Registration::TYPE_CHECK,
-                            $this->localCurrency => Registration::TYPE_LOCAL,
+                            $this->local_currency_name => Registration::TYPE_LOCAL,
                             'HelloAsso' => Registration::TYPE_HELLOASSO,
                         ),
                         'label' => 'Mode de réglement',
@@ -103,7 +102,7 @@ class RegistrationType extends AbstractType
                 $form->add('mode', ChoiceType::class, array('choices'  => array(
                     'Espèce' => Registration::TYPE_CASH,
                     'Chèque' => Registration::TYPE_CHECK,
-                    $this->localCurrency => Registration::TYPE_LOCAL,
+                    $this->local_currency_name => Registration::TYPE_LOCAL,
 //                    'CB' => Registration::TYPE_CREDIT_CARD,
                 ),'label' => 'Mode de réglement')); //todo, make it dynamic
             }


### PR DESCRIPTION
Suite de #936

### Quoi ?

Pour les épiceries dont `cycle_type` est `null`, quelques modifications sur la création (et l'affichage) des créneaux type : 
- cacher la notion de "semaine"
- les créneaux concerneront chaque semaine