### PR TITLE
Pouvoir définir le champ createdAt de façon arbitraire

### DIFF
--- a/src/AppBundle/Controller/EventController.php
+++ b/src/AppBundle/Controller/EventController.php
@@ -165,10 +165,9 @@ class EventController extends Controller
         // anonymousProxy ?
         if ($form->isSubmitted() && $form->isValid()) {
             $proxy = $em->getRepository('AppBundle:Proxy')->findOneBy(array("event"=>$event, "giver"=>null));
-            if (!$proxy){
+            if (!$proxy) {
                 $proxy = new Proxy();
                 $proxy->setEvent($event);
-                $proxy->setCreatedAt(new \DateTime());
             }
 
             $proxy->setGiver($current_app_user->getBeneficiary()->getMembership());
@@ -214,7 +213,6 @@ class EventController extends Controller
                 // create proxy
                 $proxy = new Proxy();
                 $proxy->setEvent($event);
-                $proxy->setCreatedAt(new \DateTime());
                 $proxy->setOwner($beneficiary);
                 $proxy->setGiver($current_app_user->getBeneficiary()->getMembership());
 
@@ -397,10 +395,9 @@ class EventController extends Controller
         }
 
         $proxy = $em->getRepository('AppBundle:Proxy')->findOneBy(array("event" => $event, "owner" => null));
-        if (!$proxy){
+        if (!$proxy) {
             $proxy = new Proxy();
             $proxy->setEvent($event);
-            $proxy->setCreatedAt(new \DateTime());
         }
         $form = $this->createForm(ProxyType::class, $proxy);
         $form->handleRequest($request);

--- a/src/AppBundle/Controller/MembershipController.php
+++ b/src/AppBundle/Controller/MembershipController.php
@@ -786,7 +786,6 @@ class MembershipController extends Controller
                 $beneficiaries_emails = $a_beneficiary->getBeneficiariesEmailsAsArray();
                 foreach ($beneficiaries_emails as $email) {
                     $new_anonymous_beneficiary = new AnonymousBeneficiary();
-                    $new_anonymous_beneficiary->setCreatedAtValue(new \DateTime());
                     $new_anonymous_beneficiary->setEmail($email);
                     $new_anonymous_beneficiary->setJoinTo($member->getMainBeneficiary());
                     $new_anonymous_beneficiary->setRegistrar($a_beneficiary->getRegistrar());

--- a/src/AppBundle/Controller/TaskController.php
+++ b/src/AppBundle/Controller/TaskController.php
@@ -89,10 +89,10 @@ class TaskController extends Controller
     public function editAction(Request $request, Task $task)
     {
         $session = new Session();
+        $em = $this->getDoctrine()->getManager();
 
         $this->denyAccessUnlessGranted('edit',$task);
 
-        $em = $this->getDoctrine()->getManager();
         $form = $this->createForm(TaskType::class, $task);
         $form->get('due_date')->setData($task->getDueDate()->format('Y-m-d'));
         $form->get('created_at')->setData($task->getCreatedAt()->format('Y-m-d'));
@@ -100,13 +100,13 @@ class TaskController extends Controller
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $date = $form->get('due_date')->getData();
-            $new_date = new \DateTime($date);
-            $task->setDueDate($new_date);
+            $due_date = $form->get('due_date')->getData();
+            $due_date = new \DateTime($due_date);
+            $task->setDueDate($due_date);
 
-            $date = $form->get('created_at')->getData();
-            $new_date = new \DateTime($date);
-            $task->setCreatedAt($new_date);
+            $created_at = $form->get('created_at')->getData();
+            $created_at = new \DateTime($created_at);
+            $task->setCreatedAt($created_at);
 
             $em->persist($task);
             $em->flush();

--- a/src/AppBundle/Controller/TaskController.php
+++ b/src/AppBundle/Controller/TaskController.php
@@ -125,7 +125,6 @@ class TaskController extends Controller
             'form' => $form->createView(),
             'delete_form' => $this->getDeleteForm($task)->createView()
         ));
-
     }
 
 

--- a/src/AppBundle/Entity/AnonymousBeneficiary.php
+++ b/src/AppBundle/Entity/AnonymousBeneficiary.php
@@ -91,7 +91,9 @@ class AnonymousBeneficiary
      */
     public function setCreatedAtValue()
     {
-        $this->createdAt = new \DateTime();
+        if (!$this->createdAt) {
+            $this->createdAt = new \DateTime();
+        }
     }
 
     /**

--- a/src/AppBundle/Entity/Beneficiary.php
+++ b/src/AppBundle/Entity/Beneficiary.php
@@ -161,7 +161,9 @@ class Beneficiary
      */
     public function setCreatedAtValue()
     {
-        $this->createdAt = new \DateTime();
+        if (!$this->createdAt) {
+            $this->createdAt = new \DateTime();
+        }
     }
 
     /**

--- a/src/AppBundle/Entity/ClosingException.php
+++ b/src/AppBundle/Entity/ClosingException.php
@@ -118,13 +118,13 @@ class ClosingException
     /**
      * Set createdAt
      *
-     * @param \DateTime $createdAt
+     * @param \DateTime $date
      *
      * @return ClosingException
      */
-    public function setCreatedAt($createdAt)
+    public function setCreatedAt($date)
     {
-        $this->createdAt = $createdAt;
+        $this->createdAt = $date;
 
         return $this;
     }

--- a/src/AppBundle/Entity/ClosingException.php
+++ b/src/AppBundle/Entity/ClosingException.php
@@ -55,7 +55,9 @@ class ClosingException
      */
     public function setCreatedAtValue()
     {
-        $this->createdAt = new \DateTime();
+        if (!$this->createdAt) {
+            $this->createdAt = new \DateTime();
+        }
     }
 
     /**

--- a/src/AppBundle/Entity/Code.php
+++ b/src/AppBundle/Entity/Code.php
@@ -61,7 +61,9 @@ class Code
      */
     public function setCreatedAtValue()
     {
-        $this->createdAt = new \DateTime();
+        if (!$this->createdAt) {
+            $this->createdAt = new \DateTime();
+        }
     }
 
     /**

--- a/src/AppBundle/Entity/Code.php
+++ b/src/AppBundle/Entity/Code.php
@@ -101,30 +101,6 @@ class Code
     }
 
     /**
-     * Set createdAt
-     *
-     * @param \DateTime $createdAt
-     *
-     * @return Code
-     */
-    public function setCreatedAt($createdAt)
-    {
-        $this->createdAt = $createdAt;
-
-        return $this;
-    }
-
-    /**
-     * Get createdAt
-     *
-     * @return \DateTime
-     */
-    public function getCreatedAt()
-    {
-        return $this->createdAt;
-    }
-
-    /**
      * Set registrar
      *
      * @param \AppBundle\Entity\User $registrar
@@ -170,5 +146,29 @@ class Code
     public function getClosed()
     {
         return $this->closed;
+    }
+
+    /**
+     * Set createdAt
+     *
+     * @param \DateTime $date
+     *
+     * @return Code
+     */
+    public function setCreatedAt($date)
+    {
+        $this->createdAt = $date;
+
+        return $this;
+    }
+
+    /**
+     * Get createdAt
+     *
+     * @return \DateTime
+     */
+    public function getCreatedAt()
+    {
+        return $this->createdAt;
     }
 }

