### PR TITLE
Déplacer la notion de volant du beneficiary vers le membership (re)

### DIFF
--- a/app/DoctrineMigrations/Version20230729100654.php
+++ b/app/DoctrineMigrations/Version20230729100654.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20230729100654 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE membership ADD flying TINYINT(1) DEFAULT \'0\' NOT NULL');
+        $this->addSql('UPDATE membership LEFT OUTER JOIN beneficiary ON beneficiary.id = membership.main_beneficiary_id SET membership.flying=beneficiary.flying WHERE beneficiary.flying = 1');
+        $this->addSql('ALTER TABLE beneficiary DROP flying');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE beneficiary ADD flying TINYINT(1) DEFAULT \'0\' NOT NULL');
+        $this->addSql('ALTER TABLE membership DROP flying');
+    }
+}

--- a/app/DoctrineMigrations/Version20230920100654_membership_flying.php
+++ b/app/DoctrineMigrations/Version20230920100654_membership_flying.php
@@ -10,7 +10,7 @@ use Doctrine\Migrations\AbstractMigration;
 /**
  * Auto-generated Migration: Please modify to your needs!
  */
-final class Version20230729100654 extends AbstractMigration
+final class Version20230920100654 extends AbstractMigration
 {
     public function getDescription() : string
     {

--- a/app/Resources/views/admin/member/_partial/status_icons.html.twig
+++ b/app/Resources/views/admin/member/_partial/status_icons.html.twig
@@ -12,3 +12,6 @@
 {% if member.mainBeneficiary and not member.mainBeneficiary.user.isEnabled %}
     <i class="material-icons" title="Compte pas encore activé">{{ user_account_not_enabled_material_icon }}</i>
 {% endif %}
+{% if use_fly_and_fixed and member.flying %}
+    <i class="material-icons" title="Compte volant">{{ beneficiary_flying_material_icon }}</i>
+{% endif %}

--- a/app/Resources/views/admin/member/_partial/status_icons.html.twig
+++ b/app/Resources/views/admin/member/_partial/status_icons.html.twig
@@ -13,5 +13,5 @@
     <i class="material-icons" title="Compte pas encore activé">{{ user_account_not_enabled_material_icon }}</i>
 {% endif %}
 {% if use_fly_and_fixed and member.flying %}
-    <i class="material-icons" title="Compte volant">{{ beneficiary_flying_material_icon }}</i>
+    <i class="material-icons" title="Compte volant">{{ member_flying_material_icon }}</i>
 {% endif %}

--- a/app/Resources/views/admin/period/index.html.twig
+++ b/app/Resources/views/admin/period/index.html.twig
@@ -204,7 +204,7 @@
                                             <li>{{ member_frozen_icon }} Membre gelé</li>
                                             <li>{{ member_exempted_icon }} Membre exempté de créneaux</li>
                                             <li>{{ member_registration_missing_icon }} Membre avec une adhésion expirée</li>
-                                            <li>{{ beneficiary_flying_icon }} Bénéficiaire avec un statut "volant"</li>
+                                            <li>{{ member_flying_icon }} Membre avec un statut "volant"</li>
                                         </ul>
                                     </td>
                                 </tr>

--- a/app/Resources/views/admin/user/list.html.twig
+++ b/app/Resources/views/admin/user/list.html.twig
@@ -23,32 +23,32 @@
                     <div class="col s12 m4">
                         <h5>Compte</h5>
                         <div class="row">
-                            <div class="col s4">
+                            <div class="col s3">
                                 <div class="input-field">
                                     {{ form_widget(form.withdrawn) }}
                                     {{ form_label(form.withdrawn) }}
                                 </div>
                             </div>
-                            <div class="col s4">
+                            <div class="col s3">
                                 <div class="input-field">
                                     {{ form_widget(form.enabled) }}
                                     {{ form_label(form.enabled) }}
                                 </div>
                             </div>
-                            <div class="col s4">
+                            <div class="col s3">
                                 <div class="input-field">
                                     {{ form_widget(form.frozen) }}
                                     {{ form_label(form.frozen) }}
                                 </div>
                             </div>
-                        </div>
-                        <div class="row">
-                            <div class="col s4">
+                            <div class="col s3">
                                 <div class="input-field">
                                     {{ form_widget(form.exempted) }}
                                     {{ form_label(form.exempted) }}
                                 </div>
                             </div>
+                        </div>
+                        <div class="row">
                             <div class="col s4">
                                 <div class="input-field">
                                     {{ form_widget(form.has_first_shift_date) }}
@@ -60,6 +60,14 @@
                                     <div class="input-field">
                                         {{ form_widget(form.beneficiary_count) }}
                                         {{ form_label(form.beneficiary_count) }}
+                                    </div>
+                                </div>
+                            {% endif %}
+                            {% if use_fly_and_fixed %}
+                                <div class="col s4">
+                                    <div class="input-field">
+                                        {{ form_widget(form.flying) }}
+                                        {{ form_label(form.flying) }}
                                     </div>
                                 </div>
                             {% endif %}

--- a/app/Resources/views/beneficiary/_partial/info.html.twig
+++ b/app/Resources/views/beneficiary/_partial/info.html.twig
@@ -61,16 +61,6 @@
             {% endif %})
         {% endif %}
     </div>
-    {% if use_fly_and_fixed %}
-        <div class="col s12">
-            <i class="material-icons tiny">accessibility</i>
-            {% if beneficiary.flying %}
-                <div class="chip green-text">Equipe volante</div>
-            {% else %}
-                <div class="chip green-text">Equipe fixe</div>
-            {% endif %}
-        </div>
-    {% endif %}
     {% if beneficiary.formations | length %}
         <div class="col s12">
             <i class="material-icons tiny">assignment_ind</i>

--- a/app/Resources/views/beneficiary/_partial/info.html.twig
+++ b/app/Resources/views/beneficiary/_partial/info.html.twig
@@ -7,6 +7,13 @@
     {% if beneficiary.isMain and maximum_nb_of_beneficiaries_in_membership > 1 %}
         <span class="badge main-color white-text">{{ beneficiary_main_icon }} principal</span>
     {% endif %}
+    {% if use_fly_and_fixed %}
+        {% if beneficiary.membership.flying %}
+            <span class="badge teal white-text">{{ member_flying_icon }} Compte volant</span>
+        {% else %}
+            <span class="badge main-color white-text">Compte fixe</span>
+        {% endif %}
+    {% endif %}
     {% if beneficiary.membership.withdrawn %}
         <span class="badge red white-text">{{ member_withdrawn_icon }} fermé</span>
     {% endif %}

--- a/app/Resources/views/member/show.html.twig
+++ b/app/Resources/views/member/show.html.twig
@@ -138,13 +138,13 @@
     <ul class="collapsible collapsible-expandable">
         
         <!-- Passer fixe ou volant -->
-        {% if use_fly_and_fixed and not member.withdrawn and is_granted("ROLE_USER_MANAGER") and is_granted("flying",member) %}
+        {% if use_fly_and_fixed and is_granted("ROLE_USER_MANAGER") and is_granted("flying",member) %}
             <li id="flying">
                 <div class="collapsible-header {% if frontend_cookie and frontend_cookie.user_show is defined and frontend_cookie.user_show.flying_open is defined and frontend_cookie.user_show.flying_open %}active{% endif %}">
                     <i class="material-icons">{{ member_flying_material_icon }}</i>Passer en {% if member.flying %}fixe{% else %}volant{% endif %}
                 </div>
                 <div class="collapsible-body white">
-                    <a href="#flying-member-confirmation-modal" class="modal-trigger waves-effect waves-light btn btn-small teal">
+                    <a href="#flying-member-confirmation-modal" class="modal-trigger waves-effect waves-light btn btn-small teal" {% if member.withdrawn %}disabled{% endif %}>
                         {% if not member.flying %}
                             <i class="material-icons left">cached</i><span class="hide-on-med-and-down">Passer en</span> volant
                         {% else %}

--- a/app/Resources/views/member/show.html.twig
+++ b/app/Resources/views/member/show.html.twig
@@ -219,72 +219,6 @@
             </li>
         {% endif %}
 
-        <!-- Fermer le compte -->
-        {% if is_granted("ROLE_USER_MANAGER") and is_granted("close",member) %}
-            <li id="close">
-                <div class="collapsible-header {% if frontend_cookie and frontend_cookie.user_show is defined and frontend_cookie.user_show.close_open is defined and frontend_cookie.user_show.close_open %}active{% endif %}">
-                    <i class="material-icons">close</i>{% if member.withdrawn %}Ré-ouvrir le compte{% else %}Fermer le compte{% endif %}
-                </div>
-                <div class="collapsible-body white">
-                    {% if not member.withdrawn %}
-                        <a href="#close-member-confirmation-modal" class="modal-trigger waves-effect waves-light btn red">
-                            <i class="material-icons left">close</i>Fermer le compte
-                        </a>
-                        {{ form_start(close_form) }}
-                        <div id="close-member-confirmation-modal" class="modal">
-                            <div class="modal-content">
-                                <h5>
-                                    <i class="material-icons left small">remove_circle_outline</i>Fermeture du compte membre
-                                </h5>
-                                <p>Attention, vous êtes sur le point de fermer le compte du membre.</p>
-                                <ul>
-                                    {% if use_fly_and_fixed %}
-                                        <li>Ce membre a {{ period_positions | length }} créneau{% if period_positions | length > 1 %}x{% endif %} fixe.</li>
-                                    {% endif %}
-                                    <li>Ce membre a {{ in_progress_and_upcoming_shifts | length }} créneau{% if in_progress_and_upcoming_shifts | length > 1 %}x{% endif %} réservé à venir.</li>
-                                </ul>
-                            </div>
-                            <div class="modal-footer">
-                                <a href="#!" class="modal-action modal-close waves-effect waves-green btn-flat green-text">Retour à la raison</a>
-                                <button type="submit" class="btn waves-effect waves-light orange">
-                                    <i class="material-icons left">check</i>Je sais ce que je fais !
-                                </button>
-                            </div>
-                        </div>
-                        {{ form_end(close_form) }}
-                    {% else %}
-                        {% if member.withdrawnDate %}
-                            <p>
-                                Compte fermé le <i>{{ member.withdrawnDate | date_fr }}</i>
-                                {% if member.withdrawnBy %}
-                                    par {% include "admin/member/_partial/member_or_user_link.html.twig" with { user: member.withdrawnBy, target_blank: true } %}.
-                                {% endif %}
-                            </p>
-                        {% endif %}
-                        <a href="#open-member-confirmation-modal" class="modal-trigger waves-effect waves-light btn teal">
-                            <i class="material-icons left">check</i>Ré-ouvrir le compte
-                        </a>
-                        {{ form_start(open_form) }}
-                        <div id="open-member-confirmation-modal" class="modal">
-                            <div class="modal-content">
-                                <h5>
-                                    <i class="material-icons left small">info_outline</i>Ré-ouverture du compte membre
-                                </h5>
-                                <p>Attention, vous êtes sur le point de ré-ouvrir le compte du membre.</p>
-                            </div>
-                            <div class="modal-footer">
-                                <a href="#!" class="modal-action modal-close waves-effect waves-green btn-flat green-text">Retour à la raison</a>
-                                <button type="submit" class="btn waves-effect waves-light orange">
-                                    <i class="material-icons left">check</i>Je sais ce que je fais !
-                                </button>
-                            </div>
-                        </div>
-                        {{ form_end(open_form) }}
-                    {% endif %}
-                </div>
-            </li>
-        {% endif %}
-
         <!-- Rôles -->
         {% if is_granted("ROLE_ADMIN") %}
             <li id="super">
@@ -346,6 +280,53 @@
             </li>
         {% endif %}
     </ul>
+
+    <div id="withdrawn-member-confirmation-modal" class="modal">
+        <div class="modal-content">
+            <h5>
+                <i class="material-icons left small">remove_circle_outline</i>{% if member.withdrawn %}Ré-ouverture{% else %}Fermeture{% endif %} du compte membre
+            </h5>
+            <p>Attention, vous êtes sur le point de {% if member.withdrawn %}ré-ouvrir{% else %}fermer{% endif %} le compte du membre.</p>
+            {% if not member.withdrawn %}
+            <ul>
+                {% if use_fly_and_fixed %}
+                    <li>Ce membre a {{ period_positions | length }} créneau{% if period_positions | length > 1 %}x{% endif %} fixe.</li>
+                {% endif %}
+                <li>Ce membre a {{ in_progress_and_upcoming_shifts | length }} créneau{% if in_progress_and_upcoming_shifts | length > 1 %}x{% endif %} réservé à venir.</li>
+            </ul>
+            {% endif %}
+        </div>
+        <div class="modal-footer">
+            {{ form_start(withdrawn_form) }}
+            <a href="#!" class="modal-action modal-close waves-effect waves-green btn-flat green-text">Retour à la raison</a>
+            <button type="submit" class="btn waves-effect waves-light orange">
+                <i class="material-icons left">check</i>Je sais ce que je fais !
+            </button>
+            {{ form_end(withdrawn_form) }}
+        </div>
+    </div>
+
+    <div id="flying-member-confirmation-modal" class="modal">
+        <div class="modal-content">
+            <h5>
+                <i class="material-icons left small">remove_circle_outline</i>Passage du compte en {% if member.flying %}fixe{% else %}volant{% endif %}
+            </h5>
+            <p>Attention, vous êtes sur le point de passer le compte du membre en {% if member.flying %}fixe{% else %}volant{% endif %}.</p>
+            {% if not member.flying %}
+            <ul>
+                <li>Ce membre a {{ period_positions | length }} créneau{% if period_positions | length > 1 %}x{% endif %} fixe.</li>
+            </ul>
+            {% endif %}
+        </div>
+        <div class="modal-footer">
+            {{ form_start(flying_form) }}
+            <a href="#!" class="modal-action modal-close waves-effect waves-green btn-flat green-text">Retour à la raison</a>
+            <button type="submit" class="btn waves-effect waves-light orange">
+                <i class="material-icons left">check</i>OK
+            </button>
+            {{ form_end(flying_form) }}
+        </div>
+    </div>
 {% endblock %}
 
 {% block javascripts %}

--- a/app/Resources/views/member/show.html.twig
+++ b/app/Resources/views/member/show.html.twig
@@ -46,6 +46,7 @@
         </ul>
     {% endif %}
 
+    <!-- Collapsible "informations" -->
     <ul class="collapsible collapsible-expandable">
         <!-- Adhésion(s) -->
         <li id="registration">
@@ -128,6 +129,49 @@
                 </div>
                 <div class="collapsible-body white">
                     {% include "member/_partial/swipe_cards.html.twig" with { member: member } %}
+                </div>
+            </li>
+        {% endif %}
+    </ul>
+
+    <!-- Collapsible "actions" -->
+    <ul class="collapsible collapsible-expandable">
+        
+        <!-- Passer fixe ou volant -->
+        {% if use_fly_and_fixed and not member.withdrawn and is_granted("ROLE_USER_MANAGER") and is_granted("flying",member) %}
+            <li id="flying">
+                <div class="collapsible-header {% if frontend_cookie and frontend_cookie.user_show is defined and frontend_cookie.user_show.flying_open is defined and frontend_cookie.user_show.flying_open %}active{% endif %}">
+                    <i class="material-icons">{{ member_flying_material_icon }}</i>Passer en {% if member.flying %}fixe{% else %}volant{% endif %}
+                </div>
+                <div class="collapsible-body white">
+                    <a href="#flying-member-confirmation-modal" class="modal-trigger waves-effect waves-light btn btn-small teal">
+                        {% if not member.flying %}
+                            <i class="material-icons left">cached</i><span class="hide-on-med-and-down">Passer en</span> volant
+                        {% else %}
+                            <i class="material-icons left">cached</i><span class="hide-on-med-and-down">Passer en</span> fixe
+                        {% endif %}
+                    </a>
+                    <div id="flying-member-confirmation-modal" class="modal">
+                        <div class="modal-content">
+                            <h5>
+                                <i class="material-icons left small">remove_circle_outline</i>Passage du compte en {% if member.flying %}fixe{% else %}volant{% endif %}
+                            </h5>
+                            <p>Attention, vous êtes sur le point de passer le compte du membre en {% if member.flying %}fixe{% else %}volant{% endif %}.</p>
+                            {% if not member.flying %}
+                            <ul>
+                                <li>Ce membre a {{ period_positions | length }} créneau{% if period_positions | length > 1 %}x{% endif %} fixe.</li>
+                            </ul>
+                            {% endif %}
+                        </div>
+                        <div class="modal-footer">
+                            {{ form_start(flying_form) }}
+                            <a href="#!" class="modal-action modal-close waves-effect waves-green btn-flat green-text">Retour à la raison</a>
+                            <button type="submit" class="btn waves-effect waves-light orange">
+                                <i class="material-icons left">check</i>OK
+                            </button>
+                            {{ form_end(flying_form) }}
+                        </div>
+                    </div>
                 </div>
             </li>
         {% endif %}
@@ -219,6 +263,55 @@
             </li>
         {% endif %}
 
+        <!-- Fermer le compte -->
+        {% if is_granted("ROLE_USER_MANAGER") and ((member.withdrawn and is_granted("open",member)) or (not member.withdrawn and is_granted("close",member))) %}
+        <li id="close">
+            <div class="collapsible-header {% if frontend_cookie and frontend_cookie.user_show is defined and frontend_cookie.user_show.close_open is defined and frontend_cookie.user_show.close_open %}active{% endif %}">
+                <i class="material-icons">{{ member_withdrawn_material_icon }}</i>{% if member.withdrawn %}Ré-ouvrir le compte{% else %}Fermer le compte{% endif %}
+            </div>
+            <div class="collapsible-body white">
+                {% if not member.withdrawn %}
+                    <a href="#withdrawn-member-confirmation-modal" class="modal-trigger waves-effect waves-light btn btn-small {% if not member.withdrawn %}red{% else %}teal{% endif %}">
+                        {% if not member.withdrawn %}
+                            <i class="material-icons left">{{ member_withdrawn_material_icon }}</i>Fermer <span class="hide-on-med-and-down">le compte</span>
+                        {% else %}
+                            <i class="material-icons left">check</i>Ré-ouvrir <span class="hide-on-med-and-down">le compte</span>
+                        {% endif %}
+                    </a>
+                    <div id="withdrawn-member-confirmation-modal" class="modal">
+                        <div class="modal-content">
+                            <h5>
+                                <i class="material-icons left small">remove_circle_outline</i>{% if member.withdrawn %}Ré-ouverture{% else %}Fermeture{% endif %} du compte membre
+                            </h5>
+                            <p>Attention, vous êtes sur le point de {% if member.withdrawn %}ré-ouvrir{% else %}fermer{% endif %} le compte du membre.</p>
+                            {% if not member.withdrawn %}
+                            <ul>
+                                {% if use_fly_and_fixed %}
+                                    <li>Ce membre a {{ period_positions | length }} créneau{% if period_positions | length > 1 %}x{% endif %} fixe.</li>
+                                {% endif %}
+                                <li>Ce membre a {{ in_progress_and_upcoming_shifts | length }} créneau{% if in_progress_and_upcoming_shifts | length > 1 %}x{% endif %} réservé à venir.</li>
+                            </ul>
+                            {% endif %}
+                        </div>
+                        <div class="modal-footer">
+                            {{ form_start(withdrawn_form) }}
+                            <a href="#!" class="modal-action modal-close waves-effect waves-green btn-flat green-text">Retour à la raison</a>
+                            <button type="submit" class="btn waves-effect waves-light orange">
+                                <i class="material-icons left">check</i>Je sais ce que je fais !
+                            </button>
+                            {{ form_end(withdrawn_form) }}
+                        </div>
+                    </div>
+                {% elseif member.withdrawnDate %}
+                    Compte fermé le <i>{{ member.withdrawnDate | date_fr }}</i>
+                    {% if member.withdrawnBy %}
+                        par {% include "admin/member/_partial/member_or_user_link.html.twig" with { user: member.withdrawnBy, target_blank: true } %}.
+                    {% endif %}
+                {% endif %}
+            </div>
+        </li>
+        {% endif %}
+
         <!-- Rôles -->
         {% if is_granted("ROLE_ADMIN") %}
             <li id="super">
@@ -279,54 +372,7 @@
                 </div>
             </li>
         {% endif %}
-    </ul>
-
-    <div id="withdrawn-member-confirmation-modal" class="modal">
-        <div class="modal-content">
-            <h5>
-                <i class="material-icons left small">remove_circle_outline</i>{% if member.withdrawn %}Ré-ouverture{% else %}Fermeture{% endif %} du compte membre
-            </h5>
-            <p>Attention, vous êtes sur le point de {% if member.withdrawn %}ré-ouvrir{% else %}fermer{% endif %} le compte du membre.</p>
-            {% if not member.withdrawn %}
-            <ul>
-                {% if use_fly_and_fixed %}
-                    <li>Ce membre a {{ period_positions | length }} créneau{% if period_positions | length > 1 %}x{% endif %} fixe.</li>
-                {% endif %}
-                <li>Ce membre a {{ in_progress_and_upcoming_shifts | length }} créneau{% if in_progress_and_upcoming_shifts | length > 1 %}x{% endif %} réservé à venir.</li>
-            </ul>
-            {% endif %}
-        </div>
-        <div class="modal-footer">
-            {{ form_start(withdrawn_form) }}
-            <a href="#!" class="modal-action modal-close waves-effect waves-green btn-flat green-text">Retour à la raison</a>
-            <button type="submit" class="btn waves-effect waves-light orange">
-                <i class="material-icons left">check</i>Je sais ce que je fais !
-            </button>
-            {{ form_end(withdrawn_form) }}
-        </div>
-    </div>
-
-    <div id="flying-member-confirmation-modal" class="modal">
-        <div class="modal-content">
-            <h5>
-                <i class="material-icons left small">remove_circle_outline</i>Passage du compte en {% if member.flying %}fixe{% else %}volant{% endif %}
-            </h5>
-            <p>Attention, vous êtes sur le point de passer le compte du membre en {% if member.flying %}fixe{% else %}volant{% endif %}.</p>
-            {% if not member.flying %}
-            <ul>
-                <li>Ce membre a {{ period_positions | length }} créneau{% if period_positions | length > 1 %}x{% endif %} fixe.</li>
-            </ul>
-            {% endif %}
-        </div>
-        <div class="modal-footer">
-            {{ form_start(flying_form) }}
-            <a href="#!" class="modal-action modal-close waves-effect waves-green btn-flat green-text">Retour à la raison</a>
-            <button type="submit" class="btn waves-effect waves-light orange">
-                <i class="material-icons left">check</i>OK
-            </button>
-            {{ form_end(flying_form) }}
-        </div>
-    </div>
+    </ul> 
 {% endblock %}
 
 {% block javascripts %}

--- a/app/Resources/views/period/_partial/position_shifter_display.html.twig
+++ b/app/Resources/views/period/_partial/position_shifter_display.html.twig
@@ -17,7 +17,7 @@
             Réservé
         </div>
     {% else %}
-        {% set warning = beneficiary_service.hasWarningStatus(shifter) %}
+        {% set warning = membership_service.hasWarningStatus(shifter.membership) %}
         <a href="{{ path('member_show', { 'member_number': shifter.membership.memberNumber }) }}" target="_blank"
            class="black-text tooltipped editable-box truncate" data-position="bottom"
            data-tooltip="{{ shifter | print_with_number_and_status_icon | raw }} &#013;&#010; ({{ formation }})">

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -83,13 +83,14 @@ twig:
     member_exempted_icon: '%member_exempted_icon%'
     member_exempted_material_icon: '%member_exempted_material_icon%'
     member_exempted_background_color: '%member_exempted_background_color%'
+    member_flying_icon: '%member_flying_icon%'
+    member_flying_material_icon: '%member_flying_material_icon%'
     member_registration_missing_icon: '%member_registration_missing_icon%'
     member_registration_missing_material_icon: '%member_registration_missing_material_icon%'
     member_registration_missing_background_color: '%member_registration_missing_background_color%'
     # beneficiary
     beneficiary_main_icon: '%beneficiary_main_icon%'
     beneficiary_new_icon: '%beneficiary_new_icon%'
-    beneficiary_flying_icon: '%beneficiary_flying_icon%'
     # admin: member
     admin_member_display_shift_free_log: '%admin_member_display_shift_free_log%'
     admin_member_display_period_position_free_log: '%admin_member_display_period_position_free_log%'

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -146,6 +146,8 @@ parameters:
     member_exempted_icon: '☂'
     member_exempted_material_icon: 'beach_access'
     member_exempted_background_color: rgb(0, 150, 136, 0.1)
+    member_flying_icon: '✈'
+    member_flying_material_icon: 'flightsmode'
     member_registration_missing_icon: '$'
     member_registration_missing_material_icon: 'attach_money'
     member_registration_missing_background_color: rgb(0, 150, 136, 0.1)
@@ -153,7 +155,6 @@ parameters:
     # Beneficiary configuration
     beneficiary_main_icon: '⚐'
     beneficiary_new_icon: '★'
-    beneficiary_flying_icon: '✈'
 
     # Admin: member
     admin_member_display_shift_free_log: true

--- a/src/AppBundle/Command/ImportUsersCommand.php
+++ b/src/AppBundle/Command/ImportUsersCommand.php
@@ -168,7 +168,6 @@ class ImportUsersCommand extends CsvCommand
                         $dispatcher->dispatch(BeneficiaryCreatedEvent::NAME, new BeneficiaryCreatedEvent($beneficiary));
 
                         $beneficiary->setEmail($email);
-                        $beneficiary->setFlying(false);
 
                         $em->persist($beneficiary);
                     }

