### PR TITLE
Horaires d'ouverture : pouvoir configurer les messages du bandeau Ouvert / Fermé

### DIFF
--- a/app/Resources/views/admin/openinghour/_partial/open_closed_badge.html.twig
+++ b/app/Resources/views/admin/openinghour/_partial/open_closed_badge.html.twig
@@ -1,7 +1,7 @@
 {% if opening_hour_kind_service.hasEnabled %}
     {% if opening_hour_service.isOpen %}
-        <span class="badge green white-text" style="font-family:'Raleway',sans-serif;float:unset;">Ouvert</span>
+        <span class="badge green white-text" style="font-family:'Raleway',sans-serif;float:unset;">{{ opening_hour_open_message }}</span>
     {% else %}
-        <span class="badge red white-text" style="font-family:'Raleway',sans-serif;float:unset;">Fermé</span>
+        <span class="badge red white-text" style="font-family:'Raleway',sans-serif;float:unset;">{{ opening_hour_closed_message }}</span>
     {% endif %}
 {% endif %}

--- a/app/Resources/views/admin/openinghour/_partial/open_closed_badge.html.twig
+++ b/app/Resources/views/admin/openinghour/_partial/open_closed_badge.html.twig
@@ -1,7 +1,7 @@
 {% if opening_hour_kind_service.hasEnabled %}
     {% if opening_hour_service.isOpen %}
-        <span class="badge green white-text" style="font-family:'Raleway',sans-serif;float:unset;">{{ opening_hour_open_message }}</span>
+        <span class="badge green white-text" style="font-family:'Raleway',sans-serif;float:unset;">{{ opening_hour_open_closed_header_open_message }}</span>
     {% else %}
-        <span class="badge red white-text" style="font-family:'Raleway',sans-serif;float:unset;">{{ opening_hour_closed_message }}</span>
+        <span class="badge red white-text" style="font-family:'Raleway',sans-serif;float:unset;">{{ opening_hour_open_closed_header_closed_message }}</span>
     {% endif %}
 {% endif %}

--- a/app/Resources/views/admin/openinghour/_partial/open_closed_surheader.html.twig
+++ b/app/Resources/views/admin/openinghour/_partial/open_closed_surheader.html.twig
@@ -3,9 +3,9 @@
         <div class="wrapper center-align {% if opening_hour_service.isOpen %}green{% else %}red{% endif %}">
             <div class="col s12">
                 {% if opening_hour_service.isOpen %}
-                    <span class="white-text">{{ opening_hour_open_message }}</span>
+                    <span class="white-text">{{ opening_hour_open_closed_header_open_message }}</span>
                 {% else %}
-                    <span class="white-text">{{ opening_hour_closed_message }}</span>
+                    <span class="white-text">{{ opening_hour_open_closed_header_closed_message }}</span>
                 {% endif %}
             </div>
         </div>

--- a/app/Resources/views/admin/openinghour/_partial/open_closed_surheader.html.twig
+++ b/app/Resources/views/admin/openinghour/_partial/open_closed_surheader.html.twig
@@ -3,9 +3,9 @@
         <div class="wrapper center-align {% if opening_hour_service.isOpen %}green{% else %}red{% endif %}">
             <div class="col s12">
                 {% if opening_hour_service.isOpen %}
-                    <span class="white-text">Ouvert</span>
+                    <span class="white-text">{{ opening_hour_open_message }}</span>
                 {% else %}
-                    <span class="white-text">Fermé</span>
+                    <span class="white-text">{{ opening_hour_closed_message }}</span>
                 {% endif %}
             </div>
         </div>

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -102,6 +102,8 @@ twig:
     time_log_saving_shift_free_min_time_in_advance_days: '%time_log_saving_shift_free_min_time_in_advance_days%'
     # opening hours
     display_opening_hour_open_closed_header: '%display_opening_hour_open_closed_header%'
+    opening_hour_open_message: '%opening_hour_open_message%'
+    opening_hour_closed_message: '%opening_hour_closed_message%'
     # role names & icons
     role_user_name: Utilisateur
     role_user_material_icon: person

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -102,8 +102,8 @@ twig:
     time_log_saving_shift_free_min_time_in_advance_days: '%time_log_saving_shift_free_min_time_in_advance_days%'
     # opening hours
     display_opening_hour_open_closed_header: '%display_opening_hour_open_closed_header%'
-    opening_hour_open_message: '%opening_hour_open_message%'
-    opening_hour_closed_message: '%opening_hour_closed_message%'
+    opening_hour_open_closed_header_open_message: '%opening_hour_open_closed_header_open_message%'
+    opening_hour_open_closed_header_closed_message: '%opening_hour_open_closed_header_closed_message%'
     # role names & icons
     role_user_name: Utilisateur
     role_user_material_icon: person

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -122,6 +122,8 @@ parameters:
     profile_display_task_list: true
     profile_display_time_log: true
     profile_display_shift_free_log: true
+    display_freeze_account: true
+    display_freeze_account_false_message: "Le gel de compte n'est pas autorisé."
 
     # User configuration
     user_account_not_enabled_material_icon: 'phonelink_off'
@@ -158,17 +160,20 @@ parameters:
     # Time log saving
     time_log_saving_shift_free_min_time_in_advance_days: null
 
+    # Opening hours
+    display_opening_hour_open_closed_header: true
+    opening_hour_open_message: "Ouvert"
+    opening_hour_closed_message: "Fermé"
+
+    # Code generation
+    code_generation_enabled: true
+    display_keys_shop: true
+
+    # Logging
     logging.mattermost.enabled: false
     logging.mattermost.level: 'critical'
     logging.mattermost.url: 'http://mattermost.yourcoop.local'
     logging.mattermost.channel: ~
-
     logging.swiftmailer.enabled: false
     logging.swiftmailer.level: 'critical'
     logging.swiftmailer.recipient: ~
-
-    code_generation_enabled: true
-    display_freeze_account: true
-    display_freeze_account_false_message: "Le gel de compte n'est pas autorisé."
-    display_keys_shop: true
-    display_opening_hour_open_closed_header: true

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -162,8 +162,8 @@ parameters:
 
     # Opening hours
     display_opening_hour_open_closed_header: true
-    opening_hour_open_message: "Ouvert"
-    opening_hour_closed_message: "Fermé"
+    opening_hour_open_closed_header_open_message: "Ouvert"
+    opening_hour_open_closed_header_closed_message: "Fermé"
 
     # Code generation
     code_generation_enabled: true


### PR DESCRIPTION
Suite de #886 

### Quoi ?

Ajout de 2 nouveaux paramètres - `opening_hour_open_closed_header_open_message` & `opening_hour_open_closed_header_closed_message` - pour pouvoir afficher un message alternatif à "Ouvert" et "Fermé" dans le bandeau en haut.

### Capture d'écran

![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/d96473ad-261a-400e-8760-4d7e01e32e3b)
