### PR TITLE
Créneaux : réparer & améliorer le processus de pré-réservation de créneaux

### DIFF
--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -165,6 +165,7 @@ services:
                 $wikiKeysUrl: "%wiki_keys_url%"
             tags:
                 - { name: kernel.event_listener, event: code.new, method: onCodeNew }
+                - { name: kernel.event_listener, event: shift.reserved, method: onShiftReserved }
                 - { name: kernel.event_listener, event: shift.booked, method: onShiftBooked }
                 - { name: kernel.event_listener, event: shift.freed, method: onShiftFreed }
                 - { name: kernel.event_listener, event: shift.deleted, method: onShiftDeleted }

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -94,89 +94,90 @@ services:
         tags:
             - { name: form.type, alias: app_user_registration }
     app.authentication_success_handler:
-            class: AppBundle\EventListener\AuthenticationSuccessHandler
-            tags:
-                - { name: kernel.event_listener, event: security.interactive_login, method: onSecurityInteractiveLogin }
+        class: AppBundle\EventListener\AuthenticationSuccessHandler
+        tags:
+            - { name: kernel.event_listener, event: security.interactive_login, method: onSecurityInteractiveLogin }
 
     # listeners
     oauth_event_listener:
-            class: AppBundle\EventListener\OAuthEventListener
-            arguments:
-                $entityManager: "@doctrine.orm.entity_manager"
-            tags:
-                - { name: kernel.event_listener, event: fos_oauth_server.pre_authorization_process, method: onPreAuthorizationProcess }
-                - { name: kernel.event_listener, event: fos_oauth_server.post_authorization_process, method: onPostAuthorizationProcess }
+        class: AppBundle\EventListener\OAuthEventListener
+        arguments:
+            $entityManager: "@doctrine.orm.entity_manager"
+        tags:
+            - { name: kernel.event_listener, event: fos_oauth_server.pre_authorization_process, method: onPreAuthorizationProcess }
+            - { name: kernel.event_listener, event: fos_oauth_server.post_authorization_process, method: onPostAuthorizationProcess }
     helloasso_event_listener:
-            class: AppBundle\EventListener\HelloassoEventListener
-            arguments:
-                $mailer: "@mailer"
-                $entityManager: "@doctrine.orm.entity_manager"
-                $container: "@service_container"
-                $memberEmail: "%emails.member%"
-            tags:
-                - { name: kernel.event_listener, event: helloasso.payment_after_save, method: onPaymentAfterSave }
-                - { name: kernel.event_listener, event: helloasso.orphan_solve, method: onOrphanSolve }
+        class: AppBundle\EventListener\HelloassoEventListener
+        arguments:
+            $entityManager: "@doctrine.orm.entity_manager"
+            $container: "@service_container"
+            $mailer: "@mailer"
+            $memberEmail: "%emails.member%"
+        tags:
+            - { name: kernel.event_listener, event: helloasso.payment_after_save, method: onPaymentAfterSave }
+            - { name: kernel.event_listener, event: helloasso.orphan_solve, method: onOrphanSolve }
     commission_leave_or_join_listener:
-            class: AppBundle\EventListener\CommissionEventListener
-            arguments:
-                $entityManager: "@doctrine.orm.entity_manager"
-                $logger: "@logger"
-                $container: "@service_container"
-            tags:
-                - { name: kernel.event_listener, event: commission.join, method: onJoin }
-                - { name: kernel.event_listener, event: commission.leave, method: onLeave }
+        class: AppBundle\EventListener\CommissionEventListener
+        arguments:
+            $entityManager: "@doctrine.orm.entity_manager"
+            $logger: "@logger"
+            $container: "@service_container"
+        tags:
+            - { name: kernel.event_listener, event: commission.join, method: onJoin }
+            - { name: kernel.event_listener, event: commission.leave, method: onLeave }
     shift_free_log_event_listener:
-            class: AppBundle\EventListener\ShiftFreeLogEventListener
-            arguments:
-                $entityManager: "@doctrine.orm.entity_manager"
-                $logger: "@logger"
-                $container: "@service_container"
-            tags:
-                - { name: kernel.event_listener, event: shift.freed, method: onShiftFreed }
+        class: AppBundle\EventListener\ShiftFreeLogEventListener
+        arguments:
+            $entityManager: "@doctrine.orm.entity_manager"
+            $logger: "@logger"
+            $container: "@service_container"
+        tags:
+            - { name: kernel.event_listener, event: shift.freed, method: onShiftFreed }
     period_position_free_log_event_listener:
