### PR TITLE
Membre fixe/volant : afficher des messages pour les cas particuliers

### DIFF
--- a/app/Resources/views/Profile/show_content.html.twig
+++ b/app/Resources/views/Profile/show_content.html.twig
@@ -3,10 +3,12 @@
 {% if app.user.beneficiary %}
     {% set beneficiary = app.user.beneficiary %}
     {% set member = beneficiary.membership %}
+
     <h5 class="center-align">
         <img src="{{ gravatar(beneficiary.email,100) }}" alt="{{ beneficiary.firstname | lower | capitalize }}" class="circle responsive-img">
         <br />
         {{ app.user }}
+        {% include "admin/member/_partial/status_icons.html.twig" with { member: member } %}
     </h5>
     <ul class="collapsible">
         <li>

--- a/app/Resources/views/beneficiary/_partial/info.html.twig
+++ b/app/Resources/views/beneficiary/_partial/info.html.twig
@@ -8,13 +8,7 @@
         <span class="badge main-color white-text">{{ beneficiary_main_icon }} principal</span>
     {% endif %}
     {% if use_fly_and_fixed %}
-        {% if fly_and_fixed_entity_flying == 'Membership' %}
-            {% if beneficiary.membership.flying %}
-                <span class="badge teal white-text">{{ member_flying_icon }} Compte volant</span>
-            {% else %}
-                <span class="badge main-color white-text">Compte fixe</span>
-            {% endif %}
-        {% else %}
+        {% if fly_and_fixed_entity_flying == 'Beneficiary' %}
             {% if beneficiary.flying %}
                 <span class="badge teal white-text">{{ beneficiary_flying_icon }} Equipe volante</span>
             {% else %}

--- a/app/Resources/views/booking/_partial/modal.html.twig
+++ b/app/Resources/views/booking/_partial/modal.html.twig
@@ -25,15 +25,13 @@
 
         {% if bookableShifts | length == 1 %}
             {% if not firstBookable.formation and beneficiary.formations | length %}
-                <div class="card-panel teal warning">
-                    <span class="white-text">
-                        <i class="material-icons">warning</i>
-                        Ce créneau n'est <b>pas</b> qualifié.
-                        <br>
-                        {{ beneficiary.firstname }} a {% if beneficiary.formations | length == 1 %}une formation{% else %}des formations{% endif %} ({{ beneficiary.formations | join(', ')}}).
-                        <br>
-                        Tes compétences sont précieuses, pense si possible à les valoriser sur <b>un créneau qualifié</b>.
-                    </span>
+                <div class="card-panel teal warning white-text">
+                    <i class="material-icons">warning</i>
+                    Ce créneau n'est <b>pas</b> qualifié.
+                    <br>
+                    {{ beneficiary.firstname }} a {% if beneficiary.formations | length == 1 %}une formation{% else %}des formations{% endif %} ({{ beneficiary.formations | join(', ')}}).
+                    <br>
+                    Tes compétences sont précieuses, pense si possible à les valoriser sur <b>un créneau qualifié</b>.
                 </div>
             {% endif %}
         {% endif %}

--- a/app/Resources/views/booking/home_booked_shifts.html.twig
+++ b/app/Resources/views/booking/home_booked_shifts.html.twig
@@ -6,20 +6,38 @@
         {% if use_fly_and_fixed %}
             <li class="active">
                 <div class="collapsible-header">
-                    <i class="material-icons">event</i>Créneau fixe
+                    <i class="material-icons">event</i>Créneau{% if period_positions | length > 1 %}x{% endif %} fixe
+                    {% if member.flying and period_positions | length > 1 or not member.flying and period_positions | length == 0 %}
+                        <span style="margin-left:14px;">⚠️</span>
+                    {% endif %}
                 </div>
                 <div class="collapsible-body">
