### PR TITLE
Filtre sur les membres : améliorer la liste des membres en retard de créneaux

### DIFF
--- a/src/AppBundle/Controller/AmbassadorController.php
+++ b/src/AppBundle/Controller/AmbassadorController.php
@@ -186,7 +186,7 @@ class AmbassadorController extends Controller
             'compteurlt' => 0,
             'registration' => 2,
         ];
-        $disabledFields = ['withdrawn', 'compteurlt', 'registration'];
+        $disabledFields = ['withdrawn', 'registration'];
 
         $form = $formHelper->createMemberShiftTimeLogFilterForm($this->createFormBuilder(), $defaults, $disabledFields);
         $form->handleRequest($request);

--- a/src/AppBundle/Controller/AmbassadorController.php
+++ b/src/AppBundle/Controller/AmbassadorController.php
@@ -180,7 +180,7 @@ class AmbassadorController extends Controller
     {
         $defaults = [
             'sort' => 'time',
-            'dir' => 'DESC',
+            'dir' => 'ASC',
             'withdrawn' => 1,
             'frozen' => 1,
             'compteurlt' => 0,

--- a/src/AppBundle/Controller/AmbassadorController.php
+++ b/src/AppBundle/Controller/AmbassadorController.php
@@ -191,29 +191,12 @@ class AmbassadorController extends Controller
         $form = $formHelper->createMemberShiftTimeLogFilterForm($this->createFormBuilder(), $defaults, $disabledFields);
         $form->handleRequest($request);
 
-        $qb = $formHelper->initSearchQuery($this->getDoctrine()->getManager());
-        $qb = $qb->leftJoin("m.registrations", "lr", Join::WITH,'lr.date > r.date')->addSelect("lr")
-            ->where('lr.id IS NULL') // registration is the last one registered
-            ->addSelect("(SELECT SUM(ti.time) FROM AppBundle\Entity\TimeLog ti WHERE ti.membership = m.id) AS HIDDEN time")
-            ->leftJoin("m.timeLogs", "tl")->addSelect("tl")
-            ->leftJoin("m.notes", "n")->addSelect("n");
+        $qb = $formHelper->initSearchQuery($this->getDoctrine()->getManager(), 'shifttimelog');
+        $qb = $formHelper->processSearchFormAmbassadorData($form, $qb);
 
-        if ($form->isSubmitted() && $form->isValid()) {
-            $qb = $formHelper->processSearchFormAmbassadorData($form, $qb);
-            $sort = $form->get('sort')->getData();
-            $order = $form->get('dir')->getData();
-            $currentPage = $form->get('page')->getData();
-        } else {
-            $sort = $defaults['sort'];
-            $order = $defaults['dir'];
-            $currentPage = 1;
-            $qb = $qb->andWhere('m.withdrawn = :withdrawn')
-                ->setParameter('withdrawn', $defaults['withdrawn']-1);
-            $qb = $qb->andWhere('m.frozen = :frozen')
-                ->setParameter('frozen', $defaults['frozen']-1);
-            $qb = $qb->andWhere('b.membership IN (SELECT IDENTITY(t.membership) FROM AppBundle\Entity\TimeLog t GROUP BY t.membership HAVING SUM(t.time) < :compteurlt * 60)')
-                ->setParameter('compteurlt', $defaults['compteurlt']);
-        }
+        $sort = $form->get('sort')->getData();
+        $order = $form->get('dir')->getData();
+        $currentPage = $form->get('page')->getData();
 
         $limitPerPage = 25;
         $qb = $qb->orderBy($sort, $order);

--- a/src/AppBundle/Service/SearchUserFormHelper.php
+++ b/src/AppBundle/Service/SearchUserFormHelper.php
@@ -347,12 +347,21 @@ class SearchUserFormHelper
             ->leftJoin("m.registrations", "r")->addSelect("r")
             ->leftJoin("r.helloassoPayment", "rhp")->addSelect("rhp")
             ->leftJoin("m.membershipShiftExemptions", "mse")->addSelect("mse");
+
         if ($type == 'search') {
             $qb->leftJoin("b.commissions", "c")->addSelect("c");
             $qb->leftJoin("b.formations", "f")->addSelect("f");
+        } else if ($type == 'shifttimelog') {
+            $qb->leftJoin("m.registrations", "lr", Join::WITH,'lr.date > r.date')->addSelect("lr")
+                ->where('lr.id IS NULL') // registration is the last one registered
+                ->addSelect("(SELECT SUM(ti.time) FROM AppBundle\Entity\TimeLog ti WHERE ti.membership = m.id) AS HIDDEN time")
+                ->leftJoin("m.timeLogs", "tl")->addSelect("tl")
+                ->leftJoin("m.notes", "n")->addSelect("n");
         }
+
         // do not include admin user
         $qb = $qb->andWhere('m.member_number > 0');
+
         return $qb;
     }
 

--- a/src/AppBundle/Service/SearchUserFormHelper.php
+++ b/src/AppBundle/Service/SearchUserFormHelper.php
@@ -354,7 +354,7 @@ class SearchUserFormHelper
         } else if ($type == 'shifttimelog') {
             $qb->leftJoin("m.registrations", "lr", Join::WITH,'lr.date > r.date')->addSelect("lr")
                 ->where('lr.id IS NULL') // registration is the last one registered
-                ->addSelect("(SELECT SUM(ti.time) FROM AppBundle\Entity\TimeLog ti WHERE ti.membership = m.id) AS HIDDEN time")
+                ->addSelect("(SELECT SUM(ti.time) FROM AppBundle\Entity\TimeLog ti WHERE ti.membership = m.id and ti.type != 20) AS HIDDEN time")
                 ->leftJoin("m.timeLogs", "tl")->addSelect("tl")
                 ->leftJoin("m.notes", "n")->addSelect("n");
         }


### PR DESCRIPTION
### Quoi ?

Modifications apportées sur la page admin "Liste des membres en retard de créneaux" : 
- rendre modifiable la valeur max du compteur temps (la valeur par défaut reste 0)
- ordonner par plus grand retard en premier
- simplifier le controlleur
- réparé une erreur dans le tri par compteurs (car cela prenait en compte les log d'épargne dans le calcul)