### PR TITLE
Période : améliorer encore l'affichage lorsque cycle_type n'est pas défini

### DIFF
--- a/app/DoctrineMigrations/Version20230823170329_period_position_weekcycle_allow_null.php
+++ b/app/DoctrineMigrations/Version20230823170329_period_position_weekcycle_allow_null.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20230823170329 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE period_position CHANGE week_cycle week_cycle VARCHAR(1) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE period_position CHANGE week_cycle week_cycle VARCHAR(1) CHARACTER SET utf8mb4 NOT NULL COLLATE `utf8mb4_unicode_ci`');
+    }
+}

--- a/app/Resources/views/admin/period/edit.html.twig
+++ b/app/Resources/views/admin/period/edit.html.twig
@@ -36,116 +36,19 @@
 
     <h5>Postes disponibles</h5>
 
-    {% if use_fly_and_fixed %}
-        {% if (period.positionsperweekcycle | length == 0) %}
-            Aucun poste n'existe pour ce créneau
-        {% endif %}
-        {% for week, positions in period.positionsperweekcycle %}
-            {% if cycle_type == 'abcd' %}
-                <h6>Semaine {{ week }}</h6>
-            {% endif %}
-            <ul class="collapsible">
-                {% for position in positions %}
-                    {% if position.shifter %}
-                        <li id="position{{ position.id }}">
-                            <div class="collapsible-header">
-                                <div class="col s12">
-                                    {% if position.formation %}<b data-formation="{{ position.formation.name }}">{% endif %}
-                                    {{ position.shifter.displayNameWithMemberNumber }}
-                                    {% if position.formation %}</b>&nbsp;({{ position.formation.name }}){% endif %}
-                                    {% if not position.formation and position.shifter.formations | length > 0 %}
-                                        &nbsp;<b class="orange-text">({{ position.shifter.formations | join(', ') }})</b>
-                                    {% endif %}
-                                    {% if position.shifter.isNew %}
-                                        &nbsp;<strong class="red-text" title="Nouveau membre">{{ beneficiary_new_icon }}</strong>
-                                    {% endif %}
-                                </div>
-                            </div>
-                            <div class="collapsible-body">
-                                <p>
-                                    Créneau fixe réservé
-                                    pour <a href="{{ path("member_show", { 'member_number': position.shifter.membership.memberNumber }) }}" target="_blank">{{ position.shifter }}</a>
-                                    le <i>{{ position.bookedTime | date_fr_full_with_time }}</i>
-                                    par {% include "admin/member/_partial/member_or_user_link.html.twig" with { user: position.booker, target_blank: true } %}.
-                                </p>
-                                {{ form_start(positions_free_forms[position.id]) }}
-                                {{ form_widget(positions_free_forms[position.id]) }}
-                                <a href="#" class="btn waves-effect waves-light orange" onclick="var r = confirm('Etes-vous sûr de vouloir libérer ce poste ?!'); if (r == true) {$(this).closest('form').submit();}; event.stopPropagation();" title="Libérer ce poste">
-                                    <i class="material-icons left">lock_open</i>Libérer
-                                </a>
-                                {{ form_end(positions_free_forms[position.id]) }}
-                            </div>
-                        </li>
-                    {% else %}
-                        <li id="position{{ position.id }}">
-                            <div class="collapsible-header">
-                                <div class="row" style="margin-bottom: 0; width: 100%;">
-                                    <div class="col s12">
-                                        <b>
-                                            <span style="font-style: italic">libre</span>
-                                        </b>
-                                        {% if position.formation %}
-                                            &nbsp;({{ position.formation.name }})
-                                        {% else %}
-                                            &nbsp;(sans formation particulière)
-                                        {% endif %}
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="collapsible-body">
-                                {{ form_start(positions_book_forms[position.id]) }}
-                                <div class="row">
-                                    <div class="col s7 input-field">
-                                        {{ form_label(positions_book_forms[position.id].shifter) }}
-                                        {{ form_errors(positions_book_forms[position.id].shifter) }}
-                                        {{ form_widget(positions_book_forms[position.id].shifter) }}
-                                    </div>
-                                    <div class="col s3">
-                                        <button type="submit" class="btn waves-effect waves-light">
-                                            <i class="material-icons left">add</i>Ajouter
-                                        </button>
-                                    </div>
-                                </div>
-                                {{ form_end(positions_book_forms[position.id]) }}
-                                {% if is_granted("ROLE_ADMIN") %}
-                                    <div class="row">
-                                        {{ form_start(positions_delete_forms[position.id]) }}
-                                        {{ form_widget(positions_delete_forms[position.id]) }}
-                                        <a href="#" class="btn waves-effect waves-light red" onclick="var r = confirm('Etes-vous sûr de vouloir supprimer ce poste ?!'); if (r == true) {$(this).closest('form').submit();}; event.stopPropagation();" title="Supprimer ce poste">
-                                            <i class="material-icons left">delete</i>Supprimer
-                                        </a>
-                                        {{ form_end(positions_delete_forms[position.id]) }}
-                                    </div>
-                                {% endif %}
-                                {% if position.createdBy %}
-                                    <p>
-                                        Poste type créé le <i>{{ position.createdAt | date_fr_full_with_time }}</i>
-                                        par {% include "admin/member/_partial/member_or_user_link.html.twig" with { user: position.createdBy, target_blank: true } %}.
-                                    </p>
-                                {% endif %}
-                            </div>
-                        </li>
-                    {% endif %}
-                {% endfor %}
-           </ul>
-        {% endfor %}
-    {% else %}
-        {% for week, positions in period.positionsperweekcycle %}
-            {% if cycle_type == 'abcd' %}
-                <h6>Semaine {{ week }}</h6>
-            {% endif %}
-            <ul>
-            {% for position in positions %}
-                <li>
-                    {{ form_start(positions_delete_forms[position.id]) }}
-                    {{ form_widget(positions_delete_forms[position.id]) }}
-                    {{ position }} <a href="#" onclick="$(this).closest('form').submit()" title="supprimer" class="red-text">&cross;</a>
-                    {{ form_end(positions_delete_forms[position.id]) }}
-                </li>
-            {% endfor %}
-            </ul>
-        {% endfor %}
+    {% if (period.positionsperweekcycle | length == 0) %}
+        Aucun poste n'existe pour ce créneau
     {% endif %}