-                    {% if period_positions %}
-                        <div class="row">
+                    <div class="row">
+                        {% if period_positions | length > 0 %}
                             {% for period_position in period_positions %}
                                 <div class="col s12 m6 xl4">
                                     {% include "user/_partial/period_position_card.html.twig" with { period_position: period_position } %}
                                 </div>
                             {% endfor %}
-                        </div>
-                    {% else %}
-                        Pas de créneau fixe
-                    {% endif %}
+                            {% if member.flying %}
+                                <div class="col s12">
+                                    <div class="card-panel red white-text">
+                                        Votre compte est <strong>volant</strong> alors que vous avez {{ period_positions | length }} créneau{% if period_positions | length > 1 %}x{% endif %} fixe.
+                                    </div>
+                                </div>
+                            {% endif %}
+                        {% else %}
+                            {% if not member.flying %}
+                                <div class="col s12">
+                                    <div class="card-panel red white-text">
+                                        Votre compte est <strong>fixe</strong> alors que vous n'avez pas de créneaux fixe.
+                                    </div>
+                                </div>
+                            {% else %}
+                                <span>Aucun créneau fixe</span>
+                            {% endif %}
+                        {% endif %}
+                    </div>
                 </div>
             </li>
         {% endif %}
@@ -35,17 +53,17 @@
                 </div>
             </li>
         {% endif %}
-        {% for cycle, shiftsOfCycle in shiftsByCycle %}
+        {% for cycle, shifts in shifts_by_cycle %}
             {% if (cycle in [0, 1]) %}
                 <li class="active">
                     <div class="collapsible-header">
                         <i class="material-icons">date_range</i>{% if member.beneficiaries | length > 1 %}Vos{% else %}Mes{% endif %} créneaux pour le cycle {% if cycle == 0 %}courant{% else %}suivant{% endif %} (du {{ membership_service.startOfCycle(member,cycle) | date_fr_long }} au {{ membership_service.endOfCycle(member,cycle) | date_fr_long }})
                     </div>
                     <div class="collapsible-body">
-                        {% if shiftsOfCycle | length > 0 %}
+                        {% if shifts | length > 0 %}
                             <div class="row">
-                                {% for shift in shiftsOfCycle %}
-                                    <div class="col s12 m6 xl4 {% if shiftsOfCycle | length == 1 %}push-m3{% endif %}">
+                                {% for shift in shifts %}
+                                    <div class="col s12 m6 xl4 {% if shifts | length == 1 %}push-m3{% endif %}">
                                         {% include "booking/_partial/home_shift_card.html.twig" with { shift: shift } %}
                                     </div>
                                 {% endfor %}
@@ -66,7 +84,7 @@
                 <div class="row">
                     {% for cycle in -1..(-1 * max_nb_of_past_cycles_to_display) %}
                         <div class="col s12 m6 xl4">
-                            {% set previousShifts = shiftsByCycle[cycle] %}
+                            {% set previousShifts = shifts_by_cycle[cycle] %}
                             <h6>Cycle précédent (du {{ membership_service.startOfCycle(member,cycle) | date_short }} au {{ membership_service.endOfCycle(member,cycle) | date_short }})</h6>
                             {% if previousShifts | length > 0 %}
                                 {% for shift in previousShifts %}

--- a/app/Resources/views/booking/home_booked_shifts.html.twig
+++ b/app/Resources/views/booking/home_booked_shifts.html.twig
@@ -36,7 +36,8 @@
                                     </div>
                                 </div>
                             {% else %}
-                                <span>Aucun créneau fixe</span>
+                                <span>Aucun créneau fixe</span><br />
+                                <span>(vous avez un compte volant)</span>
                             {% endif %}
                         {% endif %}
                     </div>

--- a/app/Resources/views/booking/home_booked_shifts.html.twig
+++ b/app/Resources/views/booking/home_booked_shifts.html.twig
@@ -21,16 +21,16 @@
                             {% endfor %}
                             {% if member.flying %}
                                 <div class="col s12">
