### PR TITLE
Fermetures exceptionnelles : séparer index & list

### DIFF
--- a/app/Resources/views/admin/closingexception/_partial/table.html.twig
+++ b/app/Resources/views/admin/closingexception/_partial/table.html.twig
@@ -1,0 +1,26 @@
+<table class="responsive-table">
+    <thead>
+        <tr>
+            <th>Date de la fermeture</th>
+            <th>Raison</th>
+            <th>Auteur</th>
+            <th>Date de création</th>
+            <th>Actions</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for closingException in closingExceptions %}
+            <tr>
+                <td>{{ closingException.date | date_fr_full }}</td>
+                <td>{{ closingException.reason }}</td>
+                <td>
+                    {% include "admin/member/_partial/member_or_user_link.html.twig" with { user: closingException.createdBy, target_blank: true } %}
+                </td>
+                <td title="{{ closingException.createdAt | date_time }}">
+                    {{ closingException.createdAt | date_short }}
+                </td>
+                <td></td>
+            </tr>
+        {% endfor %}
+    </tbody>
+</table>

--- a/app/Resources/views/admin/closingexception/index.html.twig
+++ b/app/Resources/views/admin/closingexception/index.html.twig
@@ -9,6 +9,11 @@
 {% endblock %}
 
 {% block content %}
+<div class="card-panel blue lighten-3">
+    <i class="material-icons left">info</i>
+    Aucun créneau ne sera généré le jour de la fermeture exceptionnelle.
+</div>
+
 <h4>Fermetures exceptionnelles à venir ({{ closingExceptionsFuture | length }})</h4>
 
 {% if closingExceptionsFuture | length %}

--- a/app/Resources/views/admin/closingexception/index.html.twig
+++ b/app/Resources/views/admin/closingexception/index.html.twig
@@ -11,32 +11,7 @@
 {% block content %}
 <h4>Liste des fermetures exceptionnelles ({{ closingExceptions | length }})</h4>
 
-<table class="responsive-table">
-    <thead>
-        <tr>
-            <th>Date de la fermeture</th>
-            <th>Raison</th>
-            <th>Auteur</th>
-            <th>Date de création</th>
-            <th>Actions</th>
-        </tr>
-    </thead>
-    <tbody>
-    {% for closingException in closingExceptions %}
-        <tr>
-            <td>{{ closingException.date | date_fr_full }}</td>
-            <td>{{ closingException.reason }}</td>
-            <td>
-                {% include "admin/member/_partial/member_or_user_link.html.twig" with { user: closingException.createdBy, target_blank: true } %}
-            </td>
-            <td title="{{ closingException.createdAt | date_time }}">
-                {{ closingException.createdAt | date_short }}
-            </td>
-            <td></td>
-        </tr>
-    {% endfor %}
-    </tbody>
-</table>
+{% include "admin/closingexception/_partial/table.html.twig" with { closingExceptions: closingExceptions } %}
 
 <br />
 <a href="{{ path('admin_closingexception_new') }}" class="btn">

--- a/app/Resources/views/admin/closingexception/index.html.twig
+++ b/app/Resources/views/admin/closingexception/index.html.twig
@@ -9,10 +9,23 @@
 {% endblock %}
 
 {% block content %}
-<h4>Liste des fermetures exceptionnelles ({{ closingExceptions | length }})</h4>
+<h4>Fermetures exceptionnelles à venir ({{ closingExceptionsFuture | length }})</h4>
 
-{% include "admin/closingexception/_partial/table.html.twig" with { closingExceptions: closingExceptions } %}
+{% if closingExceptionsFuture | length %}
+    {% include "admin/closingexception/_partial/table.html.twig" with { closingExceptions: closingExceptionsFuture } %}
+{% endif %}
 
+<br />
+<h4>Fermetures exceptionnelles passées (10 plus récentes)</h4>
+
+{% if closingExceptionsPast | length %}
+    {% include "admin/closingexception/_partial/table.html.twig" with { closingExceptions: closingExceptionsPast } %}
+{% endif %}
+
+<br />
+<a href="{{ path("admin_closingexception_list") }}" class="btn">
+    <i class="material-icons left">list</i>Toutes les fermetures exceptionnelles
+</a>
 <br />
 <a href="{{ path('admin_closingexception_new') }}" class="btn">
     <i class="material-icons left">add</i>Ajouter une fermeture exceptionnelle

