### PR TITLE
Fermetures exceptionnelles : améliorer l'affichage pour les fermetures en cours

### DIFF
--- a/app/Resources/views/admin/closingexception/index.html.twig
+++ b/app/Resources/views/admin/closingexception/index.html.twig
@@ -16,6 +16,12 @@
     ⚠️ Les créneaux étant générés à l'avance, il faut définir le jour de fermeture d'avantage en amont ⚠️
 </div>
 
+{% if closingExceptionsOngoing %}
+    <h4>Fermeture exceptionnelle en cours</h4>
+
+    {% include "admin/closingexception/_partial/table.html.twig" with { closingExceptions: [closingExceptionsOngoing] } %}
+{% endif %}
+
 <h4>Fermetures exceptionnelles à venir ({{ closingExceptionsFuture | length }})</h4>
 
 {% if closingExceptionsFuture | length %}

--- a/app/Resources/views/closingexception/_partial/widget.html.twig
+++ b/app/Resources/views/closingexception/_partial/widget.html.twig
@@ -12,6 +12,9 @@
             <span>-</span>
             <strong>{{ closingException.date | date_fr_full }}</strong>
             {% if closingException.reason %}<i>({{ closingException.reason }})</i>{% endif %}
+            {% if closingException.isOngoing %}
+                <span>[en cours]</span>
+            {% endif %}
         </li>
     {% endfor %}
 </ul>

--- a/src/AppBundle/Controller/AdminClosingExceptionController.php
+++ b/src/AppBundle/Controller/AdminClosingExceptionController.php
@@ -33,6 +33,7 @@ class AdminClosingExceptionController extends Controller
         $em = $this->getDoctrine()->getManager();
 
         $closingExceptionsFuture = $em->getRepository('AppBundle:ClosingException')->findFutures();
+        $closingExceptionsOngoing = $em->getRepository('AppBundle:ClosingException')->findOngoing();
         $closingExceptionsPast = $em->getRepository('AppBundle:ClosingException')->findPast(10);  # only the 10 last
 
         $delete_forms = array();
@@ -42,6 +43,7 @@ class AdminClosingExceptionController extends Controller
 
         return $this->render('admin/closingexception/index.html.twig', array(
             'closingExceptionsFuture' => $closingExceptionsFuture,
+            'closingExceptionsOngoing' => $closingExceptionsOngoing,
             'closingExceptionsPast' => $closingExceptionsPast,
             'delete_forms' => $delete_forms
         ));

--- a/src/AppBundle/Controller/AdminClosingExceptionController.php
+++ b/src/AppBundle/Controller/AdminClosingExceptionController.php
@@ -34,7 +34,7 @@ class AdminClosingExceptionController extends Controller
 
         $closingExceptionsFuture = $em->getRepository('AppBundle:ClosingException')->findFutures();
         $closingExceptionsOngoing = $em->getRepository('AppBundle:ClosingException')->findOngoing();
