### PR TITLE
Compte épargne : répare à nouveau l'erreur de début de cycle

### DIFF
--- a/src/AppBundle/Entity/Membership.php
+++ b/src/AppBundle/Entity/Membership.php
@@ -111,7 +111,7 @@ class Membership
     private $firstShiftDate;
 
     /**
-     * @ORM\OneToMany(targetEntity="TimeLog", mappedBy="membership", cascade={"persist", "remove"})
+     * @ORM\OneToMany(targetEntity="TimeLog", mappedBy="membership", cascade={"refresh", "persist", "remove"})
      * @OrderBy({"createdAt" = "DESC", "type" = "DESC"})
      */
     private $timeLogs;

--- a/src/AppBundle/Entity/Membership.php
+++ b/src/AppBundle/Entity/Membership.php
@@ -111,7 +111,7 @@ class Membership
     private $firstShiftDate;
 
     /**
-     * @ORM\OneToMany(targetEntity="TimeLog", mappedBy="membership", cascade={"refresh", "persist", "remove"})
+     * @ORM\OneToMany(targetEntity="TimeLog", mappedBy="membership", cascade={"persist", "remove"})
      * @OrderBy({"createdAt" = "DESC", "type" = "DESC"})
      */
     private $timeLogs;

--- a/src/AppBundle/Entity/TimeLog.php
+++ b/src/AppBundle/Entity/TimeLog.php
@@ -96,7 +96,9 @@ class TimeLog
      */
     public function setCreatedAtValue()
     {
-        $this->createdAt = new \DateTime();
+        if (!$this->createdAt) {
+            $this->createdAt = new \DateTime();
+        }
     }
 
     /**

--- a/src/AppBundle/EventListener/TimeLogEventListener.php
+++ b/src/AppBundle/EventListener/TimeLogEventListener.php
@@ -222,11 +222,12 @@ class TimeLogEventListener
             $this->em->persist($member);
         }
 
-        $dispatcher = $this->container->get('event_dispatcher');
         if (!$member->getFrozen()) {
             $current_cycle_start = $this->container->get('membership_service')->getStartOfCycle($member, 0);
             $current_cycle_end = $this->container->get('membership_service')->getEndOfCycle($member, 0);
             $currentCycleShifts = $this->em->getRepository('AppBundle:Shift')->findShiftsForMembership($member, $current_cycle_start, $current_cycle_end);
+
+            $dispatcher = $this->container->get('event_dispatcher');
             $dispatcher->dispatch(MemberCycleStartEvent::NAME, new MemberCycleStartEvent($member, $date, $currentCycleShifts));
         }
     }
@@ -250,7 +251,7 @@ class TimeLogEventListener
             $this->em->refresh($shift);  // added to prevent from returning cached (old) data
             $member = $shift->getShifter()->getMembership();
 
-            $date_plus_one_minute = clone($date)->modify("+1 minute");
+            $date_plus_one_minute = (clone $date)->modify("+1 minute");
             $member_counter_time = $member->getShiftTimeCount($date_plus_one_minute);  // $date_plus_one_minute? to be sure we take the above log into account
             $member_counter_extra_time = $member_counter_time - ($this->due_duration_by_cycle + $this->max_time_at_end_of_shift);
 
@@ -309,7 +310,7 @@ class TimeLogEventListener
 
         $this->em->refresh($member);  // added to prevent from returning cached (old) data
 
-        $date_plus_one_minute = clone($date)->modify("+1 minute");
+        $date_plus_one_minute = (clone $date)->modify("+1 minute");
         $member_counter_time = $member->getShiftTimeCount($date_plus_one_minute);  // $date_plus_one_minute? to be sure we take the above log into account
         $member_counter_extra_time = $member_counter_time - $this->max_time_at_end_of_shift;  // not $this->due_duration_by_cycle? already substracted in the above log
 
@@ -329,7 +330,7 @@ class TimeLogEventListener
             if ($this->use_time_log_saving) {
                 $member_saving_time = $member->getSavingTimeCount($date_plus_one_minute);  // $date_plus_one_minute? to be sure we take the above log into account
                 if ($member_saving_time > 0) {
-                    $date_minus_one_day = clone($date)->modify("-1 days");
+                    $date_minus_one_day = (clone $date)->modify("-1 days");
                     // count missed shifts in the previous cycle
                     $previous_cycle_missed_shifts_count = $this->container->get('membership_service')->getCycleShiftMissedCount($member, $date_minus_one_day);
                     // count freed shifts within the min_time_in_advance in the previous cycle

--- a/src/AppBundle/EventListener/TimeLogEventListener.php
+++ b/src/AppBundle/EventListener/TimeLogEventListener.php
@@ -163,10 +163,10 @@ class TimeLogEventListener
                 // the member's saving account does not have enough time
             } else {
                 // decrement the savingTimeCount
-                $log = $this->container->get('time_log_service')->initSavingTimeLog($member, -1 * $shift->getDuration(), $shift);
+                $log = $this->container->get('time_log_service')->initSavingTimeLog($member, -1 * $shift->getDuration(), null, $shift);
                 $this->em->persist($log);
                 // increment the shiftTimeCount
-                $log = $this->container->get('time_log_service')->initShiftFreedSavingTimeLog($member, $shift->getDuration(), $shift);
+                $log = $this->container->get('time_log_service')->initShiftFreedSavingTimeLog($member, $shift->getDuration(), null, $shift);
                 $this->em->persist($log);
                 $this->em->flush();
             }
@@ -257,10 +257,10 @@ class TimeLogEventListener
 
             if ($member_counter_extra_time > 0) {
                 // first decrement the shiftTimeCount
-                $log = $this->container->get('time_log_service')->initRegulateOptionalShiftsTimeLog($member, -1 * $member_counter_extra_time);
+                $log = $this->container->get('time_log_service')->initRegulateOptionalShiftsTimeLog($member, -1 * $member_counter_extra_time, $date_plus_one_second);
                 $this->em->persist($log);
                 // then increment the savingTimeCount
-                $log = $this->container->get('time_log_service')->initSavingTimeLog($member, $member_counter_extra_time, $shift);
+                $log = $this->container->get('time_log_service')->initSavingTimeLog($member, $member_counter_extra_time, $date_plus_one_second, $shift);
                 $this->em->persist($log);
                 $this->em->flush();
             }
@@ -317,11 +317,11 @@ class TimeLogEventListener
         // member did extra work
         if ($member_counter_time > 0 && $member_counter_extra_time > 0) {
             // remove the extra_time from the shiftTime
-            $log = $this->container->get('time_log_service')->initRegulateOptionalShiftsTimeLog($member, -1 * $member_counter_extra_time);
+            $log = $this->container->get('time_log_service')->initRegulateOptionalShiftsTimeLog($member, -1 * $member_counter_extra_time, $date_plus_one_second);
             $this->em->persist($log);
             if ($this->use_time_log_saving) {
                 // add the extra_time to the savingTime
-                $log = $this->container->get('time_log_service')->initSavingTimeLog($member, 1 * $member_counter_extra_time);
+                $log = $this->container->get('time_log_service')->initSavingTimeLog($member, 1 * $member_counter_extra_time, $date_plus_one_second);
                 $this->em->persist($log);
             }
         // member has a negative shiftTimeCount...
@@ -342,10 +342,10 @@ class TimeLogEventListener
                         $missing_due_time = -1 * $member_counter_time;
                         $withdraw_from_saving = min($member_saving_time, $missing_due_time);
                         // first decrement the savingTime
-                        $log = $this->container->get('time_log_service')->initSavingTimeLog($member, -1 * $withdraw_from_saving);
+                        $log = $this->container->get('time_log_service')->initSavingTimeLog($member, -1 * $withdraw_from_saving, $date_plus_one_second);
                         $this->em->persist($log);
                         // then increment the shiftTime
-                        $log = $this->container->get('time_log_service')->initCycleEndSavingTimeLog($member, 1 * $withdraw_from_saving);
+                        $log = $this->container->get('time_log_service')->initCycleEndSavingTimeLog($member, 1 * $withdraw_from_saving, $date_plus_one_second);
                         $this->em->persist($log);
                     } else {
                         // not allowed to use member's saving
@@ -357,7 +357,7 @@ class TimeLogEventListener
                         if ($previous_cycle_freed_shifts_less_than_min_time_in_advance_count) {
                             $description = $description . (($previous_cycle_missed_shifts_count > 0) ? ' & ' : '') . $previous_cycle_freed_shifts_less_than_min_time_in_advance_count . " créneau" . (($previous_cycle_freed_shifts_less_than_min_time_in_advance_count > 1) ? 'x' : '') . " annulé" . (($previous_cycle_freed_shifts_less_than_min_time_in_advance_count > 1) ? 's' : '') . " sous les " . $this->time_log_saving_shift_free_min_time_in_advance_days . " jours)";
                         }
-                        $log = $this->container->get('time_log_service')->initCycleEndSavingTimeLog($member, 0, $description);
+                        $log = $this->container->get('time_log_service')->initCycleEndSavingTimeLog($member, 0, $date_plus_one_second, $description);
                         $this->em->persist($log);
                     }
                 }

--- a/src/AppBundle/EventListener/TimeLogEventListener.php
+++ b/src/AppBundle/EventListener/TimeLogEventListener.php
@@ -251,8 +251,8 @@ class TimeLogEventListener
             $this->em->refresh($shift);  // added to prevent from returning cached (old) data
             $member = $shift->getShifter()->getMembership();
 
-            $date_plus_one_minute = (clone $date)->modify("+1 minute");
-            $member_counter_time = $member->getShiftTimeCount($date_plus_one_minute);  // $date_plus_one_minute? to be sure we take the above log into account
+            $date_plus_one_second = (clone $date)->modify("+1 second");
+            $member_counter_time = $member->getShiftTimeCount($date_plus_one_second);  // $date_plus_one_second? to be sure we take the above log into account
             $member_counter_extra_time = $member_counter_time - ($this->due_duration_by_cycle + $this->max_time_at_end_of_shift);
 
             if ($member_counter_extra_time > 0) {
@@ -310,8 +310,8 @@ class TimeLogEventListener
 
         $this->em->refresh($member);  // added to prevent from returning cached (old) data
 
-        $date_plus_one_minute = (clone $date)->modify("+1 minute");
-        $member_counter_time = $member->getShiftTimeCount($date_plus_one_minute);  // $date_plus_one_minute? to be sure we take the above log into account
+        $date_plus_one_second = (clone $date)->modify("+1 second");
+        $member_counter_time = $member->getShiftTimeCount($date_plus_one_second);  // $date_plus_one_second? to be sure we take the above log into account
         $member_counter_extra_time = $member_counter_time - $this->max_time_at_end_of_shift;  // not $this->due_duration_by_cycle? already substracted in the above log
 
         // member did extra work
@@ -328,7 +328,7 @@ class TimeLogEventListener
         } elseif ($member_counter_time < 0) {
             // we can *maybe* use the member's savingTime to bring his shiftTime back to 0
             if ($this->use_time_log_saving) {
-                $member_saving_time = $member->getSavingTimeCount($date_plus_one_minute);  // $date_plus_one_minute? to be sure we take the above log into account
+                $member_saving_time = $member->getSavingTimeCount($date_plus_one_second);  // $date_plus_one_second? to be sure we take the above log into account
                 if ($member_saving_time > 0) {
                     $date_minus_one_day = (clone $date)->modify("-1 days");
                     // count missed shifts in the previous cycle

--- a/src/AppBundle/Service/TimeLogService.php
+++ b/src/AppBundle/Service/TimeLogService.php
@@ -101,9 +101,9 @@ class TimeLogService
      * @param \DateTime $date
      * @return TimeLog
      */