--- a/src/AppBundle/Entity/Commission.php
+++ b/src/AppBundle/Entity/Commission.php
@@ -108,7 +108,9 @@ class Commission
      */
     public function setCreatedAtValue()
     {
-        $this->createdAt = new \DateTime();
+        if (!$this->createdAt) {
+            $this->createdAt = new \DateTime();
+        }
     }
 
     /**

--- a/src/AppBundle/Entity/DynamicContent.php
+++ b/src/AppBundle/Entity/DynamicContent.php
@@ -103,7 +103,9 @@ class DynamicContent
      */
     public function setCreatedAtValue()
     {
-        $this->createdAt = new \DateTime();
+        if (!$this->createdAt) {
+            $this->createdAt = new \DateTime();
+        }
     }
 
     /**

--- a/src/AppBundle/Entity/Event.php
+++ b/src/AppBundle/Entity/Event.php
@@ -158,7 +158,9 @@ class Event
      */
     public function setCreatedAtValue()
     {
-        $this->createdAt = new \DateTime();
+        if (!$this->createdAt) {
+            $this->createdAt = new \DateTime();
+        }
     }
 
     /**

--- a/src/AppBundle/Entity/EventKind.php
+++ b/src/AppBundle/Entity/EventKind.php
@@ -56,7 +56,9 @@ class EventKind
      */
     public function setCreatedAtValue()
     {
-        $this->createdAt = new \DateTime();
+        if (!$this->createdAt) {
+            $this->createdAt = new \DateTime();
+        }
     }
 
     /**

--- a/src/AppBundle/Entity/Formation.php
+++ b/src/AppBundle/Entity/Formation.php
@@ -83,7 +83,9 @@ class Formation extends Group
      */
     public function setCreatedAtValue()
     {
-        $this->createdAt = new \DateTime();
+        if (!$this->createdAt) {
+            $this->createdAt = new \DateTime();
+        }
     }
 
     /**

--- a/src/AppBundle/Entity/HelloassoPayment.php
+++ b/src/AppBundle/Entity/HelloassoPayment.php
@@ -23,13 +23,6 @@ class HelloassoPayment
     private $id;
 
     /**
-     * @var \DateTime
-     *
-     * @ORM\Column(name="created_at", type="datetime")
-     */
-    private $createdAt;
-
-    /**
      * @var int
      *
      * @ORM\Column(name="payment_id", type="integer", unique=true)
@@ -92,6 +85,13 @@ class HelloassoPayment
     private $registration;
 
     /**
+     * @var \DateTime
+     *
+     * @ORM\Column(name="created_at", type="datetime")
+     */
+    private $createdAt;
+
+    /**
      * @return string
      */
     public function __toString()
