### PR TITLE
Profile : afficher la section Adhésion

### DIFF
--- a/app/Resources/views/Profile/show_content.html.twig
+++ b/app/Resources/views/Profile/show_content.html.twig
@@ -19,6 +19,15 @@
             </div>
         </li>
 
+        <li>
+            <div class="collapsible-header">
+                <i class="material-icons">card_membership</i>Adhésions
+            </div>
+            <div class="collapsible-body">
+                {% include "member/_partial/registrations.html.twig" with { member: beneficiary.membership } %}
+            </div>
+        </li>
+
         {% if profile_display_time_log %}
             <li>
                 <div class="collapsible-header">

--- a/app/Resources/views/beneficiary/_partial/info.html.twig
+++ b/app/Resources/views/beneficiary/_partial/info.html.twig
@@ -95,10 +95,4 @@
             {% endfor %}
         </div>
     {% endif %}
-    {% if beneficiary.membership.lastRegistration %}
-        <div class="col s12">
-            <i class="material-icons tiny">perm_contact_calendar</i>
-            <span>Adhésion du {{ beneficiary.membership.lastRegistration.date | date_fr_full }} au {{ beneficiary.membership | expire | date_fr_full }}</span>
-        </div>
-    {% endif %}
 </div>

--- a/app/Resources/views/member/_partial/registrations.html.twig
+++ b/app/Resources/views/member/_partial/registrations.html.twig
@@ -1,0 +1,51 @@
+{% if member.lastRegistration %}
+    <p style="margin-top:0">Adhésion du {{ member.lastRegistration.date | date_fr_full }} au {{ member | expire | date_fr_full }}</p>
+{% endif %}
+<ul class="collapsible">
+    {% for registration in member.registrations %}
+        <li>
+            <div class="collapsible-header" style="cursor: default;">
+                {% if registration.mode == constant('TYPE_CREDIT_CARD', registration) or registration.mode == constant('TYPE_HELLOASSO', registration) %}
+                    <i class="material-icons tiny">credit_card</i>
+                {% else %}
+                    <i class="material-icons tiny">attach_money</i>
+                {% endif %}
+                {{ registration.date | date_fr }}
+                {% if registration.mode == constant('TYPE_HELLOASSO', registration) %}
+                    <span class="badge right">Helloasso</span>
+                {% endif %}
+            </div>
+        </li>
+    {% endfor %}
+</ul>
+{% if member.mainBeneficiary and (member.mainBeneficiary.user != app.user) %}
+    {% if member | can_register %}
+        <ul class="collapsible">
+            <li>
+                {% if not member.lastRegistration %}
+                    <div class="collapsible-header"><i class="material-icons">add_circle</i>Adhésion</div>
+                {% else %}
+                    <div class="collapsible-header"><i class="material-icons">add_circle</i>Ré-adhésion</div>
+                {% endif %}
+                <div class="collapsible-body new_registration_form">
+                    {{ form_start(new_registration_form) }}
+                    {% include "user/_partial/registration_form.html.twig" with { form: new_registration_form } %}
+                    {{ form_end(new_registration_form) }}
+                </div>
+            </li>
+        </ul>
+    {% else %}
+        <ul class="collapsible">
+            <li>
+                {% if not member.lastRegistration %}
+                    <div class="collapsible-header"><i class="material-icons">add_circle</i>Adhésion</div>
+                {% else %}
+                    <div class="collapsible-header"><i class="material-icons">add_circle</i>Ré-adhésion</div>
+                {% endif %}
+                <div class="collapsible-body new_registration_form">
+                    Il est trop tôt pour ré-adhérer. Cette adhésion est valable encore {{ member | remainder | date('%a') }} jours.
+                </div>
+            </li>
+        </ul>
+    {% endif %}
+{% endif %}

--- a/app/Resources/views/member/_partial/registrations.html.twig
+++ b/app/Resources/views/member/_partial/registrations.html.twig
@@ -1,6 +1,9 @@
+{% set from_admin = from_admin ?? false %}
+
 {% if member.lastRegistration %}
     <p style="margin-top:0">Adhésion du {{ member.lastRegistration.date | date_fr_full }} au {{ member | expire | date_fr_full }}</p>
 {% endif %}
+
 <ul class="collapsible">
     {% for registration in member.registrations %}
         <li>
@@ -18,34 +21,37 @@
         </li>
     {% endfor %}
 </ul>
