### PR TITLE
Fermetures exceptionnelles : autoriser la suppression des fermetures futures

### DIFF
--- a/app/Resources/views/admin/closingexception/_partial/table.html.twig
+++ b/app/Resources/views/admin/closingexception/_partial/table.html.twig
@@ -1,3 +1,5 @@
+{% set delete_forms = delete_forms ?? [] %}
+
 <table class="responsive-table">
     <thead>
         <tr>
@@ -19,7 +21,15 @@
                 <td title="{{ closingException.createdAt | date_time }}">
                     {{ closingException.createdAt | date_short }}
                 </td>
-                <td></td>
+                <td>
+                    {% if delete_forms and delete_forms[closingException.id] is defined %}
+                        {{ form_start(delete_forms[closingException.id]) }}
+                        <a href="#" class="btn-floating waves-effect waves-light red" onclick="var r = confirm('Etes-vous sûr de vouloir supprimer cette fermeture exceptionnelle ?!'); if (r == true) {$(this).closest('form').submit();}; event.stopPropagation();" title="⚠️ Supprimer la fermeture exceptionnelle ⚠️">
+                            <i class="material-icons left">delete</i>
+                        </a>
+                        {{ form_end(delete_forms[closingException.id]) }}
+                    {% endif %}
+                </td>
             </tr>
         {% endfor %}
     </tbody>

--- a/app/Resources/views/admin/closingexception/index.html.twig
+++ b/app/Resources/views/admin/closingexception/index.html.twig
@@ -11,13 +11,15 @@
 {% block content %}
 <div class="card-panel blue lighten-3">
     <i class="material-icons left">info</i>
-    Aucun créneau ne sera généré le jour de la fermeture exceptionnelle.
+    Aucun créneau ne sera généré pour le jour de la fermeture exceptionnelle.
+    <br />
+    ⚠️ Les créneaux étant générés à l'avance, il faut définir le jour de fermeture d'avantage en amont ⚠️
 </div>
 
 <h4>Fermetures exceptionnelles à venir ({{ closingExceptionsFuture | length }})</h4>
 
 {% if closingExceptionsFuture | length %}
-    {% include "admin/closingexception/_partial/table.html.twig" with { closingExceptions: closingExceptionsFuture } %}
+    {% include "admin/closingexception/_partial/table.html.twig" with { closingExceptions: closingExceptionsFuture, delete_forms: delete_forms } %}
 {% endif %}
 
 <br />

--- a/app/Resources/views/admin/closingexception/list.html.twig
+++ b/app/Resources/views/admin/closingexception/list.html.twig
@@ -12,5 +12,5 @@
 {% block content %}
 <h4>Liste des fermetures exceptionnelles ({{ closingExceptions | length }})</h4>
 
-{% include "admin/closingexception/_partial/table.html.twig" with { closingExceptions: closingExceptions } %}
+{% include "admin/closingexception/_partial/table.html.twig" with { closingExceptions: closingExceptions, delete_forms: delete_forms } %}
 {% endblock %}

--- a/app/Resources/views/process/list.html.twig
+++ b/app/Resources/views/process/list.html.twig
@@ -44,7 +44,7 @@
                 {% if processUpdate.date < lastShiftDate and new %}
                     <tr class="last-shift">
                         <td><i class="material-icons left">date_range</i>{{ lastShiftDate | date_fr_full_with_time }}</td>
-                        <td colspan="{% if is_granted("ROLE_PROCESS_MANAGER") %}3{% endif %}" style="text-align: center">⬆️ Depuis et ⬇️ Avant mon dernier créneau️</td>
+                        <td colspan="{% if is_granted("ROLE_PROCESS_MANAGER") %}3{% endif %}" style="text-align: center">⬆️ Depuis et ⬇️ Avant mon dernier créneau</td>
                         <td></td>
                     </tr>
                     {% set new = false %}

--- a/src/AppBundle/Controller/AdminClosingExceptionController.php
+++ b/src/AppBundle/Controller/AdminClosingExceptionController.php
@@ -35,9 +35,15 @@ class AdminClosingExceptionController extends Controller
         $closingExceptionsFuture = $em->getRepository('AppBundle:ClosingException')->findFutures();
         $closingExceptionsPast = $em->getRepository('AppBundle:ClosingException')->findPast(10);  # only the 10 last
 