--- a/app/Resources/views/admin/closingexception/list.html.twig
+++ b/app/Resources/views/admin/closingexception/list.html.twig
@@ -1,0 +1,16 @@
+{% extends 'layout.html.twig' %}
+
+{% block title %}Fermetures exceptionnelles - {{ site_name }}{% endblock %}
+
+{% block breadcrumbs %}
+<a href="{{ path('homepage') }}"><i class="material-icons">home</i></a><i class="material-icons">chevron_right</i>
+<a href="{{ path('admin') }}"><i class="material-icons">build</i>&nbsp;Administration</a><i class="material-icons">chevron_right</i>
+<a href="{{ path('admin_closingexception_index') }}"><i class="material-icons">block</i>&nbsp;Fermetures exceptionnelles</a><i class="material-icons">chevron_right</i>
+<i class="material-icons">list</i>&nbsp;Liste des fermetures exceptionnelles
+{% endblock %}
+
+{% block content %}
+<h4>Liste des fermetures exceptionnelles ({{ closingExceptions | length }})</h4>
+
+{% include "admin/closingexception/_partial/table.html.twig" with { closingExceptions: closingExceptions } %}
+{% endblock %}

--- a/app/Resources/views/admin/event/index.html.twig
+++ b/app/Resources/views/admin/event/index.html.twig
@@ -21,7 +21,9 @@
 
 <h4>Événements passés (10 plus récents)</h4>
 
-{% include "admin/event/_partial/table.html.twig" with { events: eventsPast, from_admin: true } %}
+{% if eventsPast | length %}
+    {% include "admin/event/_partial/table.html.twig" with { events: eventsPast, from_admin: true } %}
+{% endif %}
 
 {% if is_granted("ROLE_ADMIN") %}
     <br />

--- a/app/Resources/views/admin/event/list.html.twig
+++ b/app/Resources/views/admin/event/list.html.twig
@@ -54,14 +54,6 @@
     </li>
 </ul>
 
-{% if is_granted("ROLE_ADMIN") %}
-    <br />
-    <a href="{{ path("admin_proxies_list") }}" class="btn"><i class="material-icons left">list</i>Toutes les procurations</a>
-    <br />
-    <a href="{{ path('admin_event_new') }}" class="btn"><i class="material-icons left">add</i>Ajouter un événement</a>
-{% endif %}
-{% endblock %}
-
 {% block javascripts %}
 <script>
     jQuery(function() {

--- a/src/AppBundle/Controller/AdminClosingExceptionController.php
+++ b/src/AppBundle/Controller/AdminClosingExceptionController.php
@@ -23,7 +23,7 @@ use Symfony\Component\HttpFoundation\Session\Session;
 class AdminClosingExceptionController extends Controller
 {
     /**
-     * List all closing exceptions
+     * Admin closing exception home
      *
      * @Route("/", name="admin_closingexception_index", methods={"GET"})
      * @Security("has_role('ROLE_ADMIN')")
@@ -32,9 +32,28 @@ class AdminClosingExceptionController extends Controller
     {
         $em = $this->getDoctrine()->getManager();
 
-        $closingExceptions = $em->getRepository('AppBundle:ClosingException')->findAll();
+        $closingExceptionsFuture = $em->getRepository('AppBundle:ClosingException')->findFutures();
+        $closingExceptionsPast = $em->getRepository('AppBundle:ClosingException')->findPast(10);  # only the 10 last
 
         return $this->render('admin/closingexception/index.html.twig', array(
+            'closingExceptionsFuture' => $closingExceptionsFuture,
+            'closingExceptionsPast' => $closingExceptionsPast
+        ));
+    }
+
+    /**
+     * Admin closing exception list
+     *
+     * @Route("/list", name="admin_closingexception_list", methods={"GET"})
+     * @Security("has_role('ROLE_ADMIN')")
+     */
+    public function listAction(Request $request)
+    {
+        $em = $this->getDoctrine()->getManager();
+
+        $closingExceptions = $em->getRepository('AppBundle:ClosingException')->findAll();
+
+        return $this->render('admin/closingexception/list.html.twig', array(
             'closingExceptions' => $closingExceptions
         ));
     }

--- a/src/AppBundle/Repository/ClosingExceptionRepository.php
+++ b/src/AppBundle/Repository/ClosingExceptionRepository.php
@@ -27,4 +27,21 @@ class ClosingExceptionRepository extends \Doctrine\ORM\EntityRepository
             ->getQuery()
             ->getResult();
     }
+
+    public function findPast(int $limit = null)
+    {
+        $qb = $this->createQueryBuilder('ce')
+            ->where('ce.date < :now')
+            ->setParameter('now', new \Datetime('now'));
+
+        if ($limit) {
+            $qb->setMaxResults($limit);
+        }
+
+        $qb->orderBy('ce.date', 'DESC');
+
+        return $qb
+            ->getQuery()
+            ->getResult();
+    }
 }


### PR DESCRIPTION
### Quoi ?

Sur la page index : 
- séparer les fermetures à venir des fermetures passées
- ajouter un message d'information
Sur la nouvelle page list : 
- afficher toutes les fermetures exceptionnelles
- mettre le tableau dans un template dédié

### Capture d'écran

![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/4f40e443-9d04-43b7-b45f-d6bbae588276)