-{% if member.mainBeneficiary and (member.mainBeneficiary.user != app.user) %}
-    {% if member | can_register %}
-        <ul class="collapsible">
-            <li>
-                {% if not member.lastRegistration %}
-                    <div class="collapsible-header"><i class="material-icons">add_circle</i>Adhésion</div>
-                {% else %}
-                    <div class="collapsible-header"><i class="material-icons">add_circle</i>Ré-adhésion</div>
-                {% endif %}
-                <div class="collapsible-body new_registration_form">
-                    {{ form_start(new_registration_form) }}
-                    {% include "user/_partial/registration_form.html.twig" with { form: new_registration_form } %}
-                    {{ form_end(new_registration_form) }}
-                </div>
-            </li>
-        </ul>
-    {% else %}
-        <ul class="collapsible">
-            <li>
-                {% if not member.lastRegistration %}
-                    <div class="collapsible-header"><i class="material-icons">add_circle</i>Adhésion</div>
-                {% else %}
-                    <div class="collapsible-header"><i class="material-icons">add_circle</i>Ré-adhésion</div>
-                {% endif %}
-                <div class="collapsible-body new_registration_form">
-                    Il est trop tôt pour ré-adhérer. Cette adhésion est valable encore {{ member | remainder | date('%a') }} jours.
-                </div>
-            </li>
-        </ul>
+
+{% if from_admin %}
+    {% if member.mainBeneficiary and (member.mainBeneficiary.user != app.user) %}
+        {% if member | can_register %}
+            <ul class="collapsible">
+                <li>
+                    {% if not member.lastRegistration %}
+                        <div class="collapsible-header"><i class="material-icons">add_circle</i>Adhésion</div>
+                    {% else %}
+                        <div class="collapsible-header"><i class="material-icons">add_circle</i>Ré-adhésion</div>
+                    {% endif %}
+                    <div class="collapsible-body new_registration_form">
+                        {{ form_start(new_registration_form) }}
+                        {% include "user/_partial/registration_form.html.twig" with { form: new_registration_form } %}
+                        {{ form_end(new_registration_form) }}
+                    </div>
+                </li>
+            </ul>
+        {% else %}
+            <ul class="collapsible">
+                <li>
+                    {% if not member.lastRegistration %}
+                        <div class="collapsible-header"><i class="material-icons">add_circle</i>Adhésion</div>
+                    {% else %}
+                        <div class="collapsible-header"><i class="material-icons">add_circle</i>Ré-adhésion</div>
+                    {% endif %}
+                    <div class="collapsible-body new_registration_form">
+                        Il est trop tôt pour ré-adhérer. Cette adhésion est valable encore {{ member | remainder | date('%a') }} jours.
+                    </div>
+                </li>
+            </ul>
+        {% endif %}
     {% endif %}
 {% endif %}

--- a/app/Resources/views/member/show.html.twig
+++ b/app/Resources/views/member/show.html.twig
@@ -80,57 +80,7 @@
                 <i class="material-icons">card_membership</i>Adhésions
             </div>
             <div class="collapsible-body white">
-                {% if member.lastRegistration %}
-                    <p style="margin-top:0">Adhésion du {{ member.lastRegistration.date | date_fr_full }} au {{ member | expire | date_fr_full }}</p>
-                {% endif %}
-                <ul class="collapsible">
-                    {% for registration in member.registrations %}
-                        <li>
-                            <div class="collapsible-header" style="cursor: default;">
-                                {% if registration.mode == constant('TYPE_CREDIT_CARD', registration) or registration.mode == constant('TYPE_HELLOASSO', registration) %}
-                                    <i class="material-icons tiny">credit_card</i>
-                                {% else %}
-                                    <i class="material-icons tiny">attach_money</i>
-                                {% endif %}
-                                {{ registration.date | date_fr }}
-                                {% if registration.mode == constant('TYPE_HELLOASSO', registration) %}
-                                    <span class="badge right">Helloasso</span>
-                                {% endif %}
-                            </div>
-                        </li>
-                    {% endfor %}
-                </ul>
-                {% if member.mainBeneficiary and (member.mainBeneficiary.user != app.user) %}
-                    {% if member | can_register %}
-                        <ul class="collapsible">
-                            <li>
-                                {% if not member.lastRegistration %}
-                                    <div class="collapsible-header"><i class="material-icons">add_circle</i>Adhésion</div>
-                                {% else %}
-                                    <div class="collapsible-header"><i class="material-icons">add_circle</i>Ré-adhésion</div>
-                                {% endif %}
-                                <div class="collapsible-body new_registration_form">
-                                    {{ form_start(new_registration_form) }}
-                                    {% include "user/_partial/registration_form.html.twig" with { form: new_registration_form } %}
-                                    {{ form_end(new_registration_form) }}
-                                </div>
-                            </li>
-                        </ul>
-                    {% else %}
-                        <ul class="collapsible">
-                            <li>
-                                {% if not member.lastRegistration %}
-                                    <div class="collapsible-header"><i class="material-icons">add_circle</i>Adhésion</div>
-                                {% else %}
-                                    <div class="collapsible-header"><i class="material-icons">add_circle</i>Ré-adhésion</div>
-                                {% endif %}
-                                <div class="collapsible-body new_registration_form">
-                                    Il est trop tôt pour ré-adhérer. Cette adhésion est valable encore {{ member | remainder | date('%a') }} jours.
-                                </div>
-                            </li>
-                        </ul>
-                    {% endif %}
-                {% endif %}
+                {% include "member/_partial/registrations.html.twig" with { member: member, new_registration_form: new_registration_form } %}
             </div>
         </li>
 

--- a/app/Resources/views/member/show.html.twig
+++ b/app/Resources/views/member/show.html.twig
@@ -80,6 +80,9 @@
                 <i class="material-icons">card_membership</i>Adhésions
             </div>
             <div class="collapsible-body white">
+                {% if member.lastRegistration %}
+                    <p style="margin-top:0">Adhésion du {{ member.lastRegistration.date | date_fr_full }} au {{ member | expire | date_fr_full }}</p>
+                {% endif %}
                 <ul class="collapsible">
                     {% for registration in member.registrations %}
                         <li>

--- a/app/Resources/views/member/show.html.twig
+++ b/app/Resources/views/member/show.html.twig
@@ -80,7 +80,7 @@
                 <i class="material-icons">card_membership</i>Adhésions
             </div>
             <div class="collapsible-body white">
-                {% include "member/_partial/registrations.html.twig" with { member: member, new_registration_form: new_registration_form } %}
+                {% include "member/_partial/registrations.html.twig" with { member: member, from_admin: true, new_registration_form: new_registration_form } %}
             </div>
         </li>
 


### PR DESCRIPTION
### Quoi ?

- permettre à chaque membre de voir les détails de son (ses) adhésion(s)
- basculer l'information de l'adhésion en cours depuis la "beneficiary card" vers la "member registration collapsible"

### Capture d'écran

![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/7fa94a6d-eb37-40b3-890a-6cc9d47e92a5)