@@ -110,7 +110,7 @@ class HelloassoPayment
     }
 
     /**
-     * Get id.
+     * Get id
      *
      * @return int
      */
@@ -120,31 +120,7 @@ class HelloassoPayment
     }
 
     /**
-     * Set createdAt
-     *
-     * @param \DateTime $createdAt
-     *
-     * @return HelloassoPayment
-     */
-    public function setCreatedAt($date)
-    {
-        $this->createdAt = $date;
-
-        return $this;
-    }
-
-    /**
-     * Get createdAt
-     *
-     * @return \DateTime
-     */
-    public function getCreatedAt()
-    {
-        return $this->createdAt;
-    }
-
-    /**
-     * Set date.
+     * Set date
      *
      * @param \DateTime $date
      *
@@ -158,7 +134,7 @@ class HelloassoPayment
     }
 
     /**
-     * Get date.
+     * Get date
      *
      * @return \DateTime
      */
@@ -168,7 +144,7 @@ class HelloassoPayment
     }
 
     /**
-     * Set amount.
+     * Set amount
      *
      * @param float $amount
      *
@@ -182,7 +158,7 @@ class HelloassoPayment
     }
 
     /**
-     * Get amount.
+     * Get amount
      *
      * @return float
      */
@@ -192,7 +168,7 @@ class HelloassoPayment
     }
 
     /**
-     * Set payerFirstName.
+     * Set payerFirstName
      *
      * @param string $payerFirstName
      *
@@ -206,7 +182,7 @@ class HelloassoPayment
     }
 
     /**
-     * Get payerFirstName.
+     * Get payerFirstName
      *
      * @return string
      */
@@ -216,7 +192,7 @@ class HelloassoPayment
     }
 
     /**
-     * Set payerLastName.
+     * Set payerLastName
      *
      * @param string $payerLastName
      *
@@ -230,7 +206,7 @@ class HelloassoPayment
     }
 
     /**
-     * Get payerLastName.
+     * Get payerLastName
      *
      * @return string
      */
@@ -240,7 +216,7 @@ class HelloassoPayment
     }
 
     /**
-     * Set registration.
+     * Set registration
      *
      * @param \AppBundle\Entity\Registration|null $registration
      *
@@ -254,7 +230,7 @@ class HelloassoPayment
     }
 
     /**
-     * Get registration.
+     * Get registration
      *
      * @return \AppBundle\Entity\Registration|null
      */
@@ -264,7 +240,7 @@ class HelloassoPayment
     }
 
     /**
-     * Set paymentId.
+     * Set paymentId
      *
      * @param int $paymentId
      *
@@ -278,7 +254,7 @@ class HelloassoPayment
     }
 
     /**
-     * Get paymentId.
+     * Get paymentId
      *
      * @return int
      */
@@ -336,7 +312,7 @@ class HelloassoPayment
     }
 
     /**
-     * Set campaignId.
+     * Set campaignId
      *
      * @param int $campaignId
      *
@@ -350,7 +326,7 @@ class HelloassoPayment
     }
 
     /**
-     * Get campaignId.
+     * Get campaignId
      *
      * @return int
      */
@@ -360,7 +336,7 @@ class HelloassoPayment
     }
 
     /**
-     * Set status.
+     * Set status
      *
      * @param string $status
      *
@@ -374,7 +350,7 @@ class HelloassoPayment
     }
 
     /**
-     * Get status.
+     * Get status
      *
      * @return string
      */
@@ -384,7 +360,7 @@ class HelloassoPayment
     }
 
     /**
-     * Set email.
+     * Set email
      *
      * @param string $email
      *
@@ -398,12 +374,36 @@ class HelloassoPayment
     }
 
     /**
-     * Get email.
+     * Get email
      *
      * @return string
      */
     public function getEmail()
     {
         return $this->email;
+    }
+
+    /**
+     * Set createdAt
+     *
+     * @param \DateTime $createdAt
+     *
+     * @return HelloassoPayment
+     */
+    public function setCreatedAt($date)
+    {
+        $this->createdAt = $date;
+
+        return $this;
+    }
+
+    /**
+     * Get createdAt
+     *
+     * @return \DateTime
+     */
+    public function getCreatedAt()
+    {
+        return $this->createdAt;
     }
 }