-        $closingExceptionsPast = $em->getRepository('AppBundle:ClosingException')->findPast(10);  # only the 10 last
+        $closingExceptionsPast = $em->getRepository('AppBundle:ClosingException')->findPast(null, 10);  # only the 10 last
 
         $delete_forms = array();
         foreach ($closingExceptionsFuture as $closingException) {

--- a/src/AppBundle/Controller/ClosingExceptionController.php
+++ b/src/AppBundle/Controller/ClosingExceptionController.php
@@ -25,7 +25,7 @@ class ClosingExceptionController extends Controller
 
         $filter_title = $request->query->has('title') ? ($request->get('title') == 1) : true;
 
-        $closingExceptions = $em->getRepository('AppBundle:ClosingException')->findFutures();
+        $closingExceptions = $em->getRepository('AppBundle:ClosingException')->findFuturesOrOngoing();
 
         return $this->render('closingexception/_partial/widget.html.twig', [
             'closingExceptions' => $closingExceptions,

--- a/src/AppBundle/Controller/PeriodPositionFreeLogController.php
+++ b/src/AppBundle/Controller/PeriodPositionFreeLogController.php
@@ -88,8 +88,8 @@ class PeriodPositionFreeLogController extends Controller
             ->orderBy('ppfl.' . $sort, $order);
 
         if ($filter["created_at"]) {
-            $qb = $qb->andWhere("DATE_FORMAT(ppfl.createdAt, '%Y-%m-%d') = :created_at")
-                ->setParameter('created_at', $filter['created_at']->format('Y-m-d'));
+            $qb = $qb->andWhere("DATE_FORMAT(ppfl.createdAt, '%Y-%m-%d') = :created_at_formatted")
+                ->setParameter('created_at_formatted', $filter['created_at']->format('Y-m-d'));
         }
         if ($filter["beneficiary"]) {
             $qb = $qb->andWhere('ppfl.beneficiary = :beneficiary')

--- a/src/AppBundle/Controller/ShiftFreeLogController.php
+++ b/src/AppBundle/Controller/ShiftFreeLogController.php
@@ -109,13 +109,13 @@ class ShiftFreeLogController extends Controller
             ->orderBy('sfl.' . $sort, $order);
 
         if ($filter["created_at"]) {
-            $qb = $qb->andWhere("DATE_FORMAT(sfl.createdAt, '%Y-%m-%d') = :created_at")
-                ->setParameter('created_at', $filter['created_at']->format('Y-m-d'));
+            $qb = $qb->andWhere("DATE_FORMAT(sfl.createdAt, '%Y-%m-%d') = :created_at_formatted")
+                ->setParameter('created_at_formatted', $filter['created_at']->format('Y-m-d'));
         }
         if ($filter["shift_start_date"]) {
             $qb = $qb->leftJoin('sfl.shift', 's')
-                ->andWhere("DATE_FORMAT(s.start, '%Y-%m-%d') = :shift_start_date")
-                ->setParameter('shift_start_date', $filter['shift_start_date']->format('Y-m-d'));
+                ->andWhere("DATE_FORMAT(s.start, '%Y-%m-%d') = :shift_start_date_formatted")
+                ->setParameter('shift_start_date_formatted', $filter['shift_start_date']->format('Y-m-d'));
         }
         if ($filter["beneficiary"]) {
             $qb = $qb->andWhere('sfl.beneficiary = :beneficiary')

--- a/src/AppBundle/Entity/ClosingException.php
+++ b/src/AppBundle/Entity/ClosingException.php
@@ -92,6 +92,15 @@ class ClosingException
         return $this->date;
     }
 
+    /**
+     * @return boolean
+     */
+    public function getIsOngoing()
+    {
+        $now = new \DateTime('now');
+        return ($this->date->format('Y-m-d') == $now->format('Y-m-d'));
+    }
+
     public function setReason(?string $reason): self
     {
         $this->reason = $reason;

--- a/src/AppBundle/Repository/ClosingExceptionRepository.php
+++ b/src/AppBundle/Repository/ClosingExceptionRepository.php
@@ -41,7 +41,9 @@ class ClosingExceptionRepository extends \Doctrine\ORM\EntityRepository
 
         $qb = $this->createQueryBuilder('ce')
             ->where('ce.date > :date')
-            ->setParameter('date', $date);
+            ->andWhere("DATE_FORMAT(ce.date, '%Y-%m-%d') != :date_formatted")
+            ->setParameter('date', $date)
+            ->setParameter('date_formatted', $date->format('Y-m-d'));
 
         $qb->orderBy('ce.date', 'ASC');
 
@@ -73,7 +75,9 @@ class ClosingExceptionRepository extends \Doctrine\ORM\EntityRepository
 
         $qb = $this->createQueryBuilder('ce')
             ->where('ce.date < :date')
-            ->setParameter('date', $date);
+            ->andWhere("DATE_FORMAT(ce.date, '%Y-%m-%d') != :date_formatted")
+            ->setParameter('date', $date)
+            ->setParameter('date_formatted', $date->format('Y-m-d'));
 
         if ($limit) {
             $qb->setMaxResults($limit);

--- a/src/AppBundle/Repository/ClosingExceptionRepository.php
+++ b/src/AppBundle/Repository/ClosingExceptionRepository.php
@@ -28,6 +28,21 @@ class ClosingExceptionRepository extends \Doctrine\ORM\EntityRepository
             ->getResult();
     }
 
+    public function findOngoing(\DateTime $date = null)
+    {
+        if (!$date) {
+            $date = new \DateTime('now');
+        }
+
+        $qb = $this->createQueryBuilder('ce')
+        ->where("DATE_FORMAT(ce.date, '%Y-%m-%d') = :date")
+        ->setParameter('date', $date->format('Y-m-d'));
+
+        return $qb
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
     public function findPast(int $limit = null)
     {
         $qb = $this->createQueryBuilder('ce')


### PR DESCRIPTION
### Quoi ?

Actuellement les fermetures exceptionnelles en cours sont considérés comme passées (car date "passée").

Cette PR améliore leur gestion et affichage : 
- affiché dans une nouvelle section "en cours" dans la liste des événements
- affiché dans le widget

### Capture d'écran

![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/2c9ae17a-dbdd-41c4-872f-40ddadc439d9)