-            class: AppBundle\EventListener\PeriodPositionFreeLogEventListener
-            arguments:
-                $entityManager: "@doctrine.orm.entity_manager"
-                $logger: "@logger"
-                $container: "@service_container"
-            tags:
-                - { name: kernel.event_listener, event: period_position.freed, method: onPeriodPositionFreed }
+        class: AppBundle\EventListener\PeriodPositionFreeLogEventListener
+        arguments:
+            $entityManager: "@doctrine.orm.entity_manager"
+            $logger: "@logger"
+            $container: "@service_container"
+        tags:
+            - { name: kernel.event_listener, event: period_position.freed, method: onPeriodPositionFreed }
     time_log_event_listener:
-            class: AppBundle\EventListener\TimeLogEventListener
-            arguments:
-                $entityManager: "@doctrine.orm.entity_manager"
-                $logger: "@logger"
-                $container: "@service_container"
-            tags:
-                - { name: kernel.event_listener, event: shift.booked, method: onShiftBooked }
-                - { name: kernel.event_listener, event: shift.freed, method: onShiftFreed }
-                - { name: kernel.event_listener, event: shift.deleted, method: onShiftDeleted }
-                - { name: kernel.event_listener, event: shift.validated, method: onShiftValidated }
-                - { name: kernel.event_listener, event: shift.invalidated, method: onShiftInvalidated }
-                - { name: kernel.event_listener, event: member.cycle.end, method: onMemberCycleEnd }
+        class: AppBundle\EventListener\TimeLogEventListener
+        arguments:
+            $entityManager: "@doctrine.orm.entity_manager"
+            $logger: "@logger"
+            $container: "@service_container"
+        tags:
+            - { name: kernel.event_listener, event: shift.booked, method: onShiftBooked }
+            - { name: kernel.event_listener, event: shift.freed, method: onShiftFreed }
+            - { name: kernel.event_listener, event: shift.deleted, method: onShiftDeleted }
+            - { name: kernel.event_listener, event: shift.validated, method: onShiftValidated }
+            - { name: kernel.event_listener, event: shift.invalidated, method: onShiftInvalidated }
+            - { name: kernel.event_listener, event: member.cycle.end, method: onMemberCycleEnd }
     emailing_event_listener:
