### PR TITLE
Evénements : pouvoir ajouter des liens dans le widget

### DIFF
--- a/app/Resources/views/admin/event/widget/generate.html.twig
+++ b/app/Resources/views/admin/event/widget/generate.html.twig
@@ -35,17 +35,18 @@
     </div>
 </div>
 <div class="row">
-    <div class="col s12">
-        {{ form.title.vars.label }}
-        <div class="switch">
-            <label>
-                masquer le titre
-                {{ form_widget(form.title) }}
-                <span class="lever"></span>
-                afficher le titre
-            </label>
-        </div>
-    </div>
+    {{ form_errors(form.title) }}
+    <label>
+        {{ form_widget(form.title) }}
+        <span>{{ form.title.vars.label }}</span>
+    </label>
+</div>
+<div class="row">
+    {{ form_errors(form.links) }}
+    <label>
+        {{ form_widget(form.links) }}
+        <span>{{ form.links.vars.label }}</span>
+    </label>
 </div>
 <br />
 {{ form_widget(form.generate, {'attr': {'class': 'btn waves-effect waves-light'}}) }}

--- a/app/Resources/views/event/_partial/widget.html.twig
+++ b/app/Resources/views/event/_partial/widget.html.twig
@@ -10,7 +10,8 @@
 <ul style="margin:0;">
     {% for event in events %}
         <li>
-            - <strong>{{ event.title }}</strong>
+            <span>-</span>
+            <strong>{% if links %}<a href="{{ path('event_detail', { 'id': event.id }) }}" target="_blank">{% endif %}{{ event.title }}{% if links %}</a>{% endif %}</strong>
             {{ event.date | date_fr_full_with_time }}
             {% if event.end %}<i>({{ event.duration }})</i>{% endif %}
             {# {% if not eventKind %}[{{ event.kind }}] {% endif %} #}

--- a/src/AppBundle/Controller/AdminEventController.php
+++ b/src/AppBundle/Controller/AdminEventController.php
@@ -430,16 +430,33 @@ class AdminEventController extends Controller
                 'multiple' => false,
                 'required' => false
             ))