-                                    <div class="card-panel red white-text">
-                                        Votre compte est <strong>volant</strong> alors que vous avez {{ period_positions | length }} créneau{% if period_positions | length > 1 %}x{% endif %} fixe.
+                                    <div class="card-panel teal warning white-text">
+                                        {% if member.beneficiaries | length > 1 %}Votre{% else %}Ton{% endif %} compte est <strong>volant</strong> alors que {% if member.beneficiaries | length > 1 %}vous avez{% else %}tu as{% endif %} {{ period_positions | length }} créneau{% if period_positions | length > 1 %}x{% endif %} fixe.
                                     </div>
                                 </div>
                             {% endif %}
                         {% else %}
                             {% if not member.flying %}
                                 <div class="col s12">
-                                    <div class="card-panel red white-text">
-                                        Votre compte est <strong>fixe</strong> alors que vous n'avez pas de créneaux fixe.
+                                    <div class="card-panel teal warning white-text">
+                                        {% if member.beneficiaries | length > 1 %}Votre{% else %}Ton{% endif %} compte est <strong>fixe</strong> alors que {% if member.beneficiaries | length > 1 %}vous n'avez{% else %}tu n'as{% endif %} pas de créneaux fixe.
                                     </div>
                                 </div>
                             {% else %}

--- a/app/Resources/views/booking/home_booked_shifts.html.twig
+++ b/app/Resources/views/booking/home_booked_shifts.html.twig
@@ -7,8 +7,10 @@
             <li class="active">
                 <div class="collapsible-header">
                     <i class="material-icons">event</i>Créneau{% if period_positions | length > 1 %}x{% endif %} fixe
-                    {% if member.flying and period_positions | length > 1 or not member.flying and period_positions | length == 0 %}
-                        <span style="margin-left:14px;">⚠️</span>
+                    {% if fly_and_fixed_entity_flying == 'Membership' %}
+                        {% if member.flying and period_positions | length > 1 or not member.flying and period_positions | length == 0 %}
+                            <span style="margin-left:14px;">⚠️</span>
+                        {% endif %}
                     {% endif %}
                 </div>
                 <div class="collapsible-body">
@@ -19,7 +21,7 @@
                                     {% include "user/_partial/period_position_card.html.twig" with { period_position: period_position } %}
                                 </div>
                             {% endfor %}
-                            {% if member.flying %}
+                            {% if fly_and_fixed_entity_flying == 'Membership' and member.flying %}
                                 <div class="col s12">
                                     <div class="card-panel teal warning white-text">
                                         {% if member.beneficiaries | length > 1 %}Votre{% else %}Ton{% endif %} compte est <strong>volant</strong> alors que {% if member.beneficiaries | length > 1 %}vous avez{% else %}tu as{% endif %} {{ period_positions | length }} créneau{% if period_positions | length > 1 %}x{% endif %} fixe.
@@ -27,7 +29,7 @@
                                 </div>
                             {% endif %}
                         {% else %}
-                            {% if not member.flying %}
+                            {% if fly_and_fixed_entity_flying == 'Membership' and not member.flying %}
                                 <div class="col s12">
                                     <div class="card-panel teal warning white-text">
                                         {% if member.beneficiaries | length > 1 %}Votre{% else %}Ton{% endif %} compte est <strong>fixe</strong> alors que {% if member.beneficiaries | length > 1 %}vous n'avez{% else %}tu n'as{% endif %} pas de créneaux fixe.

--- a/app/Resources/views/member/_partial/info_misc.html.twig
+++ b/app/Resources/views/member/_partial/info_misc.html.twig
@@ -1,3 +1,3 @@
-<p style="margin-top:0">Date de création du membre : {{ member.createdAt | date_fr_full }}</p>
+<p style="margin-top:0">Date de création du compte du membre : {{ member.createdAt | date_fr_full }}</p>
 
 <p>Date du tout premier créneau : {% if member.firstShiftDate %}{{ member.firstShiftDate | date_fr_full }}{% else %}Néant{% endif %}</p>