-            class: AppBundle\EventListener\EmailingEventListener
-            arguments:
-                $mailer: "@mailer"
-                $logger: "@logger"
-                $container: "@service_container"
-                $memberEmail: "%emails.member%"
-                $shiftEmail: "%emails.shift%"
-                $wikiKeysUrl: "%wiki_keys_url%"
-            tags:
-                - { name: kernel.event_listener, event: code.new, method: onCodeNew }
-                - { name: kernel.event_listener, event: shift.reserved, method: onShiftReserved }
-                - { name: kernel.event_listener, event: shift.booked, method: onShiftBooked }
-                - { name: kernel.event_listener, event: shift.freed, method: onShiftFreed }
-                - { name: kernel.event_listener, event: shift.deleted, method: onShiftDeleted }
-                - { name: kernel.event_listener, event: member.cycle.start, method: onMemberCycleStart }
-                - { name: kernel.event_listener, event: member.cycle.half, method: onMemberCycleHalf }
-                - { name: kernel.event_listener, event: member.created, method: onMemberCreated }
-                - { name: kernel.event_listener, event: anonymous_beneficiary.created, method: onAnonymousBeneficiaryCreated }
-                - { name: kernel.event_listener, event: anonymous_beneficiary.recall, method: onAnonymousBeneficiaryRecall }
-                - { name: kernel.event_listener, event: beneficiary.add, method: onBeneficiaryAdd }
-                - { name: kernel.event_listener, event: helloasso.registration_success, method: onHelloassoRegistrationSuccess }
-                - { name: kernel.event_listener, event: helloasso.too_early, method: onHelloassoTooEarly }
+        class: AppBundle\EventListener\EmailingEventListener
+        arguments:
+            $entityManager: "@doctrine.orm.entity_manager"
+            $logger: "@logger"
+            $container: "@service_container"
+            $mailer: "@mailer"
+            $memberEmail: "%emails.member%"
+            $shiftEmail: "%emails.shift%"
+            $wikiKeysUrl: "%wiki_keys_url%"
+        tags:
+            - { name: kernel.event_listener, event: code.new, method: onCodeNew }
+            - { name: kernel.event_listener, event: shift.reserved, method: onShiftReserved }
+            - { name: kernel.event_listener, event: shift.booked, method: onShiftBooked }
+            - { name: kernel.event_listener, event: shift.freed, method: onShiftFreed }
+            - { name: kernel.event_listener, event: shift.deleted, method: onShiftDeleted }
+            - { name: kernel.event_listener, event: member.cycle.start, method: onMemberCycleStart }
+            - { name: kernel.event_listener, event: member.cycle.half, method: onMemberCycleHalf }
+            - { name: kernel.event_listener, event: member.created, method: onMemberCreated }
+            - { name: kernel.event_listener, event: anonymous_beneficiary.created, method: onAnonymousBeneficiaryCreated }
+            - { name: kernel.event_listener, event: anonymous_beneficiary.recall, method: onAnonymousBeneficiaryRecall }
+            - { name: kernel.event_listener, event: beneficiary.add, method: onBeneficiaryAdd }
+            - { name: kernel.event_listener, event: helloasso.registration_success, method: onHelloassoRegistrationSuccess }
+            - { name: kernel.event_listener, event: helloasso.too_early, method: onHelloassoTooEarly }
 
     # subscribers
     beneficiary_initialization_subscriber:
@@ -194,8 +195,8 @@ services:
     validator_anonymous_beneficiary_beneficiary_can_host:
         class: AppBundle\Validator\Constraints\BeneficiaryCanHostValidator
         arguments:
-              $container: "@service_container"
-              $maximum_nb_of_beneficiaries_in_membership: "%maximum_nb_of_beneficiaries_in_membership%"
+            $container: "@service_container"
+            $maximum_nb_of_beneficiaries_in_membership: "%maximum_nb_of_beneficiaries_in_membership%"
 
     # services
     shift_service:

--- a/src/AppBundle/Command/ShiftGenerateCommand.php
+++ b/src/AppBundle/Command/ShiftGenerateCommand.php
@@ -101,13 +101,14 @@ class ShiftGenerateCommand extends ContainerAwareCommand
                             $current_shift->setJob($period->getJob());
                             $current_shift->setFormation($position->getFormation());
                             $current_shift->setPosition($position);
-                            // si c'est un créneau fixe
+                            // si c'est un créneau fixe + membre non exempté
                             if ($use_fly_and_fixed && $position->getShifter() != null && !$position->getShifter()->getMembership()->isCurrentlyExemptedFromShifts($current_shift->getStart())) {
                                 $current_shift->setFixe(True);
                                 $current_shift->setShifter($position->getShifter());
                                 $current_shift->setBookedTime(new \DateTime('now'));
                                 $current_shift->setBooker($admin);
-                            } else if ($last_cycle_shift && $last_cycle_shift->getShifter() && $reserve_new_shift_to_prior_shifter) {
+                            // créneau pré-reservé
+                            } else if ($reserve_new_shift_to_prior_shifter && $last_cycle_shift && $last_cycle_shift->getShifter()) {
                                 $current_shift->setLastShifter($last_cycle_shift->getShifter());
                                 $reservedShifts[$count_new_all] = $current_shift;
                                 $formerShifts[$count_new_all] = $last_cycle_shift;

--- a/src/AppBundle/Controller/ShiftController.php
+++ b/src/AppBundle/Controller/ShiftController.php
@@ -488,17 +488,17 @@ class ShiftController extends Controller
             $session->getFlashBag()->add('error', "Créneau pas trouvé");
             return $this->redirectToRoute("homepage");
         }
-        if (!$this->isGranted('accept', $shift)) {
-            $session->getFlashBag()->add("error", "Impossible d'accepter la réservation");
-            return $this->redirectToRoute("homepage");
-        }
         if (!$shift->getLastShifter()) {
             $session->getFlashBag()->add('error', "Oups, ce créneau a déjà été confirmé / refusé, ou le délai de reservation est écoulé.");
             return $this->redirectToRoute("homepage");
         }
