### PR TITLE
Compte épargne : lors de la validation d'un créneau, ne pas passer l'info du créneau dans le log du compteur épargne

### DIFF
--- a/src/AppBundle/EventListener/TimeLogEventListener.php
+++ b/src/AppBundle/EventListener/TimeLogEventListener.php
@@ -260,7 +260,8 @@ class TimeLogEventListener
                 $log = $this->container->get('time_log_service')->initRegulateOptionalShiftsTimeLog($member, -1 * $member_counter_extra_time, $date_plus_one_second);
                 $this->em->persist($log);
                 // then increment the savingTimeCount
-                $log = $this->container->get('time_log_service')->initSavingTimeLog($member, $member_counter_extra_time, $date_plus_one_second, $shift);
+                // we don't pass de $shift info because the extra time may not correspond to the shift time
+                $log = $this->container->get('time_log_service')->initSavingTimeLog($member, $member_counter_extra_time, $date_plus_one_second);  # $shift
                 $this->em->persist($log);
                 $this->em->flush();
             }


### PR DESCRIPTION
 ### Quoi ?

Mini cas particulier, si un créneau est validé, et que le compteur épargne est incrémenté, on indiquait l'information du créneau, alors que l'incrément n'était pas nécessairement de la durée du créneau.

Donc le plus simple c'est de ne rien indiquer du tout.

### Captures d'écran

|Avant|Après|
|---|---|
|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/31db5b73-e122-48aa-b938-1d5d725c154b)|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/69251ba1-9e27-4443-adf6-f61d2c11738c)|