+    {% for week, positions in period.positionsperweekcycle %}
+        {% if cycle_type == 'abcd' %}
+            <h6>Semaine {{ week }}</h6>
+        {% endif %}
+        <ul class="collapsible">
+            {% for position in positions %}
+                {% include "admin/periodposition/_partial/edit_collapsible.html.twig" with { position: position, position_free_form: positions_free_forms[position.id] ?? null, position_book_form: positions_book_forms[position.id] ?? null, position_delete_form: positions_delete_forms[position.id] ?? null } %}
+            {% endfor %}
+        </ul>
+    {% endfor %}
 
     <br />
     <h5>Actions supplémentaires</h5>

--- a/app/Resources/views/admin/period/edit.html.twig
+++ b/app/Resources/views/admin/period/edit.html.twig
@@ -131,7 +131,9 @@
         {% endfor %}
     {% else %}
         {% for week, positions in period.positionsperweekcycle %}
-            <h6>Semaine {{ week }}</h6>
+            {% if cycle_type == 'abcd' %}
+                <h6>Semaine {{ week }}</h6>
+            {% endif %}
             <ul>
             {% for position in positions %}
                 <li>

--- a/app/Resources/views/admin/periodposition/_partial/edit_collapsible.html.twig
+++ b/app/Resources/views/admin/periodposition/_partial/edit_collapsible.html.twig
@@ -1,0 +1,82 @@
+
+<li id="position{{ position.id }}">
+    <div class="collapsible-header">
+        <div class="row" style="margin-bottom: 0; width: 100%;">
+            <div class="col s12">
+                {% if use_fly_and_fixed %}
+                    {% if position.shifter %}
+                        {% if position.formation %}<b data-formation="{{ position.formation.name }}">{% endif %}
+                        {{ position.shifter.displayNameWithMemberNumber }}
+                        {% if position.formation %}</b>&nbsp;({{ position.formation.name }}){% endif %}
+                        {% if not position.formation and position.shifter.formations | length > 0 %}
+                            &nbsp;<b class="orange-text">({{ position.shifter.formations | join(', ') }})</b>
+                        {% endif %}
+                        {% if position.shifter.isNew %}
+                            &nbsp;<strong class="red-text" title="Nouveau membre">{{ beneficiary_new_icon }}</strong>
+                        {% endif %}
+                    {% else %}
+                        <strong style="font-style:italic">libre</strong>
+                        {% if position.formation %}
+                            &nbsp;({{ position.formation.name }})
+                        {% else %}
+                            &nbsp;(sans formation particulière)
+                        {% endif %}
+                    {% endif %}
+                {% else %}
+                    {{ position }}
+                {% endif %}
+            </div>
+        </div>
+    </div>
+    <div class="collapsible-body">
+        {% if use_fly_and_fixed %}
+            {% if position.shifter %}
+                <p>
+                    Créneau fixe réservé
+                    pour <a href="{{ path("member_show", { 'member_number': position.shifter.membership.memberNumber }) }}" target="_blank">{{ position.shifter }}</a>
+                    le <i>{{ position.bookedTime | date_fr_full_with_time }}</i>
+                    par {% include "admin/member/_partial/member_or_user_link.html.twig" with { user: position.booker, target_blank: true } %}.
+                </p>
+                {{ form_start(position_free_form) }}
+                {{ form_widget(position_free_form) }}
+                <a href="#" class="btn waves-effect waves-light orange" onclick="var r = confirm('Etes-vous sûr de vouloir libérer ce poste ?!'); if (r == true) {$(this).closest('form').submit();}; event.stopPropagation();" title="Libérer ce poste">
+                    <i class="material-icons left">lock_open</i>Libérer
+                </a>
+                {{ form_end(position_free_form) }}
+            {% else %}
+                {{ form_start(position_book_form) }}
+                <div class="row">
+                    <div class="col s7 input-field">
+                        {{ form_label(position_book_form.shifter) }}
+                        {{ form_errors(position_book_form.shifter) }}
+                        {{ form_widget(position_book_form.shifter) }}
+                    </div>
+                    <div class="col s3">
+                        <button type="submit" class="btn waves-effect waves-light">
+                            <i class="material-icons left">add</i>Ajouter
+                        </button>
+                    </div>
+                </div>
+                {{ form_end(position_book_form) }}
+            {% endif %}
+        {% endif %}
+        {% if not position.shifter %}
+            {% if is_granted("ROLE_ADMIN") %}
+                <div class="row">
+                    {{ form_start(position_delete_form) }}
+                    {{ form_widget(position_delete_form) }}
+                    <a href="#" class="btn waves-effect waves-light red" onclick="var r = confirm('Etes-vous sûr de vouloir supprimer ce poste ?!'); if (r == true) {$(this).closest('form').submit();}; event.stopPropagation();" title="Supprimer ce poste">
+                        <i class="material-icons left">delete</i>Supprimer
+                    </a>
+                    {{ form_end(position_delete_form) }}
+                </div>
+            {% endif %}
+        {% endif %}
+        {% if position.createdBy %}
+            <p>
+                Poste type créé le <i>{{ position.createdAt | date_fr_full_with_time }}</i>
+                par {% include "admin/member/_partial/member_or_user_link.html.twig" with { user: position.createdBy, target_blank: true } %}.
+            </p>
+        {% endif %}
+    </div>
+</li>

