### PR TITLE
Evénements : améliorer l'affichage pour les événements en cours

### DIFF
--- a/app/Resources/views/admin/event/_partial/card.html.twig
+++ b/app/Resources/views/admin/event/_partial/card.html.twig
@@ -1,3 +1,4 @@
+{% set ongoing = ongoing ?? false %}
 {% set from_admin = from_admin ?? false %}
 
 <div class="card small {% if from_admin %}blue-grey darken-1{% endif %}">
@@ -13,6 +14,9 @@
             {{ event.date | date_fr_full_with_time }}
             {% if event.kind %}
                 <span class="badge teal white-text">{{ event.kind }}</span>
+            {% endif %}
+            {% if ongoing %}
+                <span class="badge deep-purple white-text">En cours</span>
             {% endif %}
         </p>
         {% if event.end %}

--- a/app/Resources/views/admin/event/_partial/card.html.twig
+++ b/app/Resources/views/admin/event/_partial/card.html.twig
@@ -1,4 +1,3 @@
-{% set ongoing = ongoing ?? false %}
 {% set from_admin = from_admin ?? false %}
 
 <div class="card small {% if from_admin %}blue-grey darken-1{% endif %}">
@@ -15,7 +14,7 @@
             {% if event.kind %}
                 <span class="badge teal white-text">{{ event.kind }}</span>
             {% endif %}
-            {% if ongoing %}
+            {% if event.end and event.isOngoing %}
                 <span class="badge deep-purple white-text">En cours</span>
             {% endif %}
         </p>

--- a/app/Resources/views/admin/event/index.html.twig
+++ b/app/Resources/views/admin/event/index.html.twig
@@ -9,6 +9,18 @@
 {% endblock %}
 
 {% block content %}
+{% if eventsOngoing | length %}
+    <h4>Événements en cours ({{ eventsOngoing | length }})</h4>
+
+    <div class="row">
+        {% for event in eventsOngoing %}
+            <div class="col m12 l6">
+                {% include "admin/event/_partial/card.html.twig" with { event: event, ongoing: true, from_admin: true } %}
+            </div>
+        {% endfor %}
+    </div>
+{% endif %}
+
 <h4>Événements à venir ({{ eventsFuture | length }})</h4>
 
 <div class="row">

--- a/app/Resources/views/admin/event/index.html.twig
+++ b/app/Resources/views/admin/event/index.html.twig
@@ -15,7 +15,7 @@
     <div class="row">
         {% for event in eventsOngoing %}
             <div class="col m12 l6">
-                {% include "admin/event/_partial/card.html.twig" with { event: event, ongoing: true, from_admin: true } %}
+                {% include "admin/event/_partial/card.html.twig" with { event: event, from_admin: true } %}
             </div>
         {% endfor %}
     </div>

--- a/app/Resources/views/default/index.html.twig
+++ b/app/Resources/views/default/index.html.twig
@@ -164,8 +164,8 @@
                 <br />
                 <a href="{{ path("event_index") }}" class="btn blue" style="position: relative">
                     <i class="material-icons left" >event</i>Les événements à venir
-                    {% if eventsFuture | length %}
-                        <span class="bubble_counter red white-text">{{ eventsFuture | length }}</span>
+                    {% if eventsFutureOrOngoing | length %}
+                        <span class="bubble_counter red white-text">{{ eventsFutureOrOngoing | length }}</span>
                     {% endif %}
                 </a>
             </div>

--- a/app/Resources/views/event/_partial/widget.html.twig
+++ b/app/Resources/views/event/_partial/widget.html.twig
@@ -14,7 +14,12 @@
             <span>-</span>
             <strong>{% if links %}<a href="{{ path('event_detail', { 'id': event.id }) }}" target="_blank">{% endif %}{{ event.title }}{% if links %}</a>{% endif %}</strong>
             {{ event.date | date_fr_full_with_time }}