--- a/src/AppBundle/Entity/HelloassoPayment.php
+++ b/src/AppBundle/Entity/HelloassoPayment.php
@@ -104,7 +104,9 @@ class HelloassoPayment
      */
     public function setCreatedAtValue()
     {
-        $this->createdAt = new \DateTime();
+        if (!$this->createdAt) {
+            $this->createdAt = new \DateTime();
+        }
     }
 
     /**

--- a/src/AppBundle/Entity/Job.php
+++ b/src/AppBundle/Entity/Job.php
@@ -111,7 +111,9 @@ class Job
      */
     public function setCreatedAtValue()
     {
-        $this->createdAt = new \DateTime();
+        if (!$this->createdAt) {
+            $this->createdAt = new \DateTime();
+        }
     }
 
     /**

--- a/src/AppBundle/Entity/Membership.php
+++ b/src/AppBundle/Entity/Membership.php
@@ -149,7 +149,9 @@ class Membership
      */
     public function setCreatedAtValue()
     {
-        $this->createdAt = new \DateTime();
+        if (!$this->createdAt) {
+            $this->createdAt = new \DateTime();
+        }
     }
 
     public function getTmpToken($key = '')

--- a/src/AppBundle/Entity/MembershipShiftExemption.php
+++ b/src/AppBundle/Entity/MembershipShiftExemption.php
@@ -78,9 +78,18 @@ class MembershipShiftExemption
      */
     private $createdBy;
 
+    /**
+     * @ORM\PrePersist
+     */
+    public function setCreatedAtValue()
+    {
+        if (!$this->createdAt) {
+            $this->createdAt = new \DateTime();
+        }
+    }
 
     /**
-     * Get id.
+     * Get id
      *
      * @return int
      */
@@ -90,48 +99,7 @@ class MembershipShiftExemption
     }
 
     /**
-     * @ORM\PrePersist
-     */
-    public function setCreatedAt()
-    {
-        $this->createdAt = new \DateTime();
-    }
-
-    /**
-     * Get createdAt.
-     *
-     * @return \DateTime
-     */
-    public function getCreatedAt()
-    {
-        return $this->createdAt;
-    }
-
-    /**
-     * Set createdBy.
-     *
-     * @param \AppBundle\Entity\User $createBy
-     *
-     * @return MembershipShiftExemption
-     */
-    public function setCreatedBy(\AppBundle\Entity\User $createdBy = null)
-    {
-        $this->createdBy = $createdBy;
-        return $this;
-    }
-
-    /**
-     * Get createdBy.
-     *
-     * @return \AppBundle\Entity\User
-     */
-    public function getCreatedBy()
-    {
-        return $this->createdBy;
-    }
-
-    /**
-     * Set shiftExemption.
+     * Set shiftExemption
      *
      * @param \AppBundle\Entity\ShiftExemption $shiftExemption
      *
@@ -145,7 +113,7 @@ class MembershipShiftExemption
     }
 
     /**
-     * Get shiftExemption.
+     * Get shiftExemption
      *
      * @return ShiftExemption
      */
@@ -155,7 +123,7 @@ class MembershipShiftExemption
     }
 
     /**
-     * Set description.
+     * Set description
      *
      * @param string $description
      *
@@ -169,7 +137,7 @@ class MembershipShiftExemption
     }
 
     /**
-     * Get description.
+     * Get description
      *
      * @return string
      */
@@ -179,7 +147,7 @@ class MembershipShiftExemption
     }
 
     /**
-     * Get membership.
+     * Get membership
      *
      * @return Membership
      */
@@ -189,7 +157,7 @@ class MembershipShiftExemption
     }
 
     /**
-     * Set membership.
+     * Set membership
      *
      * @param \AppBundle\Entity\Membership $membership
      */
@@ -199,7 +167,7 @@ class MembershipShiftExemption
     }
 
     /**
-     * Set start.
+     * Set start
      *
      * @param \DateTime $start
      *
@@ -213,7 +181,7 @@ class MembershipShiftExemption
     }
 
     /**
-     * Get start.
+     * Get start
      *
      * @return \DateTime
      */
@@ -223,7 +191,7 @@ class MembershipShiftExemption
     }
 
     /**
-     * Set end.
+     * Set end
      *
      * @param \DateTime $end
      *
@@ -237,13 +205,60 @@ class MembershipShiftExemption
     }
 
     /**
-     * Get end.
+     * Get end
      *
      * @return \DateTime
      */
     public function getEnd()
     {
         return $this->end;
+    }
+
+    /**
+     * Set createdAt
+     *
+     * @param \DateTime $date
+     *
+     * @return MembershipShiftExemption
+     */
+    public function setCreatedAt($date)
+    {
+        $this->createdAt = $date;
+
+        return $this;
+    }
+
+    /**
+     * Get createdAt
+     *
+     * @return \DateTime
+     */
+    public function getCreatedAt()
+    {
+        return $this->createdAt;
+    }
+
+    /**
+     * Set createdBy
+     *
+     * @param \AppBundle\Entity\User $createBy
+     *
+     * @return MembershipShiftExemption
+     */
+    public function setCreatedBy(\AppBundle\Entity\User $createdBy = null)
+    {
+        $this->createdBy = $createdBy;
+        return $this;
+    }
+
+    /**
+     * Get createdBy
+     *
+     * @return \AppBundle\Entity\User
+     */
+    public function getCreatedBy()
+    {
+        return $this->createdBy;
     }
 
     /**

--- a/src/AppBundle/Entity/Note.php
+++ b/src/AppBundle/Entity/Note.php
@@ -74,7 +74,9 @@ class Note
      */
     public function setCreatedAtValue()
     {
-        $this->createdAt = new \DateTime();
+        if (!$this->createdAt) {
+            $this->createdAt = new \DateTime();
+        }
     }
 
     /**

--- a/src/AppBundle/Entity/OpeningHour.php
+++ b/src/AppBundle/Entity/OpeningHour.php
@@ -229,13 +229,13 @@ class OpeningHour
     /**
      * Set createdAt
      *
-     * @param \DateTime $createdAt
+     * @param \DateTime $date
      *
      * @return OpeningHour
      */