--- a/app/Resources/views/member/_partial/info_misc.html.twig
+++ b/app/Resources/views/member/_partial/info_misc.html.twig
@@ -1,3 +1,3 @@
-<p style="margin-top:0">Date de création du compte-membre : {{ member.createdAt | date_fr_full }}</p>
+<p style="margin-top:0">Date de création du membre : {{ member.createdAt | date_fr_full }}</p>
 
 <p>Date du tout premier créneau : {% if member.firstShiftDate %}{{ member.firstShiftDate | date_fr_full }}{% else %}Néant{% endif %}</p>

--- a/app/Resources/views/member/_partial/shifts.html.twig
+++ b/app/Resources/views/member/_partial/shifts.html.twig
@@ -5,14 +5,23 @@
 {% if use_fly_and_fixed %}
     <div class="row">
         <h6>Créneau{% if period_positions | length > 1 %}x{% endif %} fixe</h6>
-        {% if period_positions %}
+        {% if period_positions | length > 0 %}
             {% for period_position in period_positions %}
                 <div class="col s12 m6 xl4">
                     {% include "user/_partial/period_position_card.html.twig" with { period_position: period_position, show_actions: true } %}
                 </div>
             {% endfor %}
+            {% if member.flying %}
+                <div class="card-panel red white-text">
+                    Ce compte-membre est volant alors qu'il a 1 ou plusieurs créneaux fixe.
+                </div>
+            {% endif %}
         {% else %}
-            Pas de créneau fixe
+            {% if not member.flying %}
+                <div class="card-panel red white-text">
+                    Ce compte-membre est fixe alors qu'il n'a aucun créneaux fixe.
+                </div>
+            {% endif %}
         {% endif %}
     </div>
 {% endif %}

--- a/app/Resources/views/member/_partial/shifts.html.twig
+++ b/app/Resources/views/member/_partial/shifts.html.twig
@@ -12,15 +12,21 @@
                 </div>
             {% endfor %}
             {% if member.flying %}
-                <div class="card-panel red white-text">
-                    Ce compte-membre est volant alors qu'il a 1 ou plusieurs créneaux fixe.
+                <div class="col s12">
+                    <div class="card-panel red white-text">
+                        Ce membre est <strong>volant</strong> alors qu'il a {{ period_positions | length }} créneau{% if period_positions | length > 1 %}x{% endif %} fixe.
+                    </div>
                 </div>
             {% endif %}
         {% else %}
             {% if not member.flying %}
-                <div class="card-panel red white-text">
-                    Ce compte-membre est fixe alors qu'il n'a aucun créneaux fixe.
+                <div class="col s12">
+                    <div class="card-panel red white-text">
+                        Ce membre est <strong>fixe</strong> alors qu'il n'a aucun créneaux fixe.
+                    </div>
                 </div>
+            {% else %}
+                <span>Aucun créneau fixe</span>
             {% endif %}
         {% endif %}
     </div>
@@ -30,7 +36,7 @@
     <div class="row">
         <h6>Créneaux</h6>
         <div class="card-panel red white-text">
-            Ce compte-membre n'est pas encore inscrit à son premier créneau.
+            Ce membre n'est pas encore inscrit à son premier créneau.
         </div>
     </div>
 {% else %}

--- a/app/Resources/views/member/_partial/shifts.html.twig
+++ b/app/Resources/views/member/_partial/shifts.html.twig
@@ -11,7 +11,7 @@
                     {% include "user/_partial/period_position_card.html.twig" with { period_position: period_position, show_actions: true } %}
                 </div>
             {% endfor %}
-            {% if member.flying %}
+            {% if fly_and_fixed_entity_flying == 'Membership' and member.flying %}
                 <div class="col s12">
                     <div class="card-panel red white-text">
                         Ce membre est <strong>volant</strong> alors qu'il a {{ period_positions | length }} créneau{% if period_positions | length > 1 %}x{% endif %} fixe.
@@ -19,14 +19,15 @@
                 </div>
             {% endif %}
         {% else %}
