### PR TITLE
Membre (coté admin) : améliorations de l'affichage des créneaux

### DIFF
--- a/app/Resources/views/booking/home_booked_shifts.html.twig
+++ b/app/Resources/views/booking/home_booked_shifts.html.twig
@@ -12,7 +12,7 @@
                     {% if period_positions %}
                         <div class="row">
                             {% for period_position in period_positions %}
-                                <div class="col s12 m6 l4">
+                                <div class="col s12 m6 xl4">
                                     {% include "user/_partial/period_position_card.html.twig" with { period_position: period_position } %}
                                 </div>
                             {% endfor %}
@@ -45,7 +45,7 @@
                         {% if shiftsOfCycle | length > 0 %}
                             <div class="row">
                                 {% for shift in shiftsOfCycle %}
-                                    <div class="col s12 m6 l4 {% if shiftsOfCycle | length == 1 %}push-m3{% endif %}">
+                                    <div class="col s12 m6 xl4 {% if shiftsOfCycle | length == 1 %}push-m3{% endif %}">
                                         {% include "booking/_partial/home_shift_card.html.twig" with { shift: shift } %}
                                     </div>
                                 {% endfor %}
@@ -65,7 +65,7 @@
                 {# Shift history #}
                 <div class="row">
                     {% for cycle in -1..(-1 * max_nb_of_past_cycles_to_display) %}
-                        <div class="col s12 m6 l4">
+                        <div class="col s12 m6 xl4">
                             {% set previousShifts = shiftsByCycle[cycle] %}
                             <h6>Cycle précédent (du {{ membership_service.startOfCycle(member,cycle) | date_short }} au {{ membership_service.endOfCycle(member,cycle) | date_short }})</h6>
                             {% if previousShifts | length > 0 %}

--- a/app/Resources/views/member/_partial/shifts.html.twig
+++ b/app/Resources/views/member/_partial/shifts.html.twig
@@ -7,7 +7,7 @@
         <h6>Créneau{% if period_positions | length > 1 %}x{% endif %} fixe</h6>
         {% if period_positions %}
             {% for period_position in period_positions %}
-                <div class="col s12 m6 l4">
+                <div class="col s12 m6 xl4">
                     {% include "user/_partial/period_position_card.html.twig" with { period_position: period_position, show_actions: true } %}
                 </div>
             {% endfor %}

--- a/app/Resources/views/member/_partial/shifts.html.twig
+++ b/app/Resources/views/member/_partial/shifts.html.twig
@@ -4,7 +4,7 @@
 
 {% if use_fly_and_fixed %}
     <div class="row">
-        <h6>Créneau fixe</h6>
+        <h6>Créneau{% if period_positions | length > 1 %}x{% endif %} fixe</h6>
         {% if period_positions %}
             {% for period_position in period_positions %}
                 <div class="col s12 m6 l4">
@@ -17,26 +17,35 @@
     </div>
 {% endif %}
 
-{% for cycle, shifts in shifts_by_cycle %}
+{% if not member.firstShiftDate %}
     <div class="row">
-        <h6>
-            {% if cycle <= -1 %}
-                Cycle précédent
-            {% elseif cycle == 0 %}
-                Cycle en cours
-            {% elseif cycle == 1 %}
-                Prochain cycle
-            {% endif %}
-            (du {{ membership_service.startOfCycle(member,cycle) | date_fr_long }} au {{ membership_service.endOfCycle(member,cycle) | date_fr_long }})
-        </h6>
-        {% if shifts | length > 0 %}
-            {% for shift in shifts %}
-                <div class="col s12 m6 l4">
-                    {% include "user/_partial/shift_card.html.twig" with { shift: shift } %}
-                </div>
-            {% endfor %}
-        {% else %}
-            Pas de créneau
-        {% endif %}
+        <h6>Créneaux</h6>
+        <div class="card-panel red white-text">
+            Ce compte-membre n'est pas encore inscrit à son premier créneau.
+        </div>
     </div>
-{% endfor %}
+{% else %}
+    {% for cycle, shifts in shifts_by_cycle %}
+        <div class="row">
+            <h6>
+                {% if cycle <= -1 %}
+                    Cycle précédent
+                {% elseif cycle == 0 %}
+                    Cycle en cours
+                {% elseif cycle >= 1 %}
+                    Prochain cycle
+                {% endif %}
+                (du {{ membership_service.startOfCycle(member, cycle) | date_fr_long }} au {{ membership_service.endOfCycle(member, cycle) | date_fr_long }})
+            </h6>
+            {% if shifts | length > 0 %}
+                {% for shift in shifts %}
+                    <div class="col s12 m6 xl4">
+                        {% include "user/_partial/shift_card.html.twig" with { shift: shift } %}
+                    </div>
+                {% endfor %}
+            {% else %}
+                Pas de créneau
+            {% endif %}
+        </div>
+    {% endfor %}
+{% endif %}

--- a/app/Resources/views/member/show.html.twig
+++ b/app/Resources/views/member/show.html.twig
@@ -97,6 +97,9 @@
         <li id="shifts">
             <div class="collapsible-header {% if frontend_cookie and frontend_cookie.user_show is defined and frontend_cookie.user_show.shifts_open is defined and frontend_cookie.user_show.shifts_open %}active{% endif %}">
                 <i class="material-icons">date_range</i>Créneaux
+                {% if not member.firstShiftDate %}
+                    <span style="margin-left:14px;">⚠️</span>
+                {% endif %}
             </div>
             <div class="collapsible-body white">
                 {% include "member/_partial/shifts.html.twig" %}


### PR DESCRIPTION
### Quoi ?

- afficher un :warning: + message si le membre n'a encore jamais été inscrit à un créneau
- répare un soucis où le premier créneau d'un membre s'affichait dans le mauvais cycle

### Capture d'écran

Membre sans firstShiftDate
![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/6c1f0062-8cba-4da2-aecb-0a23b1f0d77d)
