### PR TITLE
Compteur : bouger le tableau dans un template dédié

### DIFF
--- a/app/Resources/views/member/_partial/time_logs.html.twig
+++ b/app/Resources/views/member/_partial/time_logs.html.twig
@@ -1,31 +1,7 @@
 {% set from_admin = from_admin ?? false %}
 {% set time_log_delete_forms = time_log_delete_forms ?? [] %}
 
-<table>
-    <thead>
-        <tr>
-            <th>
-                TOTAL
-                {% if use_time_log_saving %}
-                    <span>TEMPS</span>
-                {% endif %}
-            </th>
-            <th>TOTAL CYCLE EN COURS</th>
-            {% if use_time_log_saving %}
-                <th>TOTAL EPARGNE</th>
-            {% endif %}
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td>{{ member.shiftTimeCount | duration_from_minutes }}</td>
-            <td>{{ member.shiftTimeCount(membership_service.endOfCycle(member)) | duration_from_minutes }}</td>
-            {% if use_time_log_saving %}
-                <td>{{ member.savingTimeCount | duration_from_minutes }}</td>
-            {% endif %}
-        </tr>
-    </tbody>
-</table>
+{% include "timelog/_partial/recap_table.html.twig" with { member: member } %}
 
 <div style="max-height:500px;overflow:scroll;">
     {% include "timelog/_partial/table.html.twig" with { timeLogs: member.timeLogs, from_admin: from_admin, time_log_delete_forms: time_log_delete_forms } %}

--- a/app/Resources/views/member/_partial/time_logs.html.twig
+++ b/app/Resources/views/member/_partial/time_logs.html.twig
@@ -28,60 +28,7 @@
 </table>
 
 <div style="max-height:500px;overflow:scroll;">
-    <table>
-        <thead>
-            <tr class="grey lighten-2">
-                <th>Date du log</th>
-                <th>Auteur</th>
-                <th>Temps</th>
-                <th>Motif</th>
-                <th>Créneau</th>
-                {% if from_admin and is_granted("ROLE_ADMIN") %}
-                    <th>Route</th>
-                {% endif %}
-                {% if from_admin and is_granted("ROLE_SUPER_ADMIN") %}
-                    <th>Actions</th>
-                {% endif %}
-            </tr>
-        </thead>
-        <tbody>
-            {% for timeLog in member.timeLogs %}
-                <tr id="{{ timeLog.id }}" class="{% if timeLog.type == 20 %}blue{% elseif timeLog.time > 0 %}green{% elseif timeLog.time < 0 %}red{% else %}grey{% endif %} lighten-5">
-                    <td title="{{ timeLog.createdAt | date_fr_full_with_time }}">{{ timeLog.createdAt | date_short }}</td>
-                    <td>
-                        {% if from_admin %}
-                            {% include "admin/member/_partial/member_or_user_link.html.twig" with { user: timeLog.createdBy, target_blank: true } %}
-                        {% else %}
-                            {{ timeLog.createdBy }}
-                        {% endif %}
-                    </td>
-                    <td>{{ timeLog.time | duration_from_minutes }}</td>
-                    <td>{{ timeLog.typeDisplay }}</td>
-                    <td>
-                        {% if timeLog.shift %}
-                            {{ timeLog.shift.job.name }} - {{ timeLog.shift.displayDateSeperateTime }}
-                            {% if timeLog.shift.shifter and timeLog.type not in [20, 21] %}
-                                ({{ timeLog.shift.shifter }})
-                            {% endif %}
-                        {% endif %}
-                    </td>
-                    {% if from_admin and is_granted("ROLE_ADMIN") %}
-                        <td>{{ timeLog.requestRoute }}</td>
-                    {% endif %}
-                    {% if from_admin and is_granted("ROLE_SUPER_ADMIN") %}
-                    <td>
-                        {{ form_start(time_log_delete_forms[timeLog.id], {'attr': {'id': 'form_time_log_delete_'~timeLog.id }}) }}
-                        {{ form_widget(time_log_delete_forms[timeLog.id]) }}
-                        <button type="submit" class="btn-floating red" title="Supprimer" onclick="return confirm('Etes-vous sûr de vouloir supprimer ce time log ?!');">
-                            <i class="material-icons left">delete</i>
-                        </button>
-                        {{ form_end(time_log_delete_forms[timeLog.id]) }}
-                    </td>
-                    {% endif %}
-                </tr>
-            {% endfor %}
-        </tbody>
-    </table>
+    {% include "timelog/_partial/table.html.twig" with { timeLogs: member.timeLogs, from_admin: from_admin, time_log_delete_forms: time_log_delete_forms } %}
 </div>
 
 {% if from_admin and is_granted("ROLE_SHIFT_MANAGER") %}