-    public function setCreatedAt($createdAt)
+    public function setCreatedAt($date)
     {
-        $this->createdAt = $createdAt;
+        $this->createdAt = $date;
 
         return $this;
     }

--- a/src/AppBundle/Entity/OpeningHour.php
+++ b/src/AppBundle/Entity/OpeningHour.php
@@ -69,7 +69,9 @@ class OpeningHour
      */
     public function setCreatedAtValue()
     {
-        $this->createdAt = new \DateTime();
+        if (!$this->createdAt) {
+            $this->createdAt = new \DateTime();
+        }
     }
 
     /**

--- a/src/AppBundle/Entity/OpeningHourKind.php
+++ b/src/AppBundle/Entity/OpeningHourKind.php
@@ -99,7 +99,9 @@ class OpeningHourKind
      */
     public function setCreatedAtValue()
     {
-        $this->createdAt = new \DateTime();
+        if (!$this->createdAt) {
+            $this->createdAt = new \DateTime();
+        }
     }
 
     /**

--- a/src/AppBundle/Entity/Period.php
+++ b/src/AppBundle/Entity/Period.php
@@ -113,7 +113,9 @@ class Period
      */
     public function setCreatedAtValue()
     {
-        $this->createdAt = new \DateTime();
+        if (!$this->createdAt) {
+            $this->createdAt = new \DateTime();
+        }
     }
 
     /**

--- a/src/AppBundle/Entity/PeriodPosition.php
+++ b/src/AppBundle/Entity/PeriodPosition.php
@@ -110,7 +110,9 @@ class PeriodPosition
      */
     public function setCreatedAtValue()
     {
-        $this->createdAt = new \DateTime();
+        if (!$this->createdAt) {
+            $this->createdAt = new \DateTime();
+        }
     }
 
     /**

--- a/src/AppBundle/Entity/PeriodPositionFreeLog.php
+++ b/src/AppBundle/Entity/PeriodPositionFreeLog.php
@@ -79,7 +79,9 @@ class PeriodPositionFreeLog
      */
     public function setCreatedAtValue()
     {
-        $this->createdAt = new \DateTime();
+        if (!$this->createdAt) {
+            $this->createdAt = new \DateTime();
+        }
     }
 
     public function getPeriodPosition(): ?PeriodPosition

--- a/src/AppBundle/Entity/Proxy.php
+++ b/src/AppBundle/Entity/Proxy.php
@@ -8,6 +8,7 @@ use Doctrine\ORM\Mapping as ORM;
  * Proxy
  *
  * @ORM\Table(name="proxy")
+ * @ORM\HasLifecycleCallbacks()
  * @ORM\Entity(repositoryClass="AppBundle\Repository\ProxyRepository")
  */
 class Proxy
@@ -20,13 +21,6 @@ class Proxy
      * @ORM\GeneratedValue(strategy="AUTO")
      */
     private $id;
-
-    /**
-     * @var \DateTime
-     *
-     * @ORM\Column(name="created_at", type="datetime")
-     */
-    private $createdAt;
 
     /**
      * @ORM\ManyToOne(targetEntity="Event", inversedBy="proxies")
@@ -46,6 +40,22 @@ class Proxy
      */
     private $giver;
 