-            {% if event.end %}<i>({{ event.duration }})</i>{% endif %}
+            {% if event.end %}
+                <i>({{ event.duration }})</i>
+                {% if event.isOngoing %}
+                    <span>[en cours]</span>
+                {% endif %}
+            {% endif %}
             {# {% if not eventKind %}[{{ event.kind }}] {% endif %} #}
         </li>
     {% endfor %}

--- a/app/Resources/views/event/index.html.twig
+++ b/app/Resources/views/event/index.html.twig
@@ -8,6 +8,18 @@
 {% endblock %}
 
 {% block content %}
+{% if eventsOngoing | length %}
+    <h4>Événements en cours ({{ eventsOngoing | length }})</h4>
+
+    <div class="row">
+        {% for event in eventsOngoing %}
+            <div class="col m12 l6">
+                {% include "admin/event/_partial/card.html.twig" with { event: event, ongoing: true } %}
+            </div>
+        {% endfor %}
+    </div>
+{% endif %}
+
 <h4>Événements à venir ({{ eventsFuture | length }})</h4>
 
 <div class="row">

--- a/app/Resources/views/event/index.html.twig
+++ b/app/Resources/views/event/index.html.twig
@@ -14,7 +14,7 @@
     <div class="row">
         {% for event in eventsOngoing %}
             <div class="col m12 l6">
-                {% include "admin/event/_partial/card.html.twig" with { event: event, ongoing: true } %}
+                {% include "admin/event/_partial/card.html.twig" with { event: event } %}
             </div>
         {% endfor %}
     </div>

--- a/src/AppBundle/Controller/AdminEventController.php
+++ b/src/AppBundle/Controller/AdminEventController.php
@@ -85,10 +85,12 @@ class AdminEventController extends Controller
         $em = $this->getDoctrine()->getManager();
 
         $eventsFuture = $em->getRepository('AppBundle:Event')->findFutures();
+        $eventsOngoing = $em->getRepository('AppBundle:Event')->findOngoing();
         $eventsPast = $em->getRepository('AppBundle:Event')->findPast(null, 10);  # only the 10 last
 
         return $this->render('admin/event/index.html.twig', array(
             'eventsFuture' => $eventsFuture,
+            'eventsOngoing' => $eventsOngoing,
             'eventsPast' => $eventsPast,
         ));
     }

--- a/src/AppBundle/Controller/DefaultController.php
+++ b/src/AppBundle/Controller/DefaultController.php
@@ -100,12 +100,12 @@ class DefaultController extends Controller
             ]);
         }
 
-        $eventsFuture = $em->getRepository('AppBundle:Event')->findFutures();
+        $eventsFutureOrOngoing = $em->getRepository('AppBundle:Event')->findFutureOrOngoing();
         $dynamicContentTop = $em->getRepository('AppBundle:DynamicContent')->findOneByCode("HOME_TOP")->getContent();
         $dynamicContentBottom = $em->getRepository('AppBundle:DynamicContent')->findOneByCode("HOME_BOTTOM")->getContent();
 
         return $this->render('default/index.html.twig', [
-            'eventsFuture' => $eventsFuture,
+            'eventsFutureOrOngoing' => $eventsFutureOrOngoing,
             'dynamicContentTop' => $dynamicContentTop,
             'dynamicContentBottom' => $dynamicContentBottom,
         ]);

--- a/src/AppBundle/Controller/EventController.php
+++ b/src/AppBundle/Controller/EventController.php
@@ -69,10 +69,12 @@ class EventController extends Controller
         $em = $this->getDoctrine()->getManager();
 
         $eventsFuture = $em->getRepository('AppBundle:Event')->findFutures();
+        $eventsOngoing = $em->getRepository('AppBundle:Event')->findOngoing();
         $eventsPast = $em->getRepository('AppBundle:Event')->findPast();
 
         return $this->render('event/index.html.twig', array(
             'eventsFuture' => $eventsFuture,
+            'eventsOngoing' => $eventsOngoing,
             'eventsPast' => $eventsPast,
         ));
     }

