### PR TITLE
Compte épargne : corrige l'affichage sur la badgeuse

### DIFF
--- a/src/AppBundle/Controller/CardReaderController.php
+++ b/src/AppBundle/Controller/CardReaderController.php
@@ -82,7 +82,7 @@ class CardReaderController extends Controller
 
         // find corresponding beneficiary
         $beneficiary = $card->getBeneficiary();
-        $membership = $beneficiary->getMembership();
+        $member = $beneficiary->getMembership();
 
         // validate beneficiary ongoing shift(s)
         $ongoingShifts = $em->getRepository('AppBundle:Shift')->getOngoingShifts($beneficiary);
@@ -102,11 +102,11 @@ class CardReaderController extends Controller
                 }
             }
 
-            $em->refresh($membership);  // added to prevent from returning cached (old) data
+            $em->refresh($member);  // added to prevent from returning cached (old) data
         }
 
-        $cycle_end = $this->get('membership_service')->getEndOfCycle($membership, 0);
-        $counter = $membership->getShiftTimeCount($cycle_end);
+        $cycle_end = $this->get('membership_service')->getEndOfCycle($member, 0);
+        $counter = $member->getShiftTimeCount($cycle_end);
         if ($this->swipeCardLogging) {
             if ($this->swipeCardLoggingAnonymous) {
                 $card = null;


### PR DESCRIPTION
### Quoi ?

Depuis #980 et les nouveaux messages affichés par la badgeuse, on montre au bénéficiaire son compteur temps (et épargne) mis à jour en temps réel.

Mais pour une raison de "cache", ce n'était pas les bonnes valeurs qui étaient affichées.

J'ai rajouté un "refresh".