+    /**
+     * @var \DateTime
+     *
+     * @ORM\Column(name="created_at", type="datetime")
+     */
+    private $createdAt;
+
+    /**
+     * @ORM\PrePersist
+     */
+    public function setCreatedAtValue()
+    {
+        if (!$this->createdAt) {
+            $this->createdAt = new \DateTime();
+        }
+    }
 
     /**
      * Get id
@@ -55,30 +65,6 @@ class Proxy
     public function getId()
     {
         return $this->id;
-    }
-
-    /**
-     * Set createdAt
-     *
-     * @param \DateTime $createdAt
-     *
-     * @return Proxy
-     */
-    public function setCreatedAt($createdAt)
-    {
-        $this->createdAt = $createdAt;
-
-        return $this;
-    }
-
-    /**
-     * Get createdAt
-     *
-     * @return \DateTime
-     */
-    public function getCreatedAt()
-    {
-        return $this->createdAt;
     }
 
     /**
@@ -151,5 +137,29 @@ class Proxy
     public function getGiver()
     {
         return $this->giver;
+    }
+
+    /**
+     * Set createdAt
+     *
+     * @param \DateTime $createdAt
+     *
+     * @return Proxy
+     */
+    public function setCreatedAt($createdAt)
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    /**
+     * Get createdAt
+     *
+     * @return \DateTime
+     */
+    public function getCreatedAt()
+    {
+        return $this->createdAt;
     }
 }

--- a/src/AppBundle/Entity/Proxy.php
+++ b/src/AppBundle/Entity/Proxy.php
@@ -142,13 +142,13 @@ class Proxy
     /**
      * Set createdAt
      *
-     * @param \DateTime $createdAt
+     * @param \DateTime $date
      *
      * @return Proxy
      */
-    public function setCreatedAt($createdAt)
+    public function setCreatedAt($date)
     {
-        $this->createdAt = $createdAt;
+        $this->createdAt = $date;
 
         return $this;
     }

--- a/src/AppBundle/Entity/Registration.php
+++ b/src/AppBundle/Entity/Registration.php
@@ -38,14 +38,6 @@ class Registration
     private $date;
 
     /**
-     * @var \DateTime
-     *
-     * @ORM\Column(name="created_at", type="datetime")
-     * @Assert\DateTime()
-     */
-    private $createdAt;
-
-    /**
      * @var string
      *
      * @ORM\Column(name="amount", type="string", length=255)
@@ -79,6 +71,14 @@ class Registration
     private $helloassoPayment;
 
     private $is_new;
+
+    /**
+     * @var \DateTime
+     *
+     * @ORM\Column(name="created_at", type="datetime")
+     * @Assert\DateTime()
+     */
+    private $createdAt;
 
     /**
      * @ORM\PrePersist
@@ -214,30 +214,6 @@ class Registration
     }
 
     /**
-     * Set createdAt
-     *
-     * @param \DateTime $createdAt
-     *
-     * @return Registration
-     */
-    public function setCreatedAt($date)
-    {
-        $this->createdAt = $date;
-
-        return $this;
-    }
-
-    /**
-     * Get createdAt
-     *
-     * @return \DateTime
-     */
-    public function getCreatedAt()
-    {
-        return $this->createdAt;
-    }
-
-    /**
      * Set helloassoPayment.
      *
      * @param \AppBundle\Entity\HelloassoPayment|null $helloassoPayment
@@ -275,5 +251,29 @@ class Registration
     public function setMembership($membership)
     {
         $this->membership = $membership;
+    }
+
+    /**
+     * Set createdAt
+     *
+     * @param \DateTime $createdAt
+     *
+     * @return Registration
+     */
+    public function setCreatedAt($date)
+    {
+        $this->createdAt = $date;
+
+        return $this;
+    }
+
+    /**
+     * Get createdAt
+     *
+     * @return \DateTime
+     */
+    public function getCreatedAt()
+    {
+        return $this->createdAt;
     }
 }

--- a/src/AppBundle/Entity/Registration.php
+++ b/src/AppBundle/Entity/Registration.php
@@ -85,7 +85,9 @@ class Registration
      */
     public function setCreatedAtValue()
     {
-        $this->createdAt = new \DateTime();
+        if (!$this->createdAt) {
+            $this->createdAt = new \DateTime();
+        }
     }
 
     /**

--- a/src/AppBundle/Entity/Shift.php
+++ b/src/AppBundle/Entity/Shift.php
@@ -145,7 +145,9 @@ class Shift
      */
     public function setCreatedAtValue()
     {
-        $this->createdAt = new \DateTime();
+        if (!$this->createdAt) {
+            $this->createdAt = new \DateTime();
+        }
     }
 
     /**

--- a/src/AppBundle/Entity/ShiftExemption.php
+++ b/src/AppBundle/Entity/ShiftExemption.php
@@ -56,7 +56,9 @@ class ShiftExemption
      */
     public function setCreatedAtValue()
     {
-        $this->createdAt = new \DateTime();
+        if (!$this->createdAt) {
+            $this->createdAt = new \DateTime();
+        }
     }
 
     /**

--- a/src/AppBundle/Entity/ShiftFreeLog.php
+++ b/src/AppBundle/Entity/ShiftFreeLog.php
@@ -86,7 +86,9 @@ class ShiftFreeLog
      */
     public function setCreatedAtValue()
     {
-        $this->createdAt = new \DateTimeImmutable();
+        if (!$this->createdAt) {
+            $this->createdAt = new \DateTimeImmutable();
+        }
     }
 
     public function getShift(): ?Shift