--- a/app/Resources/views/user/_partial/period_position_card.html.twig
+++ b/app/Resources/views/user/_partial/period_position_card.html.twig
@@ -3,7 +3,9 @@
         <span class="card-title">
             {{ period_position.period.dayOfWeekString }} de {{ period_position.period.start | date('G\\hi') }} à {{ period_position.period.end | date('G\\hi') }}
             <br />
-            <small>(Semaine {{ period_position.weekCycle }})</small>
+            {% if cycle_type == 'abcd' %}
+                <small>(Semaine {{ period_position.weekCycle }})</small>
+            {% endif %}
         </span>
         <p>
             <i class="material-icons">person</i>{{ period_position.shifter.firstname }}

--- a/src/AppBundle/Entity/PeriodPosition.php
+++ b/src/AppBundle/Entity/PeriodPosition.php
@@ -37,7 +37,7 @@ class PeriodPosition
 
     /**
      * @var string
-     * @ORM\Column(name="week_cycle", type="string", length=1, nullable=false)
+     * @ORM\Column(name="week_cycle", type="string", length=1, nullable=true)
      */
     private $weekCycle;
 
@@ -95,7 +95,10 @@ class PeriodPosition
      */
     public function __toString()
     {
-        $name = $this->getPeriod() . ' - Semaine ' . $this->getWeekCycle();
+        $name = (string) $this->getPeriod();
+        if ($this->getWeekCycle()) {
+            $name .= ' - Semaine ' . $this->getWeekCycle();
+        }
         if ($this->getFormation()) {
             $name .= ' (' . $this->getFormation()->getName() . ')';
         }

--- a/src/AppBundle/Form/PeriodPositionType.php
+++ b/src/AppBundle/Form/PeriodPositionType.php
@@ -33,7 +33,7 @@ class PeriodPositionType extends AbstractType
         $builder
             ->add('week_cycle', ChoiceType::class, array(
                 'label' => 'Cycle',
-                'choices' => ($this->cycle_type == 'abcd') ? Period::WEEK_CYCLE_CHOICE_LIST : [],
+                'choices' => ($this->cycle_type == "abcd") ? Period::WEEK_CYCLE_CHOICE_LIST : [],
                 'expanded' => false,
                 'multiple' => true,
                 // 'data' => ($this->cycle_type == 'abcd') ? null : [Period::WEEK_A]


### PR DESCRIPTION
Suite de #933

### Quoi ?

- migration pour rendre `PeriodPosition.weekCycle` nullable (dans le cas de `cyle_type: null`)
- cacher les endroits restants où "Semaine" s'affichait (Period edit en particulier)
- refactoring de PeriodPosition edit collapsible (pour avoir le même rendu partout)

### Captures d'écran

||Avant|Après|
|---|---|---|
|Period edit|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/47184f41-0d64-4a79-ac57-ae4228bc7db1)|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/0ec6ffbb-2ece-47d8-a688-5c9587576451)|