--- a/app/Resources/views/timelog/_partial/recap_table.html.twig
+++ b/app/Resources/views/timelog/_partial/recap_table.html.twig
@@ -1,0 +1,25 @@
+<table>
+    <thead>
+        <tr>
+            <th>
+                TOTAL
+                {% if use_time_log_saving %}
+                    <span>TEMPS</span>
+                {% endif %}
+            </th>
+            <th>TOTAL CYCLE EN COURS</th>
+            {% if use_time_log_saving %}
+                <th>TOTAL EPARGNE</th>
+            {% endif %}
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>{{ member.shiftTimeCount | duration_from_minutes }}</td>
+            <td>{{ member.shiftTimeCount(membership_service.endOfCycle(member)) | duration_from_minutes }}</td>
+            {% if use_time_log_saving %}
+                <td>{{ member.savingTimeCount | duration_from_minutes }}</td>
+            {% endif %}
+        </tr>
+    </tbody>
+</table>

--- a/app/Resources/views/timelog/_partial/table.html.twig
+++ b/app/Resources/views/timelog/_partial/table.html.twig
@@ -23,6 +23,7 @@
             <tr id="{{ timeLog.id }}" class="{% if timeLog.type == 20 %}blue{% elseif timeLog.time > 0 %}green{% elseif timeLog.time < 0 %}red{% else %}grey{% endif %} lighten-5">
                 <td title="{{ timeLog.createdAt | date_fr_full_with_time }}">
                     {{ timeLog.createdAt | date_short }}
+                    {% if timeLog.createdAt > date() %}<span>(futur)</span>{% endif %}
                 </td>
                 <td>
                     {% if from_admin %}

--- a/app/Resources/views/timelog/_partial/table.html.twig
+++ b/app/Resources/views/timelog/_partial/table.html.twig
@@ -1,0 +1,60 @@
+{% set from_admin = from_admin ?? false %}
+{% set time_log_delete_forms = time_log_delete_forms ?? [] %}
+
+
+<table>
+    <thead>
+        <tr class="grey lighten-2">
+            <th>Date du log</th>
+            <th>Auteur</th>
+            <th>Temps</th>
+            <th>Motif</th>
+            <th>Créneau</th>
+            {% if from_admin and is_granted("ROLE_ADMIN") %}
+                <th>Route</th>
+            {% endif %}
+            {% if from_admin and is_granted("ROLE_SUPER_ADMIN") %}
+                <th>Actions</th>
+            {% endif %}
+        </tr>
+    </thead>
+    <tbody>
+        {% for timeLog in timeLogs %}
+            <tr id="{{ timeLog.id }}" class="{% if timeLog.type == 20 %}blue{% elseif timeLog.time > 0 %}green{% elseif timeLog.time < 0 %}red{% else %}grey{% endif %} lighten-5">
+                <td title="{{ timeLog.createdAt | date_fr_full_with_time }}">
+                    {{ timeLog.createdAt | date_short }}
+                </td>
+                <td>
+                    {% if from_admin %}
+                        {% include "admin/member/_partial/member_or_user_link.html.twig" with { user: timeLog.createdBy, target_blank: true } %}
+                    {% else %}
+                        {{ timeLog.createdBy }}
+                    {% endif %}
+                </td>
+                <td>{{ timeLog.time | duration_from_minutes }}</td>
+                <td>{{ timeLog.typeDisplay }}</td>
+                <td>
+                    {% if timeLog.shift %}
+                        {{ timeLog.shift.job.name }} - {{ timeLog.shift.displayDateSeperateTime }}
+                        {% if timeLog.shift.shifter and timeLog.type not in [20, 21] %}
+                            ({{ timeLog.shift.shifter }})
+                        {% endif %}
+                    {% endif %}
+                </td>
+                {% if from_admin and is_granted("ROLE_ADMIN") %}
+                    <td>{{ timeLog.requestRoute }}</td>
+                {% endif %}
+                {% if from_admin and is_granted("ROLE_SUPER_ADMIN") %}
+                <td>
+                    {{ form_start(time_log_delete_forms[timeLog.id], {'attr': {'id': 'form_time_log_delete_'~timeLog.id }}) }}
+                    {{ form_widget(time_log_delete_forms[timeLog.id]) }}
+                    <button type="submit" class="btn-floating red" title="Supprimer" onclick="return confirm('Etes-vous sûr de vouloir supprimer ce time log ?!');">
+                        <i class="material-icons left">delete</i>
+                    </button>
+                    {{ form_end(time_log_delete_forms[timeLog.id]) }}
+                </td>
+                {% endif %}
+            </tr>
+        {% endfor %}
+    </tbody>
+</table>


### PR DESCRIPTION
### Quoi ?

Bouger le tableau du compteur temps / épargne dans un template dédié, dans un dossier `timelogs`.
Idem pour le tableau "recap".
Aussi rajouté un message "(futur)" pour les time log dans le futur (ca peut arriver ? en local quand je test oui parfois :sweat_smile:)

### Pourquoi ?

Il apparaît à la fois dans admin et profil, donc j'ai préféré le bouger pour le retrouver plus facilement