--- a/src/AppBundle/Entity/SocialNetwork.php
+++ b/src/AppBundle/Entity/SocialNetwork.php
@@ -176,13 +176,13 @@ class SocialNetwork
     /**
      * Set createdAt
      *
-     * @param \DateTime $createdAt
+     * @param \DateTime $date
      *
      * @return SocialNetwork
      */
-    public function setCreatedAt($createdAt)
+    public function setCreatedAt($date)
     {
-        $this->createdAt = $createdAt;
+        $this->createdAt = $date;
 
         return $this;
     }

--- a/src/AppBundle/Entity/SocialNetwork.php
+++ b/src/AppBundle/Entity/SocialNetwork.php
@@ -62,11 +62,13 @@ class SocialNetwork
      */
     public function setCreatedAtValue()
     {
-        $this->createdAt = new \DateTime();
+        if (!$this->createdAt) {
+            $this->createdAt = new \DateTime();
+        }
     }
 
     /**
-     * Get id.
+     * Get id
      *
      * @return int
      */
@@ -76,7 +78,7 @@ class SocialNetwork
     }
 
     /**
-     * Set name.
+     * Set name
      *
      * @param string $name
      *
@@ -90,7 +92,7 @@ class SocialNetwork
     }
 
     /**
-     * Get name.
+     * Get name
      *
      * @return string
      */
@@ -124,7 +126,7 @@ class SocialNetwork
     }
 
     /**
-     * Set url.
+     * Set url
      *
      * @param string $url
      *
@@ -138,7 +140,7 @@ class SocialNetwork
     }
 
     /**
-     * Get url.
+     * Get url
      *
      * @return string
      */
@@ -148,7 +150,7 @@ class SocialNetwork
     }
 
     /**
-     * Set displayedFooter.
+     * Set displayedFooter
      *
      * @param bool|null $displayedFooter
      *
@@ -162,7 +164,7 @@ class SocialNetwork
     }
 
     /**
-     * Get displayedFooter.
+     * Get displayedFooter
      *
      * @return bool|null
      */
@@ -172,7 +174,7 @@ class SocialNetwork
     }
 
     /**
-     * Set createdAt.
+     * Set createdAt
      *
      * @param \DateTime $createdAt
      *
@@ -186,7 +188,7 @@ class SocialNetwork
     }
 
     /**
-     * Get createdAt.
+     * Get createdAt
      *
      * @return \DateTime
      */

--- a/src/AppBundle/Entity/SwipeCard.php
+++ b/src/AppBundle/Entity/SwipeCard.php
@@ -75,12 +75,14 @@ class SwipeCard
      */
     public function setCreatedAtValue()
     {
-        $this->createdAt = new \DateTime();
+        if (!$this->createdAt) {
+            $this->createdAt = new \DateTime();
+        }
         $this->disabled_at = null;
     }
 
     /**
-     * Get id.
+     * Get id
      *
      * @return int
      */
@@ -90,7 +92,7 @@ class SwipeCard
     }
 
     /**
-     * Set number.
+     * Set number
      *
      * @param int $number
      *
@@ -104,7 +106,7 @@ class SwipeCard
     }
 
     /**
-     * Get number.
+     * Get number
      *
      * @return int
      */
@@ -114,7 +116,7 @@ class SwipeCard
     }
 
     /**
-     * Set code.
+     * Set code
      *
      * @param string $code
      *
@@ -128,7 +130,7 @@ class SwipeCard
     }
 
     /**
-     * Get code.
+     * Get code
      *
      * @return string
      */
@@ -138,7 +140,7 @@ class SwipeCard
     }
 
     /**
-     * Set enable.
+     * Set enable
      *
      * @param bool|null $enable
      *
@@ -158,7 +160,7 @@ class SwipeCard
     }
 
     /**
-     * Get enable.
+     * Get enable
      *
      * @return bool|null
      */
@@ -170,7 +172,7 @@ class SwipeCard
     }
 
     /**
-     * Set beneficiary.
+     * Set beneficiary
      *
      * @param \AppBundle\Entity\Beneficiary|null $beneficiary
      *
@@ -184,7 +186,7 @@ class SwipeCard
     }
 
     /**
-     * Get beneficiary.
+     * Get beneficiary
      *
      * @return \AppBundle\Entity\Beneficiary|null
      */
@@ -195,7 +197,7 @@ class SwipeCard
 
 
     /**
-     * Set createdAt.
+     * Set createdAt
      *
      * @param \DateTime $createdAt
      *
@@ -209,7 +211,7 @@ class SwipeCard
     }
 
     /**
-     * Get createdAt.
+     * Get createdAt
      *
      * @return \DateTime
      */
@@ -219,7 +221,7 @@ class SwipeCard
     }
 
     /**
-     * Set disabledAt.
+     * Set disabledAt
      *
      * @param \DateTime? $disabledAt
      *
@@ -233,7 +235,7 @@ class SwipeCard
     }
 
     /**
-     * Get disabledAt.
+     * Get disabledAt
      *
      * @return \DateTime
      */

