### PR TITLE
Filtre sur les membres : améliorer la liste des membres en retard d'adhésion ou de ré-adhésion

### DIFF
--- a/src/AppBundle/Controller/AmbassadorController.php
+++ b/src/AppBundle/Controller/AmbassadorController.php
@@ -147,7 +147,7 @@ class AmbassadorController extends Controller
     }
 
     /**
-     * List all members with negative shift time logs.
+     * List all members with negative shift time count.
      *
      * @Route("/shifttimelog", name="ambassador_shifttimelog_list", methods={"GET","POST"})
      * @Security("has_role('ROLE_USER_MANAGER')")

--- a/src/AppBundle/Controller/AmbassadorController.php
+++ b/src/AppBundle/Controller/AmbassadorController.php
@@ -56,23 +56,13 @@ class AmbassadorController extends Controller
         $form = $formHelper->createMemberNoRegistrationFilterForm($this->createFormBuilder(), $defaults, $disabledFields);
         $form->handleRequest($request);
 
-        $qb = $formHelper->initSearchQuery($this->getDoctrine()->getManager());
-        $qb = $qb->leftJoin("m.timeLogs", "c")->addSelect("c")
-            ->addSelect("(SELECT SUM(ti.time) FROM AppBundle\Entity\TimeLog ti WHERE ti.membership = m.id) AS HIDDEN time");
+        $qb = $formHelper->initSearchQuery($this->getDoctrine()->getManager(), 'noregistration');
+        $qb = $formHelper->processSearchFormAmbassadorData($form, $qb);
+        $qb = $qb->andWhere('r.date IS NULL');
 
-        if ($form->isSubmitted() && $form->isValid()) {
-            $formHelper->processSearchFormAmbassadorData($form, $qb);
-            $sort = $form->get('sort')->getData();
-            $order = $form->get('dir')->getData();
-            $currentPage = $form->get('page')->getData();
-        } else {
-            $sort = $defaults['sort'];
-            $order = $defaults['dir'];
-            $currentPage = 1;
-            $qb = $qb->andWhere('m.withdrawn = :withdrawn')
-                ->setParameter('withdrawn', $defaults['withdrawn']-1);
-            $qb = $qb->andWhere('r.date IS NULL');
-        }
+        $sort = $form->get('sort')->getData();
+        $order = $form->get('dir')->getData();
+        $currentPage = $form->get('page')->getData();
 
         $limitPerPage = 25;
         $qb = $qb->orderBy($sort, $order);
@@ -127,7 +117,6 @@ class AmbassadorController extends Controller
 
         $qb = $formHelper->initSearchQuery($this->getDoctrine()->getManager(), 'lateregistration');
         $qb = $formHelper->processSearchFormAmbassadorData($form, $qb);
-
         $qb = $qb->andWhere('r.date < :lastregistrationdatelt')
             ->setParameter('lastregistrationdatelt', $defaults['lastregistrationdatelt']->format('Y-m-d'));
 

--- a/src/AppBundle/Repository/MembershipRepository.php
+++ b/src/AppBundle/Repository/MembershipRepository.php
@@ -129,7 +129,7 @@ class MembershipRepository extends \Doctrine\ORM\EntityRepository
             ->andWhere('m.member_number > 0') //do not include admin user
             ->andWhere('m.withdrawn = 0')
             ->andWhere('m.frozen = 0')
-            ->andWhere('m IN (SELECT IDENTITY(t.membership) FROM AppBundle\Entity\TimeLog t GROUP BY t.membership HAVING SUM(t.time) < :compteurlt * 60)')
+            ->andWhere('m IN (SELECT IDENTITY(t.membership) FROM AppBundle\Entity\TimeLog t WHERE t.type != 20 GROUP BY t.membership HAVING SUM(t.time) < :compteurlt * 60)')
             ->setParameter('compteurlt', $time_after_which_members_are_late_with_shifts);
 
         return $qb

--- a/src/AppBundle/Service/SearchUserFormHelper.php
+++ b/src/AppBundle/Service/SearchUserFormHelper.php
@@ -355,7 +355,7 @@ class SearchUserFormHelper
         if (in_array($type, ['noregistration', 'lateregistration', 'shifttimelog'])) {
             $qb = $qb->leftJoin("m.registrations", "lr", Join::WITH,'lr.date > r.date')->addSelect("lr")
                 ->where('lr.id IS NULL') // registration is the last one registered
-                ->addSelect("(SELECT SUM(ti.time) FROM AppBundle\Entity\TimeLog ti WHERE ti.membership = m.id and ti.type != 20) AS HIDDEN time")
+                ->addSelect("(SELECT SUM(ti.time) FROM AppBundle\Entity\TimeLog ti WHERE ti.type != 20 AND ti.membership = m.id) AS HIDDEN time")
                 ->leftJoin("m.timeLogs", "tl")->addSelect("tl")
                 ->leftJoin("m.notes", "n")->addSelect("n");
         }

--- a/src/AppBundle/Service/SearchUserFormHelper.php
+++ b/src/AppBundle/Service/SearchUserFormHelper.php
@@ -351,8 +351,9 @@ class SearchUserFormHelper
         if ($type == 'search') {
             $qb->leftJoin("b.commissions", "c")->addSelect("c");
             $qb->leftJoin("b.formations", "f")->addSelect("f");
-        } else if ($type == 'shifttimelog') {
-            $qb->leftJoin("m.registrations", "lr", Join::WITH,'lr.date > r.date')->addSelect("lr")
+        }
+        if (in_array($type, ['lateregistration', 'shifttimelog'])) {
+            $qb = $qb->leftJoin("m.registrations", "lr", Join::WITH,'lr.date > r.date')->addSelect("lr")
                 ->where('lr.id IS NULL') // registration is the last one registered
                 ->addSelect("(SELECT SUM(ti.time) FROM AppBundle\Entity\TimeLog ti WHERE ti.membership = m.id and ti.type != 20) AS HIDDEN time")
                 ->leftJoin("m.timeLogs", "tl")->addSelect("tl")

--- a/src/AppBundle/Service/SearchUserFormHelper.php
+++ b/src/AppBundle/Service/SearchUserFormHelper.php
@@ -352,7 +352,7 @@ class SearchUserFormHelper
             $qb->leftJoin("b.commissions", "c")->addSelect("c");
             $qb->leftJoin("b.formations", "f")->addSelect("f");
         }
-        if (in_array($type, ['lateregistration', 'shifttimelog'])) {
+        if (in_array($type, ['noregistration', 'lateregistration', 'shifttimelog'])) {
             $qb = $qb->leftJoin("m.registrations", "lr", Join::WITH,'lr.date > r.date')->addSelect("lr")
                 ->where('lr.id IS NULL') // registration is the last one registered
                 ->addSelect("(SELECT SUM(ti.time) FROM AppBundle\Entity\TimeLog ti WHERE ti.membership = m.id and ti.type != 20) AS HIDDEN time")


### PR DESCRIPTION
Suite de #1014

### Quoi ?

Modifications apportées sur les pages admin "Liste des membres en retard adhésion" & "Liste des membres en retard de ré-adhésion" :
- simplifié le controlleur
- réparé une erreur dans le tri par compteurs (car cela prenait en compte les log d'épargne dans le calcul)