### PR TITLE
Poste de bénévolat : améliorer le color picker

### DIFF
--- a/app/Resources/views/admin/job/_form.html.twig
+++ b/app/Resources/views/admin/job/_form.html.twig
@@ -10,24 +10,36 @@
     {{ form_widget(form.min_shifter_alert) }}
 </div>
 <div class="row">
-    {{ form_label(form.color) }}<br>
-    <a href="https://materializecss.com/color.html" target="_blank"><i class="material-icons left">link</i> Couleur
-        materialize</a>
-    <span class="badge red">red</span>
-    <span class="badge pink">pink</span>
-    <span class="badge purple">purple</span>
-    <span class="badge deep-purple">deep-purple</span>
-    <span class="badge indigo">indigo</span>
-    <span class="badge blue">blue</span>
-    <span class="badge light-blue">light-blue</span>
-    <span class="badge cyan">cyan</span>
-    <span class="badge teal">teal</span>
-    <span class="badge green">green</span>
-    <span class="badge light-green">light-green</span>
-    <span class="badge lime">lime</span>
-    <span class="badge gray">...</span>
-    {{ form_errors(form.color) }}
-    {{ form_widget(form.color) }}
+    <div class="col m6 l4">
+        {{ form_label(form.color) }}
+        {{ form_errors(form.color) }}
+        {{ form_widget(form.color) }}
+    </div>
+    <div class="col m6 l8">
+        <a href="https://materializeweb.com/color.html" target="_blank"><i class="material-icons left">link</i> Couleurs materialize</a>
+        <p>
+            <span class="badge red white-text">red</span>
+            <span class="badge pink white-text">pink</span>
+            <span class="badge purple white-text">purple</span>
+            <span class="badge deep-purple white-text">deep-purple</span>
+            <span class="badge indigo white-text">indigo</span>
+            <span class="badge blue white-text">blue</span>
+            <span class="badge light-blue white-text">light-blue</span>
+            <span class="badge cyan white-text">cyan</span>
+            <span class="badge teal white-text">teal</span>
+            <span class="badge green white-text">green</span>
+            <span class="badge light-green white-text">light-green</span>
+            <span class="badge lime white-text">lime</span>
+            <span class="badge yellow white-text">yellow</span>
+            <span class="badge amber white-text">amber</span>
+            <span class="badge orange white-text">orange</span>
+            <span class="badge deep-orange white-text">deep-orange</span>
+            <span class="badge brown white-text">brown</span>
+            <!-- <span class="badge gray white-text">gray</span> -->
+            <!-- <span class="badge blue-gray white-text">blue-gray</span> -->
+            <span class="badge black white-text">black</span>
+        </p>
+    </div>
 </div>
 <div class="row">
     {{ form_label(form.description) }}


### PR DESCRIPTION
### Quoi ?

Dans le formulaire de création / modification d'un poste de bénévolat, quelques petites améliorations pour le champ "couleur" : 
- pointer vers le nouveau lien de la librairie Materialize
- afficher les couleurs à droite

### Captures d'écran

|Avant|Après|
|---|---|
|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/d0ce89eb-f69f-48d9-ae64-da4699e2a4aa)|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/7c143d35-d9f3-4ce0-a9b6-13a786ab3c6b)|