--- a/src/AppBundle/Entity/SwipeCard.php
+++ b/src/AppBundle/Entity/SwipeCard.php
@@ -199,13 +199,13 @@ class SwipeCard
     /**
      * Set createdAt
      *
-     * @param \DateTime $createdAt
+     * @param \DateTime $date
      *
      * @return SwipeCard
      */
-    public function setCreatedAt($createdAt)
+    public function setCreatedAt($date)
     {
-        $this->createdAt = $createdAt;
+        $this->createdAt = $date;
 
         return $this;
     }

--- a/src/AppBundle/Entity/Task.php
+++ b/src/AppBundle/Entity/Task.php
@@ -8,6 +8,7 @@ use Doctrine\ORM\Mapping as ORM;
  * Task
  *
  * @ORM\Table(name="task")
+ * @ORM\HasLifecycleCallbacks()
  * @ORM\Entity(repositoryClass="AppBundle\Repository\TaskRepository")
  */
 class Task
@@ -103,6 +104,16 @@ class Task
     }
 
     /**
+     * @ORM\PrePersist
+     */
+    public function setCreatedAtValue()
+    {
+        if (!$this->createdAt) {
+            $this->createdAt = new \DateTime();
+        }
+    }
+
+    /**
      * Get id
      *
      * @return int
@@ -134,78 +145,6 @@ class Task
     public function getTitle()
     {
         return $this->title;
-    }
-
-    /**
-     * Set createdAt
-     *
-     * @param \DateTime $createdAt
-     *
-     * @return Task
-     */
-    public function setCreatedAt($createdAt)
-    {
-        $this->createdAt = $createdAt;
-
-        return $this;
-    }
-
-    /**
-     * Get createdAt
-     *
-     * @return \DateTime
-     */
-    public function getCreatedAt()
-    {
-        return $this->createdAt;
-    }
-
-    /**
-     * Set priority
-     *
-     * @param integer $priority
-     *
-     * @return Task
-     */
-    public function setPriority($priority)
-    {
-        $this->priority = $priority;
-
-        return $this;
-    }
-
-    /**
-     * Get priority
-     *
-     * @return int
-     */
-    public function getPriority()
-    {
-        return $this->priority;
-    }
-
-    /**
-     * Set status
-     *
-     * @param string $status
-     *
-     * @return Task
-     */
-    public function setStatus($status)
-    {
-        $this->status = $status;
-
-        return $this;
-    }
-
-    /**
-     * Get status
-     *
-     * @return string
-     */
-    public function getStatus()
-    {
-        return $this->status;
     }
 
     /**
@@ -347,5 +286,77 @@ class Task
     public function getClosed()
     {
         return $this->closed;
+    }
+
+    /**
+     * Set priority
+     *
+     * @param integer $priority
+     *
+     * @return Task
+     */
+    public function setPriority($priority)
+    {
+        $this->priority = $priority;
+
+        return $this;
+    }
+
+    /**
+     * Get priority
+     *
+     * @return int
+     */
+    public function getPriority()
+    {
+        return $this->priority;
+    }
+
+    /**
+     * Set status
+     *
+     * @param string $status
+     *
+     * @return Task
+     */
+    public function setStatus($status)
+    {
+        $this->status = $status;
+
+        return $this;
+    }
+
+    /**
+     * Get status
+     *
+     * @return string
+     */
+    public function getStatus()
+    {
+        return $this->status;
+    }
+
+    /**
+     * Set createdAt
+     *
+     * @param \DateTime $createdAt
+     *
+     * @return Task
+     */
+    public function setCreatedAt($createdAt)
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    /**
+     * Get createdAt
+     *
+     * @return \DateTime
+     */
+    public function getCreatedAt()
+    {
+        return $this->createdAt;
     }
 }

--- a/src/AppBundle/Entity/Task.php
+++ b/src/AppBundle/Entity/Task.php
@@ -339,13 +339,13 @@ class Task
     /**
      * Set createdAt
      *
-     * @param \DateTime $createdAt
+     * @param \DateTime $date
      *
      * @return Task
      */
-    public function setCreatedAt($createdAt)
+    public function setCreatedAt($date)
     {
-        $this->createdAt = $createdAt;
+        $this->createdAt = $date;
 
         return $this;
     }


### PR DESCRIPTION
### Quoi ?

Dans l'issue #609 on a généralisé l'utilisation du champ `createdAt`, avec une valeur par défaut définie grâce à Doctrine (PrePersist).

Mais dans certaines entités, on souhaite parfois définir une date de création arbitraire. Or la façon actuelle l'en empêche. Ce qui a pu provoquer des erreurs (ex : #1010).

Dans cette PR on généralise donc la possibilité de définir une date de création arbitraire.