### PR TITLE
Refactoring : renommer MembershipShiftExemptionController en AdminMembershipShiftExemptionController

### DIFF
--- a/app/Resources/views/admin/membershipshiftexemption/edit.html.twig
+++ b/app/Resources/views/admin/membershipshiftexemption/edit.html.twig
@@ -12,9 +12,9 @@
 {% block content %}
     <h4>Editer une exemption de bénévolat</h4>
 
-    {{ form_start(edit_form) }}
+    {{ form_start(form) }}
     <div class="errors">
-        {{ form_errors(edit_form) }}
+        {{ form_errors(form) }}
     </div>
     <div class="row">
         <div class="col s6">
@@ -22,35 +22,35 @@
             <input id='membership' type="text" value="{{ membershipShiftExemption.membership.memberNumberWithBeneficiaryListString }}" disabled>
         </div>
         <div class="col s6">
-            {{ form_label(edit_form.shiftExemption) }}
-            {{ form_errors(edit_form.shiftExemption) }}
-            {{ form_widget(edit_form.shiftExemption) }}
+            {{ form_label(form.shiftExemption) }}
+            {{ form_errors(form.shiftExemption) }}
+            {{ form_widget(form.shiftExemption) }}
         </div>
         <div class="col s12 input-field">
-            {{ form_label(edit_form.description) }}
-            {{ form_errors(edit_form.description) }}
-            {{ form_widget(edit_form.description) }}
+            {{ form_label(form.description) }}
+            {{ form_errors(form.description) }}
+            {{ form_widget(form.description) }}
         </div>
         <div class="col s6 input-field">
-            {{ form_label(edit_form.start) }}
-            {{ form_errors(edit_form.start) }}
-            {{ form_widget(edit_form.start) }}
+            {{ form_label(form.start) }}
+            {{ form_errors(form.start) }}
+            {{ form_widget(form.start) }}
         </div>
         <div class="col s6 input-field">
-            {{ form_label(edit_form.end) }}
-            {{ form_errors(edit_form.end) }}
-            {{ form_widget(edit_form.end) }}
+            {{ form_label(form.end) }}
+            {{ form_errors(form.end) }}
+            {{ form_widget(form.end) }}
         </div>
     </div>
     <a href="{{ path('admin_membershipshiftexemption_index') }}" class="waves-effect waves-light btn red white-text" title="Annuler">Annuler</a>
     <button type="submit" class="btn waves-effect waves-light">
         <i class="material-icons left">save</i>Enregistrer
     </button>
-    {{ form_end(edit_form) }}
+    {{ form_end(form) }}
 
     {% if ((membershipShiftExemption.start | date('Y-m-d')) > ('now' | date('Y-m-d'))) or is_granted("ROLE_SUPER_ADMIN") %}
         {{ form_start(delete_form) }}
-        <button type="submit" class="btn waves-effect waves-light red">
+        <button type="submit" class="btn waves-effect waves-light red" onclick="var r = confirm('Etes-vous sûr de vouloir supprimer cette exemption ?!'); if (r == true) {$(this).closest('form').submit();}; event.stopPropagation();">
             <i class="material-icons left">delete</i>Supprimer
         </button>
         {{ form_end(delete_form) }}

--- a/app/Resources/views/admin/membershipshiftexemption/edit.html.twig
+++ b/app/Resources/views/admin/membershipshiftexemption/edit.html.twig
@@ -18,8 +18,8 @@
     </div>
     <div class="row">
         <div class="col s6">
-            <label for="beneficiaries">Bénéficiaires</label>
-            <input id='beneficiaries' type="text" value="{{ membershipShiftExemption.membership.beneficiaries | join(', ') }}" disabled>
+            <label for="membership">Membre</label>
+            <input id='membership' type="text" value="{{ membershipShiftExemption.membership.memberNumberWithBeneficiaryListString }}" disabled>
         </div>
         <div class="col s6">
             {{ form_label(edit_form.shiftExemption) }}

--- a/app/Resources/views/admin/membershipshiftexemption/index.html.twig
+++ b/app/Resources/views/admin/membershipshiftexemption/index.html.twig
@@ -1,15 +1,15 @@
 {% extends 'layout.html.twig' %}
 
-{% block title %}Liste des membres exempté.e.s de bénévolat - {{ site_name }}{% endblock %}
+{% block title %}Liste des membres exemptés de bénévolat - {{ site_name }}{% endblock %}
 
 {% block breadcrumbs %}
 <a href="{{ path('homepage') }}"><i class="material-icons">home</i></a><i class="material-icons">chevron_right</i>
 <a href="{{ path('admin') }}"><i class="material-icons">build</i>&nbsp;Administration</a><i class="material-icons">chevron_right</i>