-            {% if not member.flying %}
+            {% if fly_and_fixed_entity_flying == 'Membership' and not member.flying %}
                 <div class="col s12">
                     <div class="card-panel red white-text">
                         Ce membre est <strong>fixe</strong> alors qu'il n'a aucun créneaux fixe.
                     </div>
                 </div>
             {% else %}
-                <span>Aucun créneau fixe</span>
+                <span>Aucun créneau fixe</span><br />
+                <span>(compte volant)</span>
             {% endif %}
         {% endif %}
     </div>

--- a/app/Resources/views/member/show.html.twig
+++ b/app/Resources/views/member/show.html.twig
@@ -93,7 +93,7 @@
                 {% endif %}
             </div>
             <div class="collapsible-body white">
-                {% include "member/_partial/shifts.html.twig" %}
+                {% include "member/_partial/shifts.html.twig" with { member: member, period_positions: period_positions, shifts_by_cycle: shifts_by_cycle } %}
             </div>
         </li>
 

--- a/app/Resources/views/member/show.html.twig
+++ b/app/Resources/views/member/show.html.twig
@@ -88,8 +88,12 @@
         <li id="shifts">
             <div class="collapsible-header {% if frontend_cookie and frontend_cookie.shifts_show is defined and frontend_cookie.user_show.shifts_open is defined and frontend_cookie.user_show.shifts_open %}active{% endif %}">
                 <i class="material-icons">date_range</i>Créneaux
-                {% if not member.firstShiftDate or use_fly_and_fixed and member.flying and period_positions | length > 1 or use_fly_and_fixed and not member.flying and period_positions | length == 0 %}
+                {% if not member.firstShiftDate %}
                     <span style="margin-left:14px;">⚠️</span>
+                {% elseif use_fly_and_fixed and fly_and_fixed_entity_flying == 'Membership' %}
+                    {% if member.flying and period_positions | length > 1 or not member.flying and period_positions | length == 0 %}
+                        <span style="margin-left:14px;">⚠️</span>
+                    {% endif %}
                 {% endif %}
             </div>
             <div class="collapsible-body white">

--- a/app/Resources/views/member/show.html.twig
+++ b/app/Resources/views/member/show.html.twig
@@ -88,7 +88,7 @@
         <li id="shifts">
             <div class="collapsible-header {% if frontend_cookie and frontend_cookie.shifts_show is defined and frontend_cookie.user_show.shifts_open is defined and frontend_cookie.user_show.shifts_open %}active{% endif %}">
                 <i class="material-icons">date_range</i>Créneaux
-                {% if not member.firstShiftDate %}
+                {% if not member.firstShiftDate or use_fly_and_fixed and member.flying and period_positions | length > 1 or use_fly_and_fixed and not member.flying and period_positions | length == 0 %}
                     <span style="margin-left:14px;">⚠️</span>
                 {% endif %}
             </div>

--- a/src/AppBundle/Controller/BookingController.php
+++ b/src/AppBundle/Controller/BookingController.php
@@ -63,14 +63,14 @@ class BookingController extends Controller
      */
     public function homepageShiftsAction(): Response
     {
-        $membership = $this->getUser()->getBeneficiary()->getMembership();
-        $beneficiaries = $membership->getBeneficiaries();
-
         $em = $this->getDoctrine()->getManager();
-        $preceding_previous_cycle_start = $this->get('membership_service')->getStartOfCycle($membership, -1 * $this->getParameter('max_nb_of_past_cycles_to_display'));
-        $next_cycle_end = $this->get('membership_service')->getEndOfCycle($membership, 1);
-        $shifts_by_cycle = $em->getRepository('AppBundle:Shift')->findShiftsByCycles($membership, $preceding_previous_cycle_start, $next_cycle_end);
-        $period_positions = $em->getRepository('AppBundle:PeriodPosition')->findByBeneficiaries($beneficiaries);
+
+        $member = $this->getUser()->getBeneficiary()->getMembership();
+
+        $period_positions = $this->get('membership_service')->getPeriodPositions($member);
+        $preceding_previous_cycle_start = $this->get('membership_service')->getStartOfCycle($member, -1 * $this->getParameter('max_nb_of_past_cycles_to_display'));
+        $next_cycle_end = $this->get('membership_service')->getEndOfCycle($member, 1);
+        $shifts_by_cycle = $em->getRepository('AppBundle:Shift')->findShiftsByCycles($member, $preceding_previous_cycle_start, $next_cycle_end);
 
         $shiftFreeForms = [];
         foreach ($shifts_by_cycle as $key => $shifts) {
@@ -80,9 +80,9 @@ class BookingController extends Controller
         }
 
         return $this->render('booking/home_booked_shifts.html.twig', array(
-            'shift_free_forms' => $shiftFreeForms,
             'period_positions' => $period_positions,
-            'shiftsByCycle' => $shifts_by_cycle,
+            'shifts_by_cycle' => $shifts_by_cycle,
+            'shift_free_forms' => $shiftFreeForms,
         ));
     }
 

