### PR TITLE
Membre (coté admin) : pouvoir afficher l'historique de ses créneaux annulés

### DIFF
--- a/app/Resources/views/member/show.html.twig
+++ b/app/Resources/views/member/show.html.twig
@@ -95,7 +95,7 @@
 
         <!-- Créneaux -->
         <li id="shifts">
-            <div class="collapsible-header {% if frontend_cookie and frontend_cookie.user_show is defined and frontend_cookie.user_show.shifts_open is defined and frontend_cookie.user_show.shifts_open %}active{% endif %}">
+            <div class="collapsible-header {% if frontend_cookie and frontend_cookie.shifts_show is defined and frontend_cookie.user_show.shifts_open is defined and frontend_cookie.user_show.shifts_open %}active{% endif %}">
                 <i class="material-icons">date_range</i>Créneaux
                 {% if not member.firstShiftDate %}
                     <span style="margin-left:14px;">⚠️</span>
@@ -103,6 +103,16 @@
             </div>
             <div class="collapsible-body white">
                 {% include "member/_partial/shifts.html.twig" %}
+            </div>
+        </li>
+
+        <!-- Créneaux annulés -->
+        <li id="shifts">
+            <div class="collapsible-header {% if frontend_cookie and frontend_cookie.shiftfreelogs_show is defined and frontend_cookie.user_show.shifts_open is defined and frontend_cookie.user_show.shiftfreelogs_open %}active{% endif %}">
+                <i class="material-icons">delete_sweep</i>Historique des créneaux annulés
+            </div>
+            <div class="collapsible-body">
+                {% include "member/_partial/shift_free_logs.html.twig" with { shiftFreeLogs: membership_service.getShiftFreeLogs(member), custom_styles: "max-height:500px;overflow:scroll;" } %}
             </div>
         </li>
 

--- a/app/Resources/views/member/show.html.twig
+++ b/app/Resources/views/member/show.html.twig
@@ -107,14 +107,16 @@
         </li>
 
         <!-- Créneaux annulés -->
-        <li id="shifts">
-            <div class="collapsible-header {% if frontend_cookie and frontend_cookie.shiftfreelogs_show is defined and frontend_cookie.user_show.shifts_open is defined and frontend_cookie.user_show.shiftfreelogs_open %}active{% endif %}">
-                <i class="material-icons">delete_sweep</i>Historique des créneaux annulés
-            </div>
-            <div class="collapsible-body">
-                {% include "member/_partial/shift_free_logs.html.twig" with { shiftFreeLogs: membership_service.getShiftFreeLogs(member), custom_styles: "max-height:500px;overflow:scroll;" } %}
-            </div>
-        </li>
+        {% if admin_member_display_shift_free_log %}
+            <li id="shiftfreelogs">
+                <div class="collapsible-header {% if frontend_cookie and frontend_cookie.shiftfreelogs_show is defined and frontend_cookie.user_show.shifts_open is defined and frontend_cookie.user_show.shiftfreelogs_open %}active{% endif %}">
+                    <i class="material-icons">delete_sweep</i>Historique des créneaux annulés
+                </div>
+                <div class="collapsible-body">
+                    {% include "member/_partial/shift_free_logs.html.twig" with { shiftFreeLogs: membership_service.getShiftFreeLogs(member), custom_styles: "max-height:500px;overflow:scroll;" } %}
+                </div>
+            </li>
+        {% endif %}
 
         <!-- Badges -->
         {% if is_granted("ROLE_USER_MANAGER") %}

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -89,6 +89,8 @@ twig:
     beneficiary_main_icon: '%beneficiary_main_icon%'
     beneficiary_new_icon: '%beneficiary_new_icon%'
     beneficiary_flying_icon: '%beneficiary_flying_icon%'
+    # admin: member
+    admin_member_display_shift_free_log: '%admin_member_display_shift_free_log%'
     # swipe card
     display_swipe_cards_settings: '%display_swipe_cards_settings%'
     display_freeze_account: '%display_freeze_account%'

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -149,6 +149,9 @@ parameters:
     beneficiary_new_icon: '★'
     beneficiary_flying_icon: '✈'
 
+    # Admin: member
+    admin_member_display_shift_free_log: true
+
     # Swipe card configuration
     swipe_card_logging: true
     swipe_card_logging_anonymous: true


### PR DESCRIPTION
Grâce à #685, similaire à #862

### Quoi ?

Le membre peut déjà voir l'historique de ses créneaux annulés dans son profil.
On rajoute ce tableau coté admin.

Un paramètre permet de cacher cette section : `admin_member_display_shift_free_log`

### Capture d'écran

![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/2f2923f1-1322-47be-ab40-9704d1bc33a4)