-<i class="material-icons">list</i>&nbsp;Liste des membres exempté.e.s de bénévolat
+<i class="material-icons">list</i>&nbsp;Liste des membres exemptés de bénévolat
 {% endblock %}
 
 {% block content %}
-    <h4>Liste des membres exempté.e.s de bénévolat ({{ result_count }})</h4>
+    <h4>Liste des membres exemptés de bénévolat ({{ result_count }})</h4>
 
     {# Filter form  --------- #}
     <ul class="collapsible">
@@ -69,7 +69,7 @@
                 </td>
                 <td>
                     <a href="{{ path("member_show", { 'member_number': membershipShiftExemption.membership.memberNumber }) }}">
-                        {{ membershipShiftExemption.membership.beneficiaries | join('<br/>') | raw }}
+                        {{ membershipShiftExemption.membership.memberNumberWithBeneficiaryListString }}
                     </a>
                 </td>
                 <td>{{ membershipShiftExemption.shiftExemption }}</td>

--- a/app/Resources/views/admin/membershipshiftexemption/new.html.twig
+++ b/app/Resources/views/admin/membershipshiftexemption/new.html.twig
@@ -5,7 +5,7 @@
 {% block breadcrumbs %}
 <a href="{{ path('homepage') }}"><i class="material-icons">home</i></a><i class="material-icons">chevron_right</i>
 <a href="{{ path('admin') }}"><i class="material-icons">build</i>&nbsp;Administration</a><i class="material-icons">chevron_right</i>
-<a href="{{ path('admin_membershipshiftexemption_index') }}"><i class="material-icons">list</i>&nbsp;Liste des membres exempté.e.s de bénévolat</a><i class="material-icons">chevron_right</i>
+<a href="{{ path('admin_membershipshiftexemption_index') }}"><i class="material-icons">list</i>&nbsp;Liste des membres exemptés de bénévolat</a><i class="material-icons">chevron_right</i>
 <i class="material-icons">add</i>&nbsp;Ajouter
 {% endblock %}
 
@@ -18,9 +18,9 @@
     </div>
     <div class="row">
         <div class="col s6 input-field">
-            {{ form_label(form.beneficiary) }}
-            {{ form_errors(form.beneficiary) }}
-            {{ form_widget(form.beneficiary) }}
+            {{ form_label(form.membership) }}
+            {{ form_errors(form.membership) }}
+            {{ form_widget(form.membership) }}
         </div>
         <div class="col s6">
             {{ form_label(form.shiftExemption) }}
@@ -49,5 +49,5 @@
 {% endblock %}
 
 {% block javascripts %}
-{% include "/admin/membershipshiftexemption/_form_js.html.twig" %}
+{% include "admin/membershipshiftexemption/_form_js.html.twig" %}
 {% endblock %}

--- a/src/AppBundle/Controller/AdminMembershipShiftExemptionController.php
+++ b/src/AppBundle/Controller/AdminMembershipShiftExemptionController.php
@@ -2,7 +2,6 @@
 
 namespace AppBundle\Controller;
 
-use AppBundle\Entity\Beneficiary;
 use AppBundle\Entity\MembershipShiftExemption;
 use AppBundle\Form\AutocompleteMembershipType;
 use AppBundle\Repository\ShiftExemptionRepository;
@@ -132,7 +131,7 @@ class AdminMembershipShiftExemptionController extends Controller
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $membership = $form->get("beneficiary")->getData()->getMembership();
+            $membership = $form->get("membership")->getData();
             $membershipShiftExemption->setMembership($membership);
 
             if ($this->get('membership_service')->memberHasShiftsOnExemptionPeriod($membershipShiftExemption)) {

--- a/src/AppBundle/Controller/AdminMembershipShiftExemptionController.php
+++ b/src/AppBundle/Controller/AdminMembershipShiftExemptionController.php
@@ -135,8 +135,8 @@ class AdminMembershipShiftExemptionController extends Controller
             $membership = $form->get("beneficiary")->getData()->getMembership();
             $membershipShiftExemption->setMembership($membership);
 
-            if ($this->isMembershipHasShiftsOnExemptionPeriod($membershipShiftExemption)) {
-                $session->getFlashBag()->add("error", "Désolé, les bénéficiaires ont déjà des créneaux planifiés sur la plage d'exemption.");
+            if ($this->get('membership_service')->memberHasShiftsOnExemptionPeriod($membershipShiftExemption)) {
+                $session->getFlashBag()->add("error", "Désolé, le membre a déjà des créneaux planifiés sur la plage d'exemption.");
                 return $this->redirectToRoute('admin_membershipshiftexemption_new');
             }
 
@@ -169,8 +169,8 @@ class AdminMembershipShiftExemptionController extends Controller
         $editForm->handleRequest($request);
 
         if ($editForm->isSubmitted() && $editForm->isValid()) {
-            if ($this->isMembershipHasShiftsOnExemptionPeriod($membershipShiftExemption)) {
-                $session->getFlashBag()->add("error", "Désolé, les bénéficiaires ont déjà des créneaux planifiés sur la plage d'exemption.");
+            if ($this->get('membership_service')->memberHasShiftsOnExemptionPeriod($membershipShiftExemption)) {
+                $session->getFlashBag()->add("error", "Désolé, le membre a déjà des créneaux planifiés sur la plage d'exemption.");
             } else {
                 $session->getFlashBag()->add('success', 'L\'exemption de créneau a bien été éditée !');
                 $this->getDoctrine()->getManager()->flush();
@@ -233,12 +233,5 @@ class AdminMembershipShiftExemptionController extends Controller
         ;
     }
 
-    private function isMembershipHasShiftsOnExemptionPeriod(MembershipShiftExemption $membershipShiftExemption)
-    {
-        $em = $this->getDoctrine()->getManager();
-        $shifts = $em->getRepository('AppBundle:Shift')->findInProgressAndUpcomingShiftsForMembership($membershipShiftExemption->getMembership());
-        return $shifts->exists(function($key, $value) use ($membershipShiftExemption) {
-            return $membershipShiftExemption->isCurrent($value->getStart());
-        });
-    }
+    
 }

--- a/src/AppBundle/Controller/AdminMembershipShiftExemptionController.php
+++ b/src/AppBundle/Controller/AdminMembershipShiftExemptionController.php
@@ -22,7 +22,7 @@ use \Datetime;
  *
  * @Route("admin/membershipshiftexemption")
  */
-class MembershipShiftExemptionController extends Controller
+class AdminMembershipShiftExemptionController extends Controller
 {
     /**
      * Filter form.

--- a/src/AppBundle/Form/MembershipShiftExemptionType.php
+++ b/src/AppBundle/Form/MembershipShiftExemptionType.php
@@ -2,7 +2,7 @@
 
 namespace AppBundle\Form;
 
-use AppBundle\Form\AutocompleteBeneficiaryType;
+use AppBundle\Form\AutocompleteMembershipType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
@@ -15,7 +15,6 @@ use \Datetime;
 
 class MembershipShiftExemptionType extends AbstractType
 {
-
     /**
      * {@inheritdoc}
      */
@@ -29,9 +28,9 @@ class MembershipShiftExemptionType extends AbstractType
 
                     // checks if the MembershipShiftExamption object is "new"
                     if (!$membershipShiftExemption || null === $membershipShiftExemption->getId()) {
-                        $form->add('beneficiary', AutocompleteBeneficiaryType::class, [
+                        $form->add('membership', AutocompleteMembershipType::class, [
                             'mapped' => false,
-                            'label' => "Bénéficiaire",
+                            'label' => "Membre",
                         ]);
                     }
                     $now = new DateTime();
@@ -76,6 +75,4 @@ class MembershipShiftExemptionType extends AbstractType
     {
         return 'appbundle_membershipshiftexemption';
     }
-
-
 }

--- a/src/AppBundle/Service/MembershipService.php
+++ b/src/AppBundle/Service/MembershipService.php
@@ -4,6 +4,7 @@ namespace AppBundle\Service;
 
 use AppBundle\Entity\Beneficiary;
 use AppBundle\Entity\Membership;
+use AppBundle\Entity\MembershipShiftExemption;
 use AppBundle\Entity\Registration;
 use AppBundle\Entity\Shift;
 use AppBundle\Entity\ShiftBucket;
@@ -202,5 +203,13 @@ class MembershipService
     public function getShiftFreeLogs(Membership $member)
     {
         return $this->em->getRepository('AppBundle:ShiftFreeLog')->getMemberShiftFreed($member);
+    }
+
+    public function memberHasShiftsOnExemptionPeriod(MembershipShiftExemption $membershipShiftExemption)
+    {
+        $shifts = $this->em->getRepository('AppBundle:Shift')->findInProgressAndUpcomingShiftsForMembership($membershipShiftExemption->getMembership());
+        return $shifts->exists(function($key, $value) use ($membershipShiftExemption) {
+            return $membershipShiftExemption->isCurrent($value->getStart());
+        });
     }
 }


### PR DESCRIPTION
Modifications apportées : 
- renommé le controlleur
- déplacé une méthode vers le MembershipService
- utilisé le Membership autocomplete au lieu de Beneficiary autocomplete
- ajouté une confirmation avant la suppression
- ne pas perdre les données lors d'erreur à la création
- amélioré l'affichage des membres