### PR TITLE
Événements : pouvoir mettre en avant sur la page d'accueil

### DIFF
--- a/app/DoctrineMigrations/Version20231001143346_event_displayed_home.php
+++ b/app/DoctrineMigrations/Version20231001143346_event_displayed_home.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20231001143346 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE event ADD displayed_home TINYINT(1) DEFAULT \'0\' NOT NULL');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE event DROP displayed_home');
+    }
+}

--- a/app/Resources/views/admin/event/_partial/card.html.twig
+++ b/app/Resources/views/admin/event/_partial/card.html.twig
@@ -1,3 +1,4 @@
+{% set from_home = from_home ?? false %}
 {% set from_admin = from_admin ?? false %}
 
 <div class="card small {% if from_admin %}blue-grey darken-1{% endif %}">
@@ -9,7 +10,7 @@
     <div class="card-content {% if from_admin %}white-text{% endif %}">
         <span class="card-title">
             {{ event.title }}
-            {% if event.displayedHome %}⭐️{% endif %}
+            {% if event.displayedHome and not from_home %}⭐️{% endif %}
         </span>
         <p>
             <i class="material-icons tiny">event</i>

--- a/app/Resources/views/admin/event/_partial/card.html.twig
+++ b/app/Resources/views/admin/event/_partial/card.html.twig
@@ -7,7 +7,7 @@
             <img src="{{ event|img('imgFile', 'card') }}" />
         </div>
     {% endif %}
-    <div class="card-content {% if from_admin %}white-text{% endif %}">
+    <div class="card-content {% if from_admin %}white-text{% endif %} left-align">
         <span class="card-title">
             {{ event.title }}
             {% if event.displayedHome and not from_home %}⭐️{% endif %}
@@ -83,11 +83,11 @@
                             {% endif %}
                         {% endfor %}
                         {% if (proxy_given is null) and (proxy_received|length == 0) %}
-                            <a href="{{ path("event_proxy_give",{'id':event.id}) }}" class="waves-effect waves-light btn purple hide-on-small-only" title="Je ne peux pas venir, je fais une procuration">
-                                Je ne peux pas venir, je fais une procuration
+                            <a href="{{ path("event_proxy_give",{'id':event.id}) }}" class="waves-effect waves-light btn purple hide-on-small-only" title="Je ne peux pas venir ? je fais une procuration">
+                                Je ne peux pas venir ? je fais une procuration
                             </a>
-                            <a href="{{ path("event_proxy_give",{'id':event.id}) }}" class="waves-effect waves-light purple-text hide-on-med-and-up" title="Je ne peux pas venir, je fais une procuration">
-                                Je ne peux pas venir, je fais une procuration
+                            <a href="{{ path("event_proxy_give",{'id':event.id}) }}" class="waves-effect waves-light purple-text hide-on-med-and-up" title="Je ne peux pas venir ? je fais une procuration">
+                                Je ne peux pas venir ? je fais une procuration
                             </a>
                             {% if event.anonymousProxy %}
                                 <a href="{{ path("event_proxy_take",{'id':event.id}) }}" class="waves-effect waves-light btn green hide-on-small-only" title="Je viens, j'accepte une procuration">

--- a/app/Resources/views/admin/event/_partial/card.html.twig
+++ b/app/Resources/views/admin/event/_partial/card.html.twig
@@ -7,7 +7,10 @@
         </div>
     {% endif %}
     <div class="card-content {% if from_admin %}white-text{% endif %}">
-        <span class="card-title">{{ event.title }}</span>
+        <span class="card-title">
+            {{ event.title }}
+            {% if event.displayedHome %}⭐️{% endif %}
+        </span>
         <p>
             <i class="material-icons tiny">event</i>
             {{ event.date | date_fr_full_with_time }}

--- a/app/Resources/views/admin/event/_partial/form.html.twig
+++ b/app/Resources/views/admin/event/_partial/form.html.twig
@@ -28,6 +28,14 @@
 <div class="row">
     {{ form_row(form.imgFile) }}
 </div>
+<div class="row">
+    {{ form_errors(form.displayed_home) }}
+    <label>
+        {{ form_widget(form.displayed_home) }}
+        <span>{{ form.displayed_home.vars.label }}</span>
+        <div class="helper-text" data-error="wrong" data-success="right">L'événement sera affiché sur la page d'accueil de chaque membre</div>
+    </label>
+</div>
 
 {% if edit %}
     <h5>Nécessite un vote ?</h5>

--- a/app/Resources/views/admin/event/_partial/table.html.twig
+++ b/app/Resources/views/admin/event/_partial/table.html.twig
@@ -18,7 +18,10 @@
     <tbody>
         {% for event in events %}
             <tr>