+        if (!$this->isGranted('accept', $shift)) {
+            $session->getFlashBag()->add("error", "Impossible d'accepter la réservation");
+            return $this->redirectToRoute("homepage");
+        }
 
-        $shift->setBooker($current_user);
         $beneficiary = $shift->getLastShifter();
+        $shift->setBooker(is_object($current_user) ? $current_user : $beneficiary->getUser());
         $shift->setShifter($beneficiary);
         $shift->setBookedTime(new DateTime('now'));
         $shift->setLastShifter(null);
@@ -529,12 +529,12 @@ class ShiftController extends Controller
             $session->getFlashBag()->add('error', "Créneau pas trouvé");
             return $this->redirectToRoute("homepage");
         }
-        if (!$this->isGranted('reject', $shift)) {
-            $session->getFlashBag()->add("error", "Impossible de rejeter la réservation");
-            return $this->redirectToRoute("homepage");
-        }
         if (!$shift->getLastShifter()) {
             $session->getFlashBag()->add('error', "Oups, ce créneau a déjà été confirmé / refusé, ou le délai de reservation est écoulé.");
+            return $this->redirectToRoute("homepage");
+        }
+        if (!$this->isGranted('reject', $shift)) {
+            $session->getFlashBag()->add("error", "Impossible de rejeter la réservation");
             return $this->redirectToRoute("homepage");
         }
 