-            ->add('date_max', TextType::class, array('label' => "Jusqu'à la date (incluse) ?", 'required' => false, 'attr' => array('class' => 'datepicker')))
-            ->add('limit', IntegerType::class, array('label' => "Nombre maximum d'événements à afficher ?", 'scale' => 0, 'required' => false))
-            ->add('title', CheckboxType::class, array('label' => 'Afficher le titre du widget ?', 'data' => true, 'required' => false))
+            ->add('date_max', TextType::class, array(
+                'label' => "Jusqu'à la date (incluse) ?",
+                'required' => false,
+                'attr' => array('class' => 'datepicker')
+            ))
+            ->add('limit', IntegerType::class, array(
+                'label' => "Nombre maximum d'événements à afficher ?",
+                'scale' => 0,
+                'required' => false
+            ))
+            ->add('title', CheckboxType::class, array(
+                'label' => 'Afficher le titre du widget ?',
+                'data' => false,
+                'required' => false
+            ))
+            ->add('links', CheckboxType::class, array(
+                'label' => 'Afficher un lien vers l\'événement ?',
+                'data' => false,
+                'required' => false
+            ))
             ->add('generate', SubmitType::class, array('label' => 'Générer'))
             ->getForm();
 
         if ($form->handleRequest($request)->isValid()) {
             $data = $form->getData();
 
-            $widgetQueryString = 'event_kind_id=' . ($data['kind'] ? $data['kind']->getId() : '') . '&date_max=' . ($data['date_max'] ? $data['date_max'] : '') . '&limit=' . ($data['limit'] ? $data['limit'] : '') . '&title=' . ($data['title'] ? 1 : 0);
+            $widgetQueryString = 'event_kind_id=' . ($data['kind'] ? $data['kind']->getId() : '') . '&date_max=' . ($data['date_max'] ? $data['date_max'] : '') . '&limit=' . ($data['limit'] ? $data['limit'] : '') . '&title=' . ($data['title'] ? 1 : 0) . '&links=' . ($data['links'] ? 1 : 0);
 
             return $this->render('admin/event/widget/generate.html.twig', array(
                 'query_string' => $widgetQueryString,

--- a/src/AppBundle/Controller/AdminOpeningHourController.php
+++ b/src/AppBundle/Controller/AdminOpeningHourController.php
@@ -144,7 +144,11 @@ class AdminOpeningHourController extends Controller
     public function widgetGeneratorAction(Request $request)
     {
         $form = $this->createFormBuilder()
-            ->add('title', CheckboxType::class, array('required' => false, 'data' => true, 'label' => 'Afficher le titre du widget ?'))
+            ->add('title', CheckboxType::class, array(
+                'required' => false,
+                'data' => true,
+                'label' => 'Afficher le titre du widget ?'
+            ))
             ->add('align', ChoiceType::class, array(
                 'label' => 'Alignement',
                 'choices'  => array('centré' => 'center', 'gauche' => 'left'),
@@ -156,7 +160,7 @@ class AdminOpeningHourController extends Controller
         if ($form->handleRequest($request)->isValid()) {
             $data = $form->getData();
 
-            $widgetQueryString = 'title='.($data['title'] ? 1 : 0) . '&align=' . $data['align'];
+            $widgetQueryString = 'title=' . ($data['title'] ? 1 : 0) . '&align=' . $data['align'];
 
             return $this->render('admin/openinghour/widget_generator.html.twig', array(
                 'query_string' => $widgetQueryString,

--- a/src/AppBundle/Controller/EventController.php
+++ b/src/AppBundle/Controller/EventController.php
@@ -34,8 +34,8 @@ class EventController extends Controller
         $eventKind = null;
         $eventDateMax = null;
 
-        $filter_title = $request->query->has('title') ? ($request->get('title') == 1) : true;
-        $filter_links = $request->query->has('links') ? ($request->get('links') == 1) : true;
+        $filter_title = $request->query->has('title') ? ($request->get('title') == 1) : false;
+        $filter_links = $request->query->has('links') ? ($request->get('links') == 1) : false;
         $filter_date_max = $request->query->has('date_max') ? ($request->get('date_max') ? new DateTime($request->get('date_max')) : null) : null;
         if ($filter_date_max) {
             $eventDateMax = clone($filter_date_max);

--- a/src/AppBundle/Controller/EventController.php
+++ b/src/AppBundle/Controller/EventController.php
@@ -34,13 +34,14 @@ class EventController extends Controller
         $eventKind = null;
         $eventDateMax = null;
 
+        $filter_title = $request->query->has('title') ? ($request->get('title') == 1) : true;
+        $filter_links = $request->query->has('links') ? ($request->get('links') == 1) : true;
         $filter_date_max = $request->query->has('date_max') ? ($request->get('date_max') ? new DateTime($request->get('date_max')) : null) : null;
         if ($filter_date_max) {
             $eventDateMax = clone($filter_date_max);
             $eventDateMax->modify('+1 day');  // also return events happening on max date
         }
         $filter_limit = $request->query->has('limit') ? ($request->get('limit') ? $request->get('limit') : null) : null;
-        $filter_title = $request->query->has('title') ? ($request->get('title') == 1) : true;
 
         $filter_event_kind_id = $request->get('event_kind_id');
         if ($filter_event_kind_id) {
@@ -52,8 +53,9 @@ class EventController extends Controller
         return $this->render('event/_partial/widget.html.twig', [
             'events' => $events,
             'eventKind' => $eventKind,
+            'title' => $filter_title,
+            'links' => $filter_links,
             'maxDate' => $filter_date_max,
-            'title' => $filter_title
         ]);
     }
 


### PR DESCRIPTION
### Quoi ?

Nouveau champ dans le formulaire de création de widget, permettant d'afficher le titre des événements sous forme de liens

### Captures d'écran

|Sans lien|Avec lien|
|---|---|
|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/629f2ac9-e6ff-46c1-b066-af6b2b933631)|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/6acd21e0-4fe9-40dc-be12-e9314b8fa376)|