### PR TITLE
Répare l'affichage des formfields "markdown" dans les modals

### DIFF
--- a/app/Resources/views/form/fields.html.twig
+++ b/app/Resources/views/form/fields.html.twig
@@ -124,7 +124,7 @@
 
 {% block simplemde_editor_widget %}
     <div class="simplemde-container row" data-for="{{ id }}">
-    {{ block('textarea_widget') }}
+        {{ block('textarea_widget') }}
     </div>
     <script type="text/javascript">
         onceSimpleMDEReady(function () {
@@ -132,8 +132,10 @@
             var config = {{ form.vars.editor_config|raw}};
             var simplemde_{{ id }} = new SimpleMDE(Object.assign(config, {'element': element}));
             var required = $("#{{ id }}").attr('required') === "required";
-            $(".simplemde-container[data-for={{ id }}]").one('modalOpen',function () { //refresh
-                simplemde_{{ id }}.codemirror.refresh();
+            // refresh display
+            $(".simplemde-container[data-for={{ id }}]").one('modalOpen',function () {
+                // https://github.com/sparksuite/simplemde-markdown-editor/issues/313
+                setTimeout(function() { simplemde_{{ id }}.codemirror.refresh(); }, 0);
             });
             if (required){
                 $("#{{ id }}").removeAttr('required');

--- a/src/AppBundle/Form/MarkdownEditorType.php
+++ b/src/AppBundle/Form/MarkdownEditorType.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: gnat
- * Date: 01/11/16
- * Time: 2:18 PM
- */
 
 namespace AppBundle\Form;
 
@@ -14,13 +8,10 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+
+// https://github.com/NobletSolutions/SimpleMDEBundle/blob/master/src/Form/Types/MarkdownEditorType.php
 class MarkdownEditorType extends AbstractType
 {
-    /**
-     * Configures the options for this type.
-     *
-     * @param OptionsResolver $resolver The resolver for the options
-     */
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefined([
@@ -48,9 +39,6 @@ class MarkdownEditorType extends AbstractType
         ]);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
         $editor_config = [];
@@ -71,18 +59,19 @@ class MarkdownEditorType extends AbstractType
             $editor_config['tabSize'] = $options['tabSize'];
         }
 
-        foreach (['indentWithTabs', 'lineWrapping', 'styleSelectedText'] as $defaultTrueOption) {
+        foreach (['indentWithTabs', 'lineWrapping', 'styleSelectedText'] as $defaultTrueOption) { // removed 'spellChecker'
             if (isset($options[$defaultTrueOption]) && $options[$defaultTrueOption] === false) {
                 $editor_config[$defaultTrueOption] = false;
             }
         }
 
-        foreach (['autofocus', 'promptURLs','spellChecker','forceSync'] as $defaultFalseOption) {
+        foreach (['autofocus', 'forceSync', 'promptURLs', 'spellChecker'] as $defaultFalseOption) { // added 'spellChecker'
             if (isset($options[$defaultFalseOption]) && $options[$defaultFalseOption] === true) {
                 $editor_config[$defaultFalseOption] = true;
             }
         }
 
+        // added
         if (!isset($options['spellChecker']) || $options['spellChecker'] === false)
             $editor_config['spellChecker'] = false;
         if (!isset($options['forceSync']))

--- a/src/AppBundle/Resources/public/js/app.js
+++ b/src/AppBundle/Resources/public/js/app.js
@@ -9,7 +9,7 @@ $(document).ready(function() {
         draggable: true, // Choose whether you can drag to open on touch screens
     });
     $('.modal').modal({
-        ready: function (modal) {
+        onOpenStart: function (modal) {
             $(modal).find('.simplemde-container').trigger('modalOpen'); // tell markdown editor to refresh
         },
     });


### PR DESCRIPTION
### Quoi ?

Actuellement, lorsqu'on affiche un formulaire qui contient un `MarkdownEditorType`, il est nécessaire de "refresh" le formulaire si il est présent dans un modal (sinon il s'affiche comme vide, et il faut cliquer pour voir le texte s'afficher).

Il y avait déjà le code nécessaire pour effectuer le "refresh", mais c'était materializeCSS qui avait évolué (`modal.onOpenStart`)