--- a/src/AppBundle/Entity/Membership.php
+++ b/src/AppBundle/Entity/Membership.php
@@ -156,7 +156,7 @@ class Membership
 
     public function getTmpToken($key = '')
     {
-        return md5($this->getId().$this->getMemberNumber().$key.date('d'));
+        return md5($this->getId() . $this->getMemberNumber() . $key . date('d'));
     }
 
     /**

--- a/src/AppBundle/Entity/Shift.php
+++ b/src/AppBundle/Entity/Shift.php
@@ -627,7 +627,7 @@ class Shift
      */
     public function getTmpToken($key = '')
     {
-        return md5($this->getId().$this->getStart()->format('d/m/Y').$this->getEnd()->format('d/m/Y').$key);
+        return md5($this->getId() . $this->getStart()->format('d/m/Y') . $this->getEnd()->format('d/m/Y') . $key);
     }
 
     /**

--- a/src/AppBundle/Event/ShiftBookedEvent.php
+++ b/src/AppBundle/Event/ShiftBookedEvent.php
@@ -26,5 +26,4 @@ class ShiftBookedEvent extends Event
     {
         return $this->fromAdmin;
     }
-
 }

--- a/src/AppBundle/Event/ShiftReservedEvent.php
+++ b/src/AppBundle/Event/ShiftReservedEvent.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace AppBundle\Event;
+
+use AppBundle\Entity\Shift;
+use Symfony\Component\EventDispatcher\Event;
+
+class ShiftReservedEvent extends Event
+{
+    const NAME = 'shift.reserved';
+
+    private $shift;
+    private $formerShift;
+
+    public function __construct(Shift $shift, Shift $formerShift)
+    {
+        $this->shift = $shift;
+        $this->formerShift = $formerShift;
+    }
+
+    public function getShift()
+    {
+        return $this->shift;
+    }
+
+    public function getFormerShift()
+    {
+        return $this->formerShift;
+    }
+}

--- a/src/AppBundle/EventListener/EmailingEventListener.php
+++ b/src/AppBundle/EventListener/EmailingEventListener.php
@@ -250,8 +250,8 @@ class EmailingEventListener
                         'shift' => $shift,
                         'oldshift' => $formerShift,
                         'days' => $d,
-                        'accept_url' => $router->generate('shift_accept_reserved', array('id' => $shift->getId(),'token'=> $shift->getTmpToken($beneficiary->getId())),UrlGeneratorInterface::ABSOLUTE_URL),
-                        'reject_url' => $router->generate('shift_reject_reserved', array('id' => $shift->getId(),'token'=> $shift->getTmpToken($beneficiary->getId())),UrlGeneratorInterface::ABSOLUTE_URL),
+                        'accept_url' => $router->generate('shift_accept_reserved', array('id' => $shift->getId(), 'token' => $shift->getTmpToken($beneficiary->getId())), UrlGeneratorInterface::ABSOLUTE_URL),
+                        'reject_url' => $router->generate('shift_reject_reserved', array('id' => $shift->getId(), 'token' => $shift->getTmpToken($beneficiary->getId())), UrlGeneratorInterface::ABSOLUTE_URL),
                     )
                 ),
                 'text/html'

--- a/src/AppBundle/EventListener/EmailingEventListener.php
+++ b/src/AppBundle/EventListener/EmailingEventListener.php
@@ -23,25 +23,25 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class EmailingEventListener
 {
-    protected $mailer;
+    protected $em;
     protected $logger;
     protected $container;
+    protected $mailer;
     protected $due_duration_by_cycle;
     private $memberEmail;
     private $shiftEmail;
     private $wikiKeysUrl;
-    private $entity_manager;
 
-    public function __construct(Swift_Mailer $mailer, Logger $logger, Container $container, EntityManagerInterface $entity_manager, $memberEmail, $shiftEmail, $wikiKeysUrl)
+    public function __construct(EntityManagerInterface $entityManager, Logger $logger, Container $container, Swift_Mailer $mailer, $memberEmail, $shiftEmail, $wikiKeysUrl)
     {
-        $this->mailer = $mailer;
+        $this->em = $entityManager;
         $this->logger = $logger;
         $this->container = $container;
+        $this->mailer = $mailer;
         $this->due_duration_by_cycle = $this->container->getParameter('due_duration_by_cycle');
         $this->memberEmail = $memberEmail;
         $this->shiftEmail = $shiftEmail;
         $this->wikiKeysUrl = $wikiKeysUrl;
-        $this->entity_manager = $entity_manager;
     }
 
     /**
@@ -54,7 +54,7 @@ class EmailingEventListener
 
         $email = $event->getAnonymousBeneficiary()->getEmail();
 
-        $dynamicContent = $this->entity_manager->getRepository('AppBundle:DynamicContent')->findOneByCode("PRE_MEMBERSHIP_EMAIL")->getContent();
+        $dynamicContent = $this->em->getRepository('AppBundle:DynamicContent')->findOneByCode("PRE_MEMBERSHIP_EMAIL")->getContent();
 
         if (!$event->getAnonymousBeneficiary()->getJoinTo()){
             $url = $this->container->get('router')->generate('member_new', array('code' => $this->container->get('AppBundle\Helper\SwipeCard')->vigenereEncode($email)),UrlGeneratorInterface::ABSOLUTE_URL);
@@ -89,7 +89,7 @@ class EmailingEventListener
 
         $email = $event->getAnonymousBeneficiary()->getEmail();
 
-        $dynamicContent = $this->entity_manager->getRepository('AppBundle:DynamicContent')->findOneByCode("PRE_MEMBERSHIP_EMAIL")->getContent();
+        $dynamicContent = $this->em->getRepository('AppBundle:DynamicContent')->findOneByCode("PRE_MEMBERSHIP_EMAIL")->getContent();
 
         if (!$event->getAnonymousBeneficiary()->getJoinTo()){
             $url = $this->container->get('router')->generate('member_new', array('code' => $this->container->get('AppBundle\Helper\SwipeCard')->vigenereEncode($email)),UrlGeneratorInterface::ABSOLUTE_URL);

--- a/src/AppBundle/EventListener/HelloassoEventListener.php
+++ b/src/AppBundle/EventListener/HelloassoEventListener.php
@@ -14,14 +14,14 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class HelloassoEventListener
 {
-    protected $_em;
+    protected $em;
     protected $container;
     protected $mailer;
     private $memberEmail;
 
-    public function __construct(EntityManager $entityManager, Container $container,Swift_Mailer $mailer,$memberEmail)
+    public function __construct(EntityManager $entityManager, Container $container, Swift_Mailer $mailer, $memberEmail)
     {
-        $this->_em = $entityManager;
+        $this->em = $entityManager;
         $this->container = $container;
         $this->mailer = $mailer;
         $this->memberEmail = $memberEmail;
@@ -30,8 +30,7 @@ class HelloassoEventListener
     public function onPaymentAfterSave(HelloassoEvent $event)
     {
         $payment = $event->getPayment();
-        /** @var User $user */
-        $user = $this->_em->getRepository('AppBundle:User')->findOneBy(array('email' => strtolower($payment->getEmail())));
+        $user = $this->em->getRepository('AppBundle:User')->findOneBy(array('email' => strtolower($payment->getEmail())));
         if ($user){
             $this->linkPaymentToUser($user,$payment);
         } else {
@@ -120,7 +119,7 @@ class HelloassoEventListener
                 $registration->setMode(Registration::TYPE_HELLOASSO);
                 $registration->setMembership($membership);
 
-                $this->_em->persist($registration);
+                $this->em->persist($registration);
                 $payment->setRegistration($registration);
                 $membership->addRegistration($registration);
 
@@ -128,9 +127,9 @@ class HelloassoEventListener
                 if ($membership->isWithdrawn()) {
                     $membership->setWithdrawn(false);
                 }
-                $this->_em->persist($membership);
+                $this->em->persist($membership);
 
-                $this->_em->flush();
+                $this->em->flush();
 
                 $this->container->get('event_dispatcher')->dispatch(HelloassoEvent::RE_REGISTRATION_SUCCESS,new HelloassoEvent($payment,$beneficiary->getUser()));
             }