-                <td>{{ event.title }}</td>
+                <td>
+                    {{ event.title }}
+                    {% if event.displayedHome %}⭐️{% endif %}
+                </td>
                 <td>{{ event.kind }}</td>
                 <td>
                     {{ event.date | date_fr_full_with_time }}

--- a/app/Resources/views/admin/event/new.html.twig
+++ b/app/Resources/views/admin/event/new.html.twig
@@ -13,7 +13,7 @@
 <h4>Nouvel événement</h4>
 
 {{ form_start(form) }}
-{% include "/admin/event/_partial/form.html.twig" with { form: form } %}
+{% include "admin/event/_partial/form.html.twig" with { form: form } %}
 <button type="submit" class="btn waves-effect waves-light" title="Créer">
     <i class="material-icons left">save</i>Créer
 </button>

--- a/app/Resources/views/admin/openinghour/kind/_partial/form.html.twig
+++ b/app/Resources/views/admin/openinghour/kind/_partial/form.html.twig
@@ -17,7 +17,7 @@
     <label>
         {{ form_widget(form.enabled) }}
         <span>{{ form.enabled.vars.label }}</span>
-        <span class="helper-text" data-error="wrong" data-success="right">Nécessaire pour le bandeau Ouvert / Fermé</span>
+        <div class="helper-text" data-error="wrong" data-success="right">Nécessaire pour le bandeau Ouvert / Fermé</div>
     </label>
 </div>
 

--- a/app/Resources/views/admin/socialnetwork/new.html.twig
+++ b/app/Resources/views/admin/socialnetwork/new.html.twig
@@ -13,7 +13,7 @@
     <h4>Nouveau réseau social</h4>
 
     {{ form_start(form) }}
-    {% include "/admin/socialnetwork/_form.html.twig" with { form: form } %}
+    {% include "admin/socialnetwork/_form.html.twig" with { form: form } %}
     <div>
         <button type="submit" class="btn waves-effect waves-light">Créer</button>
     </div>

--- a/app/Resources/views/default/index.html.twig
+++ b/app/Resources/views/default/index.html.twig
@@ -159,16 +159,27 @@
                         });
                     });
                 </script>
+            </div>
 
-                <br />
-                <br />
+            <div class="homebox">
+                <h5><span class="white">Événements</span></h5>
                 <a href="{{ path("event_index") }}" class="btn blue" style="position: relative">
                     <i class="material-icons left" >event</i>Les événements à venir
                     {% if eventsFutureOrOngoing | length %}
                         <span class="bubble_counter red white-text">{{ eventsFutureOrOngoing | length }}</span>
                     {% endif %}
                 </a>
+                {% if eventsFutureOrOngoingDisplayedHome | length %}
+                    <div class="row">
+                        {% for eventDisplayedHome in eventsFutureOrOngoingDisplayedHome %}
+                            <div class="col s12">
+                                {% include "admin/event/_partial/card.html.twig" with { event: eventDisplayedHome, from_home: true } %}
+                            </div>
+                        {% endfor %}
+                    </div>
+                {% endif %}
             </div>
+
             {% if app.user.beneficiary.ownedCommissions | length %}
                 <div class="homebox">
                     <h5><span class="white">Mes commissions</span></h5>
@@ -179,6 +190,7 @@
                     {% endfor %}
                 </div>
             {% endif %}
+
             {% if (member | uptodate) and display_keys_shop %}
                 <div class="homebox">
                     <h5><span class="white"><i class="material-icons">build</i>&nbsp;Outils</span></h5>

--- a/src/AppBundle/Controller/DefaultController.php
+++ b/src/AppBundle/Controller/DefaultController.php
@@ -101,11 +101,13 @@ class DefaultController extends Controller
         }
 
         $eventsFutureOrOngoing = $em->getRepository('AppBundle:Event')->findFutureOrOngoing();
+        $eventsFutureOrOngoingDisplayedHome = $em->getRepository('AppBundle:Event')->findFutureOrOngoing(null, true);
         $dynamicContentTop = $em->getRepository('AppBundle:DynamicContent')->findOneByCode("HOME_TOP")->getContent();
         $dynamicContentBottom = $em->getRepository('AppBundle:DynamicContent')->findOneByCode("HOME_BOTTOM")->getContent();
 
         return $this->render('default/index.html.twig', [
             'eventsFutureOrOngoing' => $eventsFutureOrOngoing,
+            'eventsFutureOrOngoingDisplayedHome' => $eventsFutureOrOngoingDisplayedHome,
             'dynamicContentTop' => $dynamicContentTop,
             'dynamicContentBottom' => $dynamicContentBottom,
         ]);

