### PR TITLE
Événements : améliorations pour les utilisateurs anonymes

### DIFF
--- a/app/Resources/views/admin/event/_partial/card.html.twig
+++ b/app/Resources/views/admin/event/_partial/card.html.twig
@@ -12,7 +12,7 @@
     {% if not only_action %}
         {% include "admin/event/_partial/card_content.html.twig" with { event: event, only_header: only_header, from_admin: from_admin } %}
     {% endif %}
-    
+
     {% if not only_header %}
         {% include "admin/event/_partial/card_action.html.twig" with { event: event, only_action: only_action, from_admin: from_admin } %}
     {% endif %}

--- a/app/Resources/views/admin/event/_partial/card_action.html.twig
+++ b/app/Resources/views/admin/event/_partial/card_action.html.twig
@@ -2,7 +2,9 @@
 {% set from_admin = from_admin ?? false %}
 
 <div class="card-action">
-    {% if event.needProxy %}
+    {% if not is_granted("IS_AUTHENTICATED_REMEMBERED") %}
+        <span>Connexion requise</span>
+    {% elseif event.needProxy %}
         {% if from_admin %}
             <div class="left">
                 <a href="{{ path("admin_event_proxies_list", {'id': event.id}) }}"><i class="material-icons left">list</i>Procurations</a>
@@ -59,7 +61,6 @@
                 {% endif %}
             {% endif %}
         {% endif %}
-        <br />
     {% endif %}
     {% if from_admin %}
         <div class="right">

--- a/app/Resources/views/event/detail.html.twig
+++ b/app/Resources/views/event/detail.html.twig
@@ -4,7 +4,9 @@
 
 {% block breadcrumbs %}
 <a href="{{ path('homepage') }}"><i class="material-icons">home</i></a><i class="material-icons">chevron_right</i>
-<a href="{{ path('event_index') }}"><i class="material-icons">event</i>&nbsp;Événements</a><i class="material-icons">chevron_right</i>
+{% if is_granted("IS_AUTHENTICATED_REMEMBERED") %}
+    <a href="{{ path('event_index') }}"><i class="material-icons">event</i>&nbsp;Événements</a><i class="material-icons">chevron_right</i>
+{% endif %}
 <i class="material-icons">event</i>&nbsp;{{ event.title }}
 {% endblock %}
 

--- a/src/AppBundle/Controller/EventController.php
+++ b/src/AppBundle/Controller/EventController.php
@@ -64,6 +64,7 @@ class EventController extends Controller
      * Event home
      *
      * @Route("/", name="event_index", methods={"GET"})
+     * @Security("has_role('ROLE_USER')")
      */
     public function indexAction(Request $request)
     {


### PR DESCRIPTION
Suite de #1026

### Quoi ?

Actuellement un utilisateur anonyme qui a un lien vers un événement peut le voir, mais il voit aussi : 
- un lien vers la liste des événements
- une card action vide (ou qui provoque une erreur)

Modifications apportées pour les utilisateurs anonymes : 
- ne pas permettre à un utilisateur anonyme d'accéder à la page qui liste les événements
- afficher un bandeau "Connexion requise" sous la page détail d'un événement