--- a/src/AppBundle/EventListener/OAuthEventListener.php
+++ b/src/AppBundle/EventListener/OAuthEventListener.php
@@ -7,11 +7,11 @@ use FOS\OAuthServerBundle\Event\OAuthEvent;
 
 class OAuthEventListener
 {
-    protected $_em;
+    protected $em;
 
     public function __construct(EntityManager $entityManager)
     {
-        $this->_em = $entityManager;
+        $this->em = $entityManager;
     }
 
     public function onPreAuthorizationProcess(OAuthEvent $event)
@@ -29,14 +29,14 @@ class OAuthEventListener
             if (null !== $client = $event->getClient()) {
                 $user = $this->getUser($event);
                 $user->addClient($client);
-                $this->_em->persist($user);
-                $this->_em->flush();
+                $this->em->persist($user);
+                $this->em->flush();
             }
         }
     }
 
     protected function getUser(OAuthEvent $event)
     {
-        return $this->_em->getRepository('AppBundle:User')->findOneBy(array('username'=>$event->getUser()->getUsername()));
+        return $this->em->getRepository('AppBundle:User')->findOneBy(array('username'=>$event->getUser()->getUsername()));
     }
 }

--- a/src/AppBundle/Security/ShiftVoter.php
+++ b/src/AppBundle/Security/ShiftVoter.php
@@ -114,20 +114,20 @@ class ShiftVoter extends Voter
         return false;
     }
 
+    /**
+     * Accept / Reject reserved shifts
+     * We check if the user corresponds to the shift's last shifter
+     */
     private function canReject(Shift $shift, User $user = null)
     {
-        if ($user instanceof User) {  // the user is logged in
+        // user is logged in: we don't check the token
+        if ($user instanceof User) {
             return $user->getBeneficiary() === $shift->getLastShifter();
-        } // the user is not logged in
+        }
+        // the user is not logged in: we check the token
         $token = $this->container->get('request_stack')->getCurrentRequest()->get('token');
-        if ($shift->getId()) {
-            if ($shift->getLastShifter()) {
-                if ($token == $shift->getTmpToken($shift->getLastShifter()->getId())) {
-                    return true;
-                }
-            } else {
-                return false;
-            }
+        if ($shift->getId() && $shift->getLastShifter() && $token) {
+            return $token == $shift->getTmpToken($shift->getLastShifter()->getId());
         }
         return false;
     }


### PR DESCRIPTION
Modifications apportées : 
- cleanup de ShiftController
- créé un `ShiftReservedEvent`
- déplacé l'envoi de l'e-mail de pré-réservation dans `EmailingEventListener`
- répare une erreur dans `acceptReservedShiftAction` : il est possible d'accéder à cette vue de façon anonyme, mais il y a avait une erreur car l'on souhaitait avoir l'utilisateur connecté pour `setBooker()`
- cleanup général 