--- a/src/AppBundle/Controller/MembershipController.php
+++ b/src/AppBundle/Controller/MembershipController.php
@@ -167,11 +167,12 @@ class MembershipController extends Controller
             }
         }
 
-        $period_positions = $em->getRepository('AppBundle:PeriodPosition')->findByBeneficiaries($member->getBeneficiaries());
+        $period_positions = $this->get('membership_service')->getPeriodPositions($member);
         $previous_cycle_start = $this->get('membership_service')->getStartOfCycle($member, -1 * $this->getParameter('max_nb_of_past_cycles_to_display'));
         $next_cycle_end = $this->get('membership_service')->getEndOfCycle($member, 1);
         $shifts_by_cycle = $em->getRepository('AppBundle:Shift')->findShiftsByCycles($member, $previous_cycle_start, $next_cycle_end);
         $shifts_by_cycle = array_reverse($shifts_by_cycle, true);  // from latest to oldest
+
         $shiftFreeForms = [];
         $shiftValidateInvalidateForms = [];
         foreach ($shifts_by_cycle as $shifts) {

--- a/src/AppBundle/Entity/Beneficiary.php
+++ b/src/AppBundle/Entity/Beneficiary.php
@@ -579,6 +579,16 @@ class Beneficiary
     }
 
     /**
+     * Get periodPositions
+     *
+     * @return \Doctrine\Common\Collections\Collection
+     */
+    public function getPeriodPositions()
+    {
+        return $this->periodPositions;
+    }
+
+    /**
      * Add swipeCard
      *
      * @param \AppBundle\Entity\SwipeCard $swipeCard

--- a/src/AppBundle/Service/MembershipService.php
+++ b/src/AppBundle/Service/MembershipService.php
@@ -212,6 +212,11 @@ class MembershipService
         return $hasWarningStatus;
     }
 
+    public function getPeriodPositions(Membership $member)
+    {
+        return $this->em->getRepository('AppBundle:PeriodPosition')->findByBeneficiaries($member->getBeneficiaries());
+    }
+
     public function getShiftFreeLogs(Membership $member)
     {
         return $this->em->getRepository('AppBundle:ShiftFreeLog')->getMemberShiftFreed($member);


### PR DESCRIPTION
Suite de #956

### Quoi ?

Coté admin, et coté membre, indiquer des messages si le membre est volant mais a un créneau fixe (et vice-versa).

### Captures d'écran

||Image|
|---|---|
|Admin : membre fixe sans créneau fixe|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/18a62fcd-9e9a-4a0e-a72d-e10cad9bc483)|
|Admin : membre volant avec créneau(x) fixe|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/ee95eead-c4d1-4a3e-b131-4c00da56ceb6)|
|Membre : fixe sans créneau fixe|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/02ba37cb-1d7f-4270-9a0f-75a546d24b53)|
|Membre : volant avec créneau(x) fixe|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/e0760a4b-1b1d-4e1c-bf79-4194d35bcd9f)|