--- a/src/AppBundle/Controller/EventController.php
+++ b/src/AppBundle/Controller/EventController.php
@@ -48,7 +48,7 @@ class EventController extends Controller
             $eventKind = $em->getRepository('AppBundle:EventKind')->find($filter_event_kind_id);
         }
 
-        $events = $em->getRepository('AppBundle:Event')->findFutures($eventKind, $eventDateMax, $filter_limit);
+        $events = $em->getRepository('AppBundle:Event')->findFutureOrOngoing($eventKind, $eventDateMax, $filter_limit);
 
         return $this->render('event/_partial/widget.html.twig', [
             'events' => $events,

--- a/src/AppBundle/Entity/Event.php
+++ b/src/AppBundle/Entity/Event.php
@@ -298,6 +298,15 @@ class Event
     }
 
     /**
+     * @return boolean
+     */
+    public function getIsOngoing()
+    {
+        $now = new \DateTime('now');
+        return ($this->date < $now) && $this->end && ($this->end > $now);
+    }
+
+    /**
      * Set description
      *
      * @param string $description

--- a/src/AppBundle/Repository/EventRepository.php
+++ b/src/AppBundle/Repository/EventRepository.php
@@ -17,6 +17,37 @@ class EventRepository extends \Doctrine\ORM\EntityRepository
         return $this->findBy(array(), array('date' => 'DESC'));
     }
 
+    public function findFutureOrOngoing(EventKind $eventKind = null, \DateTime $max = null, int $limit = null)
+    {
+        $qb = $this->createQueryBuilder('e')
+            ->leftJoin('e.kind', 'ek')
+            ->addSelect('ek')
+            ->where('e.date > :now OR e.date < :now AND e.end IS NOT NULL AND e.end > :now')
+            ->setParameter('now', new \Datetime('now'));
+
+        if ($eventKind) {
+            $qb
+                ->andwhere('e.kind = :kind')
+                ->setParameter('kind', $eventKind);
+        }
+
+        if ($max) {
+            $qb
+                ->andWhere('e.date < :max')
+                ->setParameter('max', $max);
+        }
+
+        if ($limit) {
+            $qb->setMaxResults($limit);
+        }
+
+        $qb->orderBy('e.date', 'ASC');
+
+        return $qb
+            ->getQuery()
+            ->getResult();
+    }
+
     public function findFutures(EventKind $eventKind = null, \DateTime $max = null, int $limit = null)
     {
         $qb = $this->createQueryBuilder('e')

--- a/src/AppBundle/Repository/EventRepository.php
+++ b/src/AppBundle/Repository/EventRepository.php
@@ -48,6 +48,29 @@ class EventRepository extends \Doctrine\ORM\EntityRepository
             ->getResult();
     }
 
+    public function findOngoing(EventKind $eventKind = null)
+    {
+        $qb = $this->createQueryBuilder('e')
+            ->leftJoin('e.kind', 'ek')
+            ->addSelect('ek')
+            ->where('e.date < :now')
+            ->andWhere('e.end IS NOT NULL')
+            ->andWhere('e.end > :now')
+            ->setParameter('now', new \Datetime('now'));
+
+        if ($eventKind) {
+                $qb
+                    ->andwhere('e.kind = :kind')
+                    ->setParameter('kind', $eventKind);
+            }
+
+            $qb->orderBy('e.date', 'ASC');
+
+            return $qb
+                ->getQuery()
+                ->getResult();
+    }
+
     public function findPast(EventKind $eventKind = null, int $limit = null)
     {
         $qb = $this->createQueryBuilder('e')


### PR DESCRIPTION
### Quoi ?

Actuellement les événements en cours sont considérés comme passés (car date de début "passée").

Cette PR améliore leur gestion et affichage. Si l'événement a une date de début passée, mais une date de fin future, alors il est considéré comme en cours
- comptabilisé dans le count sur la home
- affiché dans une nouvelle section "en cours" dans la liste des événements
- affiché dans le widget

### Capture d'écran

![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/54952b49-7fe9-4797-b984-fa1248a417a5)