--- a/src/AppBundle/Entity/Event.php
+++ b/src/AppBundle/Entity/Event.php
@@ -103,21 +103,28 @@ class Event
     /**
      * @var bool
      *
-     * @ORM\Column(name="need_proxy", type="boolean", unique=false, options={"default" : 0},nullable=true)
+     * @ORM\Column(name="need_proxy", type="boolean", unique=false, options={"default" : 0}, nullable=true)
      */
     private $need_proxy;
 
     /**
      * @var bool
      *
-     * @ORM\Column(name="anonymous_proxy", type="boolean", unique=false, options={"default" : 0},nullable=true)
+     * @ORM\Column(name="anonymous_proxy", type="boolean", unique=false, options={"default" : 0}, nullable=true)
      */
     private $anonymous_proxy;
 
     /**
-     * @ORM\OneToMany(targetEntity="Proxy", mappedBy="event",cascade={"persist", "remove"})
+     * @ORM\OneToMany(targetEntity="Proxy", mappedBy="event", cascade={"persist", "remove"})
      */
     private $proxies;
+
+    /**
+     * @var bool
+     * 
+     * @ORM\Column(name="displayed_home", type="boolean", options={"default" : 0}, nullable=false)
+     */
+    private $displayedHome;
 
     /**
      * @var \DateTime
@@ -557,6 +564,30 @@ class Event
     public function getImgSize()
     {
         return $this->imgSize;
+    }
+
+    /**
+     * Set displayedHome
+     *
+     * @param bool|null $displayedHome
+     *
+     * @return Event
+     */
+    public function setDisplayedHome($displayedHome = false)
+    {
+        $this->displayedHome = $displayedHome;
+
+        return $this;
+    }
+
+    /**
+     * Get displayedHome
+     *
+     * @return bool
+     */
+    public function getDisplayedHome()
+    {
+        return $this->displayedHome;
     }
 
     /**

--- a/src/AppBundle/Entity/SocialNetwork.php
+++ b/src/AppBundle/Entity/SocialNetwork.php
@@ -156,7 +156,7 @@ class SocialNetwork
      *
      * @return SocialNetwork
      */
-    public function setDisplayedFooter($displayedFooter = null)
+    public function setDisplayedFooter($displayedFooter = false)
     {
         $this->displayedFooter = $displayedFooter;
 
@@ -166,7 +166,7 @@ class SocialNetwork
     /**
      * Get displayedFooter
      *
-     * @return bool|null
+     * @return bool
      */
     public function getDisplayedFooter()
     {

--- a/src/AppBundle/Form/EventType.php
+++ b/src/AppBundle/Form/EventType.php
@@ -85,6 +85,11 @@ class EventType extends AbstractType
                     'required' => false,
                     'allow_delete' => true,
                     'download_link' => true,
+                ))
+                ->add('displayed_home', CheckboxType::class, array(
+                    'required' => false,
+                    'label' => 'Mettre en avant',
+                    'attr' => array('class' => 'filled-in')
                 ));
 
             if ($userData && $userData->getId()) {

--- a/src/AppBundle/Repository/EventRepository.php
+++ b/src/AppBundle/Repository/EventRepository.php
@@ -17,7 +17,7 @@ class EventRepository extends \Doctrine\ORM\EntityRepository
         return $this->findBy(array(), array('date' => 'DESC'));
     }
 
-    public function findFutureOrOngoing(EventKind $eventKind = null, \DateTime $max = null, int $limit = null)
+    public function findFutureOrOngoing(EventKind $eventKind = null, bool $dislayedHome = false, \DateTime $max = null, int $limit = null)
     {
         $qb = $this->createQueryBuilder('e')
             ->leftJoin('e.kind', 'ek')
@@ -29,6 +29,10 @@ class EventRepository extends \Doctrine\ORM\EntityRepository
             $qb
                 ->andwhere('e.kind = :kind')
                 ->setParameter('kind', $eventKind);
+        }
+
+        if ($dislayedHome) {
+            $qb->andwhere('e.displayedHome = 1');
         }
 
         if ($max) {
@@ -121,6 +125,16 @@ class EventRepository extends \Doctrine\ORM\EntityRepository
         }
 
         $qb->orderBy('e.date', 'DESC');
+
+        return $qb
+            ->getQuery()
+            ->getResult();
+    }
+
+    public function findAllDisplayedHome()
+    {
+        $qb = $this->createQueryBuilder('e')
+            ->where('e.displayedHome = 1');
 
         return $qb
             ->getQuery()


### PR DESCRIPTION
### Quoi ?

On souhaite parfois mettre en avant un événement important. Ses détails s'afficheraient alors directement sur la page d'accueil du membre.

Modifications apportées : 
- nouveau champ `displayedHome`
- modifications des formulaires
- coté admin, ajouter une :star: si l'événement est mis en avant
- coté membre, afficher la card de l'événement dans la section dédiée

### Captures d'écran

![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/006e7a41-f5fe-4981-9aeb-1b2e20aed62f)
