### PR TITLE
Materialize CSS : traduction du datepicker

### DIFF
--- a/app/Resources/views/admin/closingexception/new.html.twig
+++ b/app/Resources/views/admin/closingexception/new.html.twig
@@ -14,8 +14,9 @@
 
 {{ form_start(form) }}
 {% include "/admin/closingexception/_partial/form.html.twig" with { form: form } %}
-<div>
-    <button type="submit" class="btn waves-effect waves-light">Créer</button>
-</div>
+<button type="submit" class="btn waves-effect waves-light" title="Créer">
+    <i class="material-icons left">save</i>Créer</button>
 {{ form_end(form) }}
+
+<a href="{{ path('admin_closingexception_index') }}" class="btn waves-effect waves-light red" title="Annuler">Annuler</a>
 {% endblock %}

--- a/src/AppBundle/Resources/public/js/datepicker.js
+++ b/src/AppBundle/Resources/public/js/datepicker.js
@@ -1,21 +1,4 @@
 
-jQuery.extend(jQuery.fn.datepicker.defaults, {
-    monthsFull: [ 'Janvier', 'Février', 'Mars', 'Avril', 'Mai', 'Juin', 'Juillet', 'Août', 'Septembre', 'Octobre', 'Novembre', 'Décembre' ],
-    monthsShort: [ 'Jan', 'Fev', 'Mar', 'Avr', 'Mai', 'Juin', 'Juil', 'Aou', 'Sep', 'Oct', 'Nov', 'Dec' ],
-    weekdaysFull: [ 'Dimanche', 'Lundi', 'Mardi', 'Mercredi', 'Jeudi', 'Vendredi', 'Samedi' ],
-    weekdaysShort: [ 'Dim', 'Lun', 'Mar', 'Mer', 'Jeu', 'Ven', 'Sam' ],
-    today: 'Aujourd\'hui',
-    clear: 'Effacer',
-    close: 'Fermer',
-    firstDay: 1,
-    format: 'yyyy-mm-dd',
-    formatSubmit: 'yyyy-mm-dd',
-    labelMonthNext: 'Mois suivant',
-    labelMonthPrev: 'Mois précédent',
-    labelMonthSelect: 'Sélectionner un mois',
-    labelYearSelect: 'Sélectionner une année'
-});
-
 // https://materializeweb.com/pickers.html
 datepickerSettings = {
     format: 'yyyy-mm-dd',
@@ -24,6 +7,10 @@ datepickerSettings = {
         done: 'OK', // text for done-button
         clear: 'Effacer', // text for clear-button
         cancel: 'Annuler', // Text for cancel-button
+        months: ['Janvier', 'Février', 'Mars', 'Avril', 'Mai', 'Juin', 'Juillet', 'Août', 'Septembre', 'Octobre', 'Novembre', 'Décembre'],
+        monthsShort: ['Jan', 'Fev', 'Mar', 'Avr', 'Mai', 'Juin', 'Juil', 'Aou', 'Sep', 'Oct', 'Nov', 'Dec'],
+        weekdays: ['Dimanche', 'Lundi', 'Mardi', 'Mercredi', 'Jeudi', 'Vendredi', 'Samedi'],
+        weekdaysShort: ['Dim', 'Lun', 'Mar', 'Mer', 'Jeu', 'Ven', 'Sam'],
     },
     autoClose: true // Close upon selecting a date
 }


### PR DESCRIPTION
### Quoi ?

Mise à jour des traductions en français du datepicker

https://materializeweb.com/pickers.html

### Captures d'écran

|Avant|Après|
|---|---|
|![Screenshot from 2023-08-25 18-50-59](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/a8159cb0-8d01-4107-ae5d-5e0289c63db3)|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/322ccdc9-bfef-4799-afb8-0161fdcf4487)|