+        $delete_forms = array();
+        foreach ($closingExceptionsFuture as $closingException) {
+            $delete_forms[$closingException->getId()] = $this->getDeleteForm($closingException)->createView();
+        }
+
         return $this->render('admin/closingexception/index.html.twig', array(
             'closingExceptionsFuture' => $closingExceptionsFuture,
-            'closingExceptionsPast' => $closingExceptionsPast
+            'closingExceptionsPast' => $closingExceptionsPast,
+            'delete_forms' => $delete_forms
         ));
     }
 
@@ -91,6 +97,30 @@ class AdminClosingExceptionController extends Controller
     }
 
     /**
+     * Closing exception delete
+     *
+     * @Route("/{id}", name="admin_closingexception_delete", methods={"DELETE"})
+     * @Security("has_role('ROLE_ADMIN')")
+     */
+    public function deleteAction(Request $request, ClosingException $closingException)
+    {
+        $session = new Session();
+        $em = $this->getDoctrine()->getManager();
+
+        $form = $this->getDeleteForm($closingException);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $em->remove($closingException);
+            $em->flush();
+
+            $session->getFlashBag()->add('success', 'La fermeture exceptionnelle a bien été supprimée !');
+        }
+
+        return $this->redirectToRoute('admin_closingexception_index');
+    }
+
+    /**
      * Closing exception widget generator
      *
      * @Route("/widget_generator", name="admin_closingexception_widget_generator", methods={"GET","POST"})
@@ -122,5 +152,17 @@ class AdminClosingExceptionController extends Controller
         return $this->render('admin/closingexception/widget_generator.html.twig', array(
             'form' => $form->createView(),
         ));
+    }
+
+    /**
+     * @param ClosingException $closingException
+     * @return \Symfony\Component\Form\FormInterface
+     */
+    protected function getDeleteForm(ClosingException $closingException)
+    {
+        return $this->createFormBuilder()
+            ->setAction($this->generateUrl('admin_closingexception_delete', array('id' => $closingException->getId())))
+            ->setMethod('DELETE')
+            ->getForm();
     }
 }

--- a/src/AppBundle/Controller/AdminClosingExceptionController.php
+++ b/src/AppBundle/Controller/AdminClosingExceptionController.php
@@ -59,8 +59,16 @@ class AdminClosingExceptionController extends Controller
 
         $closingExceptions = $em->getRepository('AppBundle:ClosingException')->findAll();
 
+        $delete_forms = array();
+        foreach ($closingExceptions as $closingException) {
+            if (!$closingException->getIsPast()) {
+                $delete_forms[$closingException->getId()] = $this->getDeleteForm($closingException)->createView();
+            }
+        }
+
         return $this->render('admin/closingexception/list.html.twig', array(
-            'closingExceptions' => $closingExceptions
+            'closingExceptions' => $closingExceptions,
+            'delete_forms' => $delete_forms
         ));
     }
 

--- a/src/AppBundle/Entity/ClosingException.php
+++ b/src/AppBundle/Entity/ClosingException.php
@@ -158,7 +158,7 @@ class ClosingException
      * @param \DateTime $date
      * @return boolean
      */
-    public function isPast(\Datetime $date = null)
+    public function getIsPast(\Datetime $date = null)
     {
         if (!$date) {
             $date = new \DateTime('now');

--- a/src/AppBundle/Entity/ClosingException.php
+++ b/src/AppBundle/Entity/ClosingException.php
@@ -151,4 +151,18 @@ class ClosingException
     {
         return $this->createdBy;
     }
+
+    /**
+     * Return if the closingException is past for a given date
+     *
+     * @param \DateTime $date
+     * @return boolean
+     */
+    public function isPast(\Datetime $date = null)
+    {
+        if (!$date) {
+            $date = new \DateTime('now');
+        }
+        return $date > $this->date;
+    }
 }


### PR DESCRIPTION
### Quoi ?

Permettre aux Admin de supprimer une fermeture exceptionnelle dont la date est dans le future

### Capture d'écran

![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/86e5ec45-7030-4a85-a00b-0cfe3292b7c9)
