### PR TITLE
Membre (coté admin) : nouvelle section "informations diverses"

### DIFF
--- a/app/Resources/views/member/_partial/info_misc.html.twig
+++ b/app/Resources/views/member/_partial/info_misc.html.twig
@@ -1,0 +1,3 @@
+<p style="margin-top:0">Date de création du compte-membre : {{ member.createdAt | date_fr_full }}</p>
+
+<p>Date du tout premier créneau : {% if member.firstShiftDate %}{{ member.firstShiftDate | date_fr_full }}{% else %}Néant{% endif %}</p>

--- a/app/Resources/views/member/_partial/shifts.html.twig
+++ b/app/Resources/views/member/_partial/shifts.html.twig
@@ -1,5 +1,3 @@
-{% set firstShiftDate = member.firstShiftDate %}
-
 {% if member.isCurrentlyExemptedFromShifts() %}
     {% include "member/_partial/exempted.html.twig" with { member: member, from_admin: true } %}
 {% endif %}
@@ -42,5 +40,3 @@
         {% endif %}
     </div>
 {% endfor %}
-
-<p>Date du tout premier créneau : {% if firstShiftDate %}{{ firstShiftDate | date_fr_full }}{% else %}Néant{% endif %}</p>

--- a/app/Resources/views/member/show.html.twig
+++ b/app/Resources/views/member/show.html.twig
@@ -387,7 +387,7 @@
                     <i class="material-icons">verified_user</i>Rôles
                 </div>
                 <div class="collapsible-body white">
-                    {% include "member/_partial/roles.html.twig" %}
+                    {% include "member/_partial/roles.html.twig" with { member: member } %}
                 </div>
             </li>
         {% endif %}
@@ -425,6 +425,18 @@
                     {{ form_end(delete_form) }}
 
                     {% include "member/_partial/recorded_registrations.html.twig" %}
+                </div>
+            </li>
+        {% endif %}
+
+        <!-- Informations sur le membre -->
+        {% if is_granted("ROLE_USER_MANAGER") %}
+            <li id="super">
+                <div class="collapsible-header {% if frontend_cookie and frontend_cookie.user_show is defined and frontend_cookie.user_show.admin_open is defined and frontend_cookie.user_show.info_open %}active{% endif %}">
+                    <i class="material-icons">info_outline</i>Informations diverses
+                </div>
+                <div class="collapsible-body white">
+                    {% include "member/_partial/info_misc.html.twig" with { member: member } %}
                 </div>
             </li>
         {% endif %}


### PR DESCRIPTION
### Quoi ?

Dans la page admin d'un membre, nouvelle section pour y mettre des informations diverses liées au compte-membre.

### Pourquoi ?

- rendre visible la date de création du compte-membre
- y mettre la date de premier créneau, et peut-être d'autres informations futures

### Capture d'écran

![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/e56d3e84-b5a7-4485-9d5a-15ab7baeb785)