-    public function initShiftFreedSavingTimeLog(Membership $member, $time, $shift)
+    public function initShiftFreedSavingTimeLog(Membership $member, $time, \DateTime $date = null, $shift)
     {
-        $log = $this->initTimeLog($member);
+        $log = $this->initTimeLog($member, $date);
         $log->setType(TimeLog::TYPE_SHIFT_FREED_SAVING);
         $log->setShift($shift);
         $log->setTime($time);  // $shift->getDuration()
@@ -148,9 +148,9 @@ class TimeLogService
      * @param \DateTime $date
      * @return TimeLog
      */
-    public function initCycleEndSavingTimeLog(Membership $member, $time, $description = null)
+    public function initCycleEndSavingTimeLog(Membership $member, $time, \DateTime $date = null, $description = null)
     {
-        $log = $this->initTimeLog($member, null, $description);
+        $log = $this->initTimeLog($member, $date, $description);
         $log->setType(TimeLog::TYPE_CYCLE_END_SAVING);
         $log->setTime($time);
 
@@ -158,15 +158,15 @@ class TimeLogService
     }
 
     /**
-     * Initialize a "regulation optjonal shifts" log with the member data
+     * Initialize a "regulation optional shifts" log with the member data
      * 
      * @param Membership $member
      * @param int $time
      * @return TimeLog
      */
-    public function initRegulateOptionalShiftsTimeLog(Membership $member, $time)
+    public function initRegulateOptionalShiftsTimeLog(Membership $member, $time, \DateTime $date = null)
     {
-        $log = $this->initTimeLog($member);
+        $log = $this->initTimeLog($member, $date);
         $log->setType(TimeLog::TYPE_REGULATE_OPTIONAL_SHIFTS);
         $log->setTime($time);
 
@@ -180,9 +180,9 @@ class TimeLogService
      * @param int $time
      * @return TimeLog
      */
-    public function initSavingTimeLog(Membership $member, $time, $shift = null)
+    public function initSavingTimeLog(Membership $member, $time, \DateTime $date = null, $shift = null)
     {
-        $log = $this->initTimeLog($member);
+        $log = $this->initTimeLog($member, $date);
         $log->setType(TimeLog::TYPE_SAVING);
         $log->setTime($time);
         if ($shift) {


### PR DESCRIPTION
Correction de la #990 

Le timelog de début de cycle n'était toujours pas pris en compte

Modifications apportées : 
- ajouté un refresh sur les TimeLogs quand on refresh un Membership
- corrigé le format de `clone`