--- a/src/AppBundle/Command/ImportUsersCommand.php
+++ b/src/AppBundle/Command/ImportUsersCommand.php
@@ -143,6 +143,7 @@ class ImportUsersCommand extends CsvCommand
                             $membership = new Membership();
                             $output->writeln("<info>No Membership with number <fg=cyan>$member_number</> found, create one</info>",OutputInterface::VERBOSITY_DEBUG);
                             $membership->setMemberNumber($member_number);
+                            $membership->setFlying(false);
                             $membership->setWithdrawn(false);
                             $membership->setFrozen(false);
                             $membership->setFrozenChange(false);

--- a/src/AppBundle/Controller/BeneficiaryController.php
+++ b/src/AppBundle/Controller/BeneficiaryController.php
@@ -143,6 +143,7 @@ class BeneficiaryController extends Controller
                 $new_member->setMainBeneficiary($beneficiary);
             }
             // init other fields
+            $new_member->setFlying(false);
             $new_member->setWithdrawn(false);
             $new_member->setFrozen(false);
             $new_member->setFrozenChange(false);

--- a/src/AppBundle/Controller/MailController.php
+++ b/src/AppBundle/Controller/MailController.php
@@ -119,7 +119,6 @@ class MailController extends Controller
                 $user = $em->getRepository(User::class)->findOneBy(array('email' => $nonMember));
                 if (is_object($user)) {
                     $fake_beneficiary = new Beneficiary();
-                    $fake_beneficiary->setFlying(false);
                     $fake_beneficiary->setUser($user);
                     $fake_beneficiary->setFirstname($user->getUsername());
                     $fake_beneficiary->setLastname(' ');

--- a/src/AppBundle/Controller/MembershipController.php
+++ b/src/AppBundle/Controller/MembershipController.php
@@ -806,6 +806,7 @@ class MembershipController extends Controller
                 $member->removeRegistration($registration); //no registration yet
             }
 
+            $member->setFlying(false);
             $member->setWithdrawn(false);
             $member->setFrozen(false);
             $member->setFrozenChange(false);

--- a/src/AppBundle/Controller/NoteController.php
+++ b/src/AppBundle/Controller/NoteController.php
@@ -11,7 +11,6 @@ use AppBundle\Entity\Registration;
 use AppBundle\Entity\Shift;
 use AppBundle\Entity\TimeLog;
 use AppBundle\Entity\User;
-use AppBundle\Form\BeneficiaryType;
 use AppBundle\Form\NoteType;
 use Symfony\Component\Form\Form;
 use Symfony\Component\HttpFoundation\Session\Session;

--- a/src/AppBundle/Controller/RegistrationsController.php
+++ b/src/AppBundle/Controller/RegistrationsController.php
@@ -12,7 +12,6 @@ use AppBundle\Entity\Registration;
 use AppBundle\Entity\Formation;
 use AppBundle\Entity\User;
 use AppBundle\Event\HelloassoEvent;
-use AppBundle\Form\BeneficiaryType;
 use AppBundle\Form\RegistrationType;
 use Doctrine\ORM\Query\ResultSetMappingBuilder;
 use Doctrine\ORM\QueryBuilder;

--- a/src/AppBundle/Controller/UserController.php
+++ b/src/AppBundle/Controller/UserController.php
@@ -14,7 +14,6 @@ use AppBundle\Entity\User;
 use AppBundle\Event\AnonymousBeneficiaryCreatedEvent;
 use AppBundle\Event\AnonymousBeneficiaryRecallEvent;
 use AppBundle\Form\AnonymousBeneficiaryType;
-use AppBundle\Form\BeneficiaryType;
 use AppBundle\Form\NoteType;
 use AppBundle\Form\UserAdminType;
 use FOS\UserBundle\Event\UserEvent;

--- a/src/AppBundle/Entity/Beneficiary.php
+++ b/src/AppBundle/Entity/Beneficiary.php
@@ -60,13 +60,6 @@ class Beneficiary
     private $address;
 
     /**
-     * @var bool
-     *
-     * @ORM\Column(name="flying", type="boolean", options={"default" : 0}, nullable=false)
-     */
-    private $flying;
-
-    /**
      * @ORM\OneToOne(targetEntity="User", inversedBy="beneficiary", cascade={"persist", "remove"})
      * @ORM\JoinColumn(name="user_id", referencedColumnName="id",nullable=false)
      * @Assert\NotNull
@@ -656,20 +649,6 @@ class Beneficiary
     public function setAddress($address)
     {
         $this->address = $address;
-    }
-
-    /**
-     * @return bool
-     */
-    public function isFlying(): ?bool {
-        return $this->flying;
-    }
-
-    /**
-     * @param bool $flying
-     */
-    public function setFlying(?bool $flying): void {
-        $this->flying = $flying;
     }
 
     /**

--- a/src/AppBundle/Entity/Membership.php
+++ b/src/AppBundle/Entity/Membership.php
@@ -71,6 +71,13 @@ class Membership
     private $frozen_change;
 
     /**
+     * @var bool
+     *
+     * @ORM\Column(name="flying", type="boolean", options={"default" : 0}, nullable=false)
+     */
+    private $flying;
+
+    /**
      * @ORM\OneToMany(targetEntity="Registration", mappedBy="membership",cascade={"persist", "remove"})
      * @OrderBy({"date" = "DESC"})
      */
@@ -487,6 +494,20 @@ class Membership
     public function getFrozenChange()
     {
         return $this->frozen_change;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isFlying(): ?bool {
+        return $this->flying;
+    }
+
+    /**
+     * @param bool $flying
+     */
+    public function setFlying(?bool $flying): void {
+        $this->flying = $flying;
     }
 
     /**

--- a/src/AppBundle/Entity/Period.php
+++ b/src/AppBundle/Entity/Period.php
@@ -414,7 +414,7 @@ class Period
         return $positionsPerWeekCycle;
     }
 
-        /**
+    /**
      * Get periodPositions grouped per week cycle
      *
      * @param String|null $weekCycle a string of the week to keep or null if no filter
@@ -475,7 +475,7 @@ class Period
         foreach ($this->positions as $position) {
             if($shifter = $position->getShifter()){
                 if((($weekCycle && $position->getWeekCycle()==$weekCycle) or !$weekCycle)
-                    and ($shifter->isFlying()
+                    and ($shifter->getMembership()->isFlying()
                     or $shifter->getMembership()->isFrozen()
                     or $shifter->getMembership()->isWithdrawn())){
                     return true;

--- a/src/AppBundle/Form/BeneficiaryType.php
+++ b/src/AppBundle/Form/BeneficiaryType.php
@@ -66,14 +66,6 @@ class BeneficiaryType extends AbstractType
         $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) use ($user) {
             $form = $event->getForm();
             if (is_object($user)&&($user->hasRole('ROLE_USER_MANAGER') || $user->hasRole('ROLE_ADMIN') || $user->hasRole('ROLE_SUPER_ADMIN'))) {
-                $form->add('flying', ChoiceType::class, array(
-                    'choices'  => array(
-                        'Oui' => true,
-                        'Non' => false,
-                    ),
-                    'required' => true,
-                    'label' => 'Equipe volante'
-                ));
                 $form->add('commissions', EntityType::class, array(
                     'class' => 'AppBundle:Commission',
                     'choice_label' => 'name',

--- a/src/AppBundle/Security/MembershipVoter.php
+++ b/src/AppBundle/Security/MembershipVoter.php
@@ -20,6 +20,7 @@ class MembershipVoter extends Voter
     const CLOSE = 'close';
     const FREEZE = 'freeze';
     const FREEZE_CHANGE = 'freeze_change';
+    const FLYING = "flying";
     const ROLE_REMOVE = 'role_remove';
     const ROLE_ADD = 'role_add';
     const ANNOTATE = 'annotate';
@@ -46,6 +47,7 @@ class MembershipVoter extends Voter
                 self::ROLE_ADD,
                 self::FREEZE,
                 self::FREEZE_CHANGE,
+                self::FLYING,
                 self::CREATE,
                 self::ANNOTATE,
                 self::ACCESS_TOOLS,
@@ -103,6 +105,7 @@ class MembershipVoter extends Voter
             case self::ROLE_ADD:
             case self::ROLE_REMOVE:
             case self::EDIT:
+            case self::FLYING:
                 return $this->canEdit($subject, $token);
         }
 

--- a/src/AppBundle/Service/BeneficiaryService.php
+++ b/src/AppBundle/Service/BeneficiaryService.php
@@ -83,7 +83,7 @@ class BeneficiaryService
             $symbols[] = $this->container->getParameter('member_frozen_icon');
         }
         if ($beneficiary->getMembership()->isFlying()) {
-            $symbols[] = $this->container->getParameter('beneficiary_flying_icon');;
+            $symbols[] = $this->container->getParameter('member_flying_icon');;
         }
         if ($beneficiary->getMembership()->isCurrentlyExemptedFromShifts()) {
             $symbols[] = $this->container->getParameter('member_exempted_icon');

--- a/src/AppBundle/Service/BeneficiaryService.php
+++ b/src/AppBundle/Service/BeneficiaryService.php
@@ -65,20 +65,6 @@ class BeneficiaryService
     }
 
     /**
-     * Return true if the beneficiary is in a "warning" status
-     */
-    public function hasWarningStatus(Beneficiary $beneficiary): bool
-    {
-        $hasWarningStatus = $this->membershipService->hasWarningStatus($beneficiary->getMembership());
-
-        if ($this->container->getParameter('use_fly_and_fixed')) {
-            $hasWarningStatus = $hasWarningStatus || $beneficiary->isFlying();
-        }
-        
-        return $hasWarningStatus;
-    }
-
-    /**
      * Return a string with emoji between brackets depending on the
      * beneficiary status, if she/he is inactive (withdrawn), frozen or flying
      * or an empty string if none of those
@@ -96,7 +82,7 @@ class BeneficiaryService
         if ($beneficiary->getMembership()->getFrozen()) {
             $symbols[] = $this->container->getParameter('member_frozen_icon');
         }
-        if ($beneficiary->isFlying()) {
+        if ($beneficiary->getMembership()->isFlying()) {
             $symbols[] = $this->container->getParameter('beneficiary_flying_icon');;
         }
         if ($beneficiary->getMembership()->isCurrentlyExemptedFromShifts()) {

--- a/src/AppBundle/Service/MembershipService.php
+++ b/src/AppBundle/Service/MembershipService.php
@@ -194,10 +194,16 @@ class MembershipService
      */
     public function hasWarningStatus(Membership $member): bool
     {
-        return $member->getWithdrawn() ||
+        $hasWarningStatus = $member->getWithdrawn() ||
             $member->getFrozen() ||
             $member->isCurrentlyExemptedFromShifts() ||
             !$this->isUptodate($member);
+
+        if ($this->container->getParameter('use_fly_and_fixed')) {
+            $hasWarningStatus = $hasWarningStatus || $member->isFlying();
+        }
+
+        return $hasWarningStatus;
     }
 
     public function getShiftFreeLogs(Membership $member)

--- a/src/AppBundle/Service/MembershipService.php
+++ b/src/AppBundle/Service/MembershipService.php
@@ -20,6 +20,7 @@ class MembershipService
     protected $registration_duration;
     protected $registration_every_civil_year;
     protected $cycle_type;
+    protected $use_fly_and_fixed;
 
     public function __construct(ContainerInterface $container, EntityManagerInterface $em)
     {
@@ -27,6 +28,7 @@ class MembershipService
         $this->registration_duration = $container->getParameter('registration_duration');
         $this->registration_every_civil_year = $container->getParameter('registration_every_civil_year');
         $this->cycle_type = $container->getParameter('cycle_type');
+        $this->use_fly_and_fixed = $container->getParameter('use_fly_and_fixed');
     }
 
      /**
@@ -199,7 +201,7 @@ class MembershipService
             $member->isCurrentlyExemptedFromShifts() ||
             !$this->isUptodate($member);
 
-        if ($this->container->getParameter('use_fly_and_fixed')) {
+        if ($this->use_fly_and_fixed) {
             $hasWarningStatus = $hasWarningStatus || $member->isFlying();
         }
 

--- a/src/AppBundle/Service/SearchUserFormHelper.php
+++ b/src/AppBundle/Service/SearchUserFormHelper.php
@@ -635,7 +635,7 @@ class SearchUserFormHelper
 
         if ($this->use_fly_and_fixed) {
             if ($form->get('flying')->getData() > 0) {
-                $qb = $qb->andWhere('b.flying = :flying')
+                $qb = $qb->andWhere('m.flying = :flying')
                     ->setParameter('flying', $form->get('flying')->getData()-1);
             }
             if ($form->has('has_period_position')) {
@@ -711,7 +711,6 @@ class SearchUserFormHelper
                     ->setParameter('subQueryformations', $subQuery);
             }
         }
-
         return $qb;
     }
 }

--- a/src/AppBundle/Service/SearchUserFormHelper.php
+++ b/src/AppBundle/Service/SearchUserFormHelper.php
@@ -87,7 +87,7 @@ class SearchUserFormHelper
             }
             if ($this->use_fly_and_fixed) {
                 $formBuilder->add('flying', ChoiceType::class, [
-                    'label' => $this->container->getParameter('beneficiary_flying_icon') . ' volant',
+                    'label' => $this->container->getParameter('member_flying_icon') . ' volant',
                     'required' => false,
                     'choices' => [
                         'Oui' => 2,

--- a/src/AppBundle/Service/SearchUserFormHelper.php
+++ b/src/AppBundle/Service/SearchUserFormHelper.php
@@ -67,6 +67,14 @@ class SearchUserFormHelper
                     'Non exempté' => 1,
                 ]
             ]);
+            $formBuilder->add('has_first_shift_date', ChoiceType::class, [
+                'label' => 'créneau inscrit',
+                'required' => false,
+                'choices' => [
+                    'Oui' => 2,
+                    'Non (jamais inscrit à un créneau)' => 1,
+                ]
+            ]);
             if ($this->maximum_nb_of_beneficiaries_in_membership > 1) {
                 $formBuilder->add('beneficiary_count', ChoiceType::class, [
                     'label' => 'nb de bénéficiaires',
@@ -77,14 +85,25 @@ class SearchUserFormHelper
                     ]
                 ]);
             }
-            $formBuilder->add('has_first_shift_date', ChoiceType::class, [
-                'label' => 'créneau inscrit',
-                'required' => false,
-                'choices' => [
-                    'Oui' => 2,
-                    'Non (jamais inscrit à un créneau)' => 1,
-                ]
-            ]);
+            if ($this->use_fly_and_fixed) {
+                $formBuilder->add('flying', ChoiceType::class, [
+                    'label' => $this->container->getParameter('beneficiary_flying_icon') . ' volant',
+                    'required' => false,
+                    'choices' => [
+                        'Oui' => 2,
+                        'Non (fixe)' => 1,
+                    ],
+                ])
+                ->add('has_period_position', ChoiceType::class, [
+                    'label' => 'créneau fixe',
+                    'required' => false,
+                    'disabled' => in_array('has_period_position', $disabledFields) ? true : false,
+                    'choices' => [
+                        'Oui' => 2,
+                        'Non (pas de créneau fixe)' => 1,
+                    ]
+                ]);
+            }
         }
         $formBuilder->add('membernumber', TextType::class, [
             'label' => '# =',
@@ -199,26 +218,6 @@ class SearchUserFormHelper
                 'choices' => [
                     'Oui' => 2,
                     'Non (pas renseigné)' => 1,
-                ]
-            ]);
-        }
-        if ($this->use_fly_and_fixed) {
-            $formBuilder->add('flying', ChoiceType::class, [
-                'label' => $this->container->getParameter('beneficiary_flying_icon') . ' volant',
-                'required' => false,
-                'disabled' => in_array('flying', $disabledFields) ? true : false,
-                'choices' => [
-                    'Oui' => 2,
-                    'Non (fixe)' => 1,
-                ],
-            ])
-            ->add('has_period_position', ChoiceType::class, [
-                'label' => 'créneau fixe',
-                'required' => false,
-                'disabled' => in_array('has_period_position', $disabledFields) ? true : false,
-                'choices' => [
-                    'Oui' => 2,
-                    'Non (pas de créneau fixe)' => 1,
                 ]
             ]);
         }
@@ -711,6 +710,7 @@ class SearchUserFormHelper
                     ->setParameter('subQueryformations', $subQuery);
             }
         }
+
         return $qb;
     }
 }


### PR DESCRIPTION
PR identique à #918, ré-ouverte pour la faire passer dans une release dédiée (et pouvoir tester master avant / après)

### Quoi ?

Cette PR : 
- déplace la notion de volant du beneficiary vers le membership
- met à jour les status (affichage, warning)

Note : la migration du statut de volant de beneficiary vers le membership récupére le status du main beneficiary et l'applique au membership.

### Captures d'écran

||Image|
|---|---|
|Compte fixe|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/1d937a5d-cb4b-4e01-96ab-0c18de31edb0)|
|Compte volant|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/472f560a-700c-4bd7-a2c2-6f6f2699f61a)|
|Passer un compte en volant (ou fixe)|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/026cc9ff-2920-48b0-88c2-40c11f2115de)|