### PR TITLE
Événements : améliorations supplémentaires sur les procurations

### DIFF
--- a/app/Resources/views/admin/event/_partial/card_action.html.twig
+++ b/app/Resources/views/admin/event/_partial/card_action.html.twig
@@ -65,7 +65,7 @@
                     {% else %}
                         <div>
                             <b>{{ proxy_received_item.owner.membership.memberNumberWithBeneficiaryListString }}</b> accepte une procuration.
-                            <a href="{{ path("event_proxy_lite_delete",{'event':event.id,'proxy':proxy_received_item.id}) }}" class="red-text" onclick="return confirm('Etes-vous sûr ?!');">X</a>
+                            <a href="{{ path("event_proxy_lite_delete",{'id':event.id,'proxy':proxy_received_item.id}) }}" class="red-text" onclick="return confirm('Etes-vous sûr ?!');">X</a>
                         </div>
                     {% endif %}
                 {% endfor %}

--- a/app/Resources/views/admin/event/_partial/card_action.html.twig
+++ b/app/Resources/views/admin/event/_partial/card_action.html.twig
@@ -63,7 +63,10 @@
                     {% if proxy_received_item.giver %}
                         <div>Procuration portée par <b>{{ proxy_received_item.owner.membership.memberNumberWithBeneficiaryListString }}</b> de la part de&nbsp;<b>{{ proxy_received_item.giver.memberNumberWithBeneficiaryListString }}</b></div>
                     {% else %}
-                        <div><b>{{ proxy_received_item.owner.membership.memberNumberWithBeneficiaryListString }}</b> accepte une procuration. <a href="{{ path("event_proxy_lite_remove",{'event':event.id,'proxy':proxy_received_item.id}) }}" class="red-text">X</a></div>
+                        <div>
+                            <b>{{ proxy_received_item.owner.membership.memberNumberWithBeneficiaryListString }}</b> accepte une procuration.
+                            <a href="{{ path("event_proxy_lite_delete",{'event':event.id,'proxy':proxy_received_item.id}) }}" class="red-text" onclick="return confirm('Etes-vous sûr ?!');">X</a>
+                        </div>
                     {% endif %}
                 {% endfor %}
                 {% if (proxy_given is null) and (proxy_received|length == 0) %}

--- a/app/Resources/views/admin/event/_partial/card_action.html.twig
+++ b/app/Resources/views/admin/event/_partial/card_action.html.twig
@@ -2,58 +2,79 @@
 {% set from_admin = from_admin ?? false %}
 
 <div class="card-action">
+    {% if not only_action %}
+        <div class="right">
+            <a href="{{ path("event_detail", {'id': event.id}) }}" class="{% if not from_admin %}btn blue{% endif %}" {% if from_admin %}target="_blank"{% endif %}>
+                <i class="material-icons left">visibility</i>Voir
+            </a>
+        </div>
+    {% endif %}
     {% if not is_granted("IS_AUTHENTICATED_REMEMBERED") %}
         <span>Connexion requise</span>
-    {% elseif event.needProxy %}
-        {% if from_admin %}
+    {% elseif from_admin %}
+        {% if event.needProxy %}
             <div class="left">
-                <a href="{{ path("admin_event_proxies_list", {'id': event.id}) }}"><i class="material-icons left">list</i>Procurations</a>
+                <a href="{{ path("admin_event_proxies_list", {'id': event.id}) }}">
+                    <i class="material-icons left">list</i>Procurations
+                </a>
             </div>
             <div class="left">
-                <a href="{{ path("admin_event_signatures", {'id': event.id}) }}"><i class="material-icons left">print</i>Emargement</a>
+                <a href="{{ path("admin_event_signatures", {'id': event.id}) }}">
+                    <i class="material-icons left">print</i>Emargement
+                </a>
             </div>
+        {% endif %}
+        <div class="right">
+            <a href="{{ path("admin_event_edit", {'id': event.id}) }}">
+                <i class="material-icons left">edit</i>Editer
+            </a>
+        </div>
+    {% elseif event.needProxy %}{# member side #}
+        {% if not app.user.beneficiary or not app.user.beneficiary.membership or not app.user.beneficiary.membership.lastRegistration %}
+            <span>Oups, nous n'avons enregistré aucune adhésion pour ton compte. Tu ne pourras pas voter pour cet événement.</span>
         {% else %}
-            {% if not app.user.beneficiary or not app.user.beneficiary.membership or not app.user.beneficiary.membership.lastRegistration %}
-                <span>Oups, nous n'avons enregistré aucune adhésion pour ton compte. Tu ne pourras pas voter pour cet événement.</span>
-            {% else %}
-                {% set member = app.user.beneficiary.membership %}
-                {% set proxy_given = event | givenProxy %}
-                {% set proxy_received = event | receivedProxies %}
+            {% set member = app.user.beneficiary.membership %}
+            {% set proxy_given = event | givenProxy %}
+            {% set proxy_received = event | receivedProxies %}
 
-                {% if (registration_duration is not null) %}
-                    {% set minDateOfLastRegistration = event.maxDateOfLastRegistration | date_modify('-' ~ registration_duration) %}
-                {% else %}
-                    {% set minDateOfLastRegistration = null %}
-                {% endif %}
-                {% if (minDateOfLastRegistration is not null and member.lastRegistration.date < minDateOfLastRegistration) %}
-                    <b>Oups</b>, seuls les membres qui ont adhéré ou ré-adhéré <b>après le {{ minDateOfLastRegistration | date_short }}</b> peuvent voter à cet événement.
-                    <br />
-                    Pense à mettre à jour ton adhésion pour participer ! :)
-                {% elseif (member.getShiftTimeCount(event.maxDateOfLastRegistration) < time_after_which_members_are_late_with_shifts * 60) %}
-                    <b>Oups</b>, seuls les membres avec un compteur de créneaux supérieur à <b>{{ time_after_which_members_are_late_with_shifts }} à la date du {{ event.maxDateOfLastRegistration | date_short }}</b> peuvent voter à cet événement.
-                    <br />
-                    Pense à rattraper tes créneaux pour la prochaine fois ! :)
-                {% else %}
-                    {% if proxy_given is not null %}
-                        {% if proxy_given.owner is null %}
-                            <span>Procuration donnée au premier membre volontaire</span>
-                        {% else %}
-                            <span>Procuration donnée à &nbsp;<b>{{ proxy_given.owner.membership.memberNumberWithBeneficiaryListString }}</b></span>
-                        {% endif %}
+            {% if (registration_duration is not null) %}
+                {% set minDateOfLastRegistration = event.maxDateOfLastRegistration | date_modify('-' ~ registration_duration) %}
+            {% else %}
+                {% set minDateOfLastRegistration = null %}
+            {% endif %}
+
+            {% if (minDateOfLastRegistration is not null and member.lastRegistration.date < minDateOfLastRegistration) %}
+                <b>Oups</b>, seuls les membres qui ont adhéré ou ré-adhéré <b>après le {{ minDateOfLastRegistration | date_short }}</b> peuvent voter à cet événement.
+                <br />
+                Pense à mettre à jour ton adhésion pour participer ! :)
+            {% elseif (member.getShiftTimeCount(event.maxDateOfLastRegistration) < time_after_which_members_are_late_with_shifts * 60) %}
+                <b>Oups</b>, seuls les membres avec un compteur de créneaux supérieur à <b>{{ time_after_which_members_are_late_with_shifts }} à la date du {{ event.maxDateOfLastRegistration | date_short }}</b> peuvent voter à cet événement.
+                <br />
+                Pense à rattraper tes créneaux pour la prochaine fois ! :)
+            {% else %}{# member allowed to vote #}
+                {% if proxy_given is not null %}
+                    {% if proxy_given.owner is null %}
+                        <span>Procuration donnée au premier membre volontaire</span>
+                    {% else %}
+                        <span>Procuration donnée à <b>{{ proxy_given.owner.membership.memberNumberWithBeneficiaryListString }}</b></span>
                     {% endif %}
-                    {% for proxy_received_item in proxy_received %}
-                        {% if proxy_received_item.giver %}
-                            <div>Procuration portée par <b>{{ proxy_received_item.owner.membership.memberNumberWithBeneficiaryListString }}</b> de la part de&nbsp;<b>{{ proxy_received_item.giver.memberNumberWithBeneficiaryListString }}</b></div>
-                        {% else %}
-                            <div><b>{{ proxy_received_item.owner.membership.memberNumberWithBeneficiaryListString }}</b> accepte une procuration. <a href="{{ path("event_proxy_lite_remove",{'event':event.id,'proxy':proxy_received_item.id}) }}" class="red-text">X</a></div>
-                        {% endif %}
-                    {% endfor %}
-                    {% if (proxy_given is null) and (proxy_received|length == 0) %}
-                        <a href="{{ path("event_proxy_give",{'id':event.id}) }}" class="btn purple hide-on-small-only" title="Je ne peux pas venir ? je fais une procuration">
+                {% endif %}
+                {% for proxy_received_item in proxy_received %}
+                    {% if proxy_received_item.giver %}
+                        <div>Procuration portée par <b>{{ proxy_received_item.owner.membership.memberNumberWithBeneficiaryListString }}</b> de la part de&nbsp;<b>{{ proxy_received_item.giver.memberNumberWithBeneficiaryListString }}</b></div>
+                    {% else %}
+                        <div><b>{{ proxy_received_item.owner.membership.memberNumberWithBeneficiaryListString }}</b> accepte une procuration. <a href="{{ path("event_proxy_lite_remove",{'event':event.id,'proxy':proxy_received_item.id}) }}" class="red-text">X</a></div>
+                    {% endif %}
+                {% endfor %}
+                {% if (proxy_given is null) and (proxy_received|length == 0) %}
+                    {% if event.isPast %}
+                    <button class="btn" disabled>Événement passé</button>
+                    {% else %}
+                        <a href="{{ path("event_proxy_give",{'id':event.id}) }}" class="btn purple" title="Je ne peux pas venir ? je fais une procuration">
                             Je ne peux pas venir ? je fais une procuration
                         </a>
                         {% if event.anonymousProxy %}
-                            <a href="{{ path("event_proxy_take",{'id':event.id}) }}" class="btn green hide-on-small-only" title="Je viens, j'accepte une procuration">
+                            <a href="{{ path("event_proxy_take",{'id':event.id}) }}" class="btn green" title="Je viens, j'accepte une procuration">
                                 Je viens, j'accepte une procuration
                             </a>
                         {% endif %}
@@ -61,15 +82,5 @@
                 {% endif %}
             {% endif %}
         {% endif %}
-    {% endif %}
-    {% if from_admin %}
-        <div class="right">
-            <a href="{{ path("admin_event_edit", {'id': event.id}) }}"><i class="material-icons left">edit</i>Editer</a>
-        </div>
-    {% endif %}
-    {% if not only_action %}
-        <div class="right">
-            <a href="{{ path("event_detail", {'id': event.id}) }}" class="{% if not from_admin %}btn blue{% endif %}" {% if from_admin %}target="_blank"{% endif %}><i class="material-icons left">visibility</i>Voir</a>
-        </div>
     {% endif %}
 </div>

--- a/app/Resources/views/admin/event/proxy/edit.html.twig
+++ b/app/Resources/views/admin/event/proxy/edit.html.twig
@@ -6,11 +6,15 @@
 <a href="{{ path('homepage') }}"><i class="material-icons">home</i></a><i class="material-icons">chevron_right</i>
 <a href="{{ path('admin') }}"><i class="material-icons">build</i>&nbsp;Administration</a><i class="material-icons">chevron_right</i>
 <a href="{{ path('admin_event_index') }}"><i class="material-icons">event</i>&nbsp;Événements</a><i class="material-icons">chevron_right</i>
+<i class="material-icons">event</i>&nbsp;{{ event.title }}<i class="material-icons">chevron_right</i>
+<a href="{{ path('admin_event_proxies_list', {'id': event.id}) }}"><i class="material-icons">list</i>&nbsp;Liste des procurations</a><i class="material-icons">chevron_right</i>
 <i class="material-icons">edit</i>&nbsp;Editer une procuration
 {% endblock %}
 
 {% block content %}
     <h4>Editer une procuration</h4>
+
+    {% include "admin/event/_partial/card.html.twig" with { event: event, only_header: true } %}
 
     {{ form_start(form) }}
     {{ form_widget(form) }}

--- a/app/Resources/views/admin/event/proxy/list.html.twig
+++ b/app/Resources/views/admin/event/proxy/list.html.twig
@@ -75,12 +75,6 @@
                     {% if is_granted("ROLE_SUPER_ADMIN") %}
                         <td>
                             <a href="{{ path("admin_proxy_edit",{'id':proxy.id}) }}"><i class="material-icons">edit</i>Editer</a>
-                            {{ form_start(delete_forms[proxy.id]) }}
-                            {{ form_widget(delete_forms[proxy.id]) }}
-                            <div>
-                                <button type="submit" class="btn btn-small waves-effect waves-light red">Supprimer</button>
-                            </div>
-                            {{ form_end(delete_forms[proxy.id]) }}
                         </td>
                     {% endif %}
                 </tr>

--- a/app/Resources/views/admin/event/proxy/list.html.twig
+++ b/app/Resources/views/admin/event/proxy/list.html.twig
@@ -74,7 +74,7 @@
                     </td>
                     {% if is_granted("ROLE_SUPER_ADMIN") %}
                         <td>
-                            <a href="{{ path("admin_proxy_edit",{'id':proxy.id}) }}"><i class="material-icons">edit</i>Editer</a>
+                            <a href="{{ path("admin_event_proxy_edit",{'id':proxy.event.id, 'proxy':proxy.id}) }}"><i class="material-icons">edit</i>Editer</a>
                         </td>
                     {% endif %}
                 </tr>

--- a/src/AppBundle/Controller/AdminEventController.php
+++ b/src/AppBundle/Controller/AdminEventController.php
@@ -261,10 +261,10 @@ class AdminEventController extends Controller
     /**
      * Proxy edit
      *
-     * @Route("/proxies/{id}", name="admin_proxy_edit", methods={"GET","POST"})
+     * @Route("/{id}/proxies/{proxy}", name="admin_event_proxy_edit", methods={"GET","POST"})
      * @Security("has_role('ROLE_SUPER_ADMIN')")
      */
-    public function editProxyAction(Request $request, Proxy $proxy, \Swift_Mailer $mailer)
+    public function editEventProxyAction(Event $event, Proxy $proxy, Request $request, \Swift_Mailer $mailer)
     {
         $session = new Session();
         $em = $this->getDoctrine()->getManager();
@@ -335,6 +335,7 @@ class AdminEventController extends Controller
         }
 
         return $this->render('admin/event/proxy/edit.html.twig', array(
+            'event' => $event,
             'form' => $form->createView(),
             'delete_form' => $this->getProxyDeleteForm($proxy)->createView(),
         ));
@@ -343,10 +344,10 @@ class AdminEventController extends Controller
     /**
      * Proxy delete
      *
-     * @Route("/proxies/{id}", name="admin_proxy_delete", methods={"DELETE"})
+     * @Route("/{id}/proxies/{proxy}", name="admin_event_proxy_delete", methods={"DELETE"})
      * @Security("has_role('ROLE_SUPER_ADMIN')")
      */
-    public function deleteProxyAction(Request $request, Proxy $proxy)
+    public function deleteEventProxyAction(Event $event, Proxy $proxy, Request $request)
     {
         $session = new Session();
         $em = $this->getDoctrine()->getManager();
@@ -361,7 +362,7 @@ class AdminEventController extends Controller
             $session->getFlashBag()->add('success', 'La procuration a bien été supprimée !');
         }
 
-        return $this->redirectToRoute('event_proxies_list', array('id'=>$proxy->getEvent()->getId()));
+        return $this->redirectToRoute('admin_event_proxies_list', array('id' => $proxy->getEvent()->getId()));
     }
 
 
@@ -481,7 +482,7 @@ class AdminEventController extends Controller
     protected function getProxyDeleteForm(Proxy $proxy)
     {
         return $this->createFormBuilder()
-            ->setAction($this->generateUrl('admin_proxy_delete', array('id' => $proxy->getId())))
+            ->setAction($this->generateUrl('admin_event_proxy_delete', array('id' => $proxy->getEvent()->getId(), 'proxy' => $proxy->getId())))
             ->setMethod('DELETE')
             ->getForm();
     }

--- a/src/AppBundle/Controller/AdminEventController.php
+++ b/src/AppBundle/Controller/AdminEventController.php
@@ -235,14 +235,9 @@ class AdminEventController extends Controller
 
         $proxies = $em->getRepository('AppBundle:Proxy')->findAll();
 
-        $delete_forms = array();
-        foreach ($proxies as $proxy){
-            $delete_forms[$proxy->getId()] = $this->getProxyDeleteForm($proxy)->createView();
-        }
 
         return $this->render('admin/event/proxy/list.html.twig', array(
             'proxies' => $proxies,
-            'delete_forms' => $delete_forms,
             'event' => null,
         ));
     }
@@ -257,40 +252,10 @@ class AdminEventController extends Controller
     {
         $proxies = $event->getProxies();
 
-        $delete_forms = array();
-        foreach ($proxies as $proxy) {
-            $delete_forms[$proxy->getId()] = $this->getProxyDeleteForm($proxy)->createView();
-        }
-
         return $this->render('admin/event/proxy/list.html.twig', array(
             'proxies' => $proxies,
-            'delete_forms' => $delete_forms,
             'event' => $event,
         ));
-    }
-
-    /**
-     * Proxy delete
-     *
-     * @Route("/proxies/{id}", name="admin_proxy_delete", methods={"DELETE"})
-     * @Security("has_role('ROLE_SUPER_ADMIN')")
-     */
-    public function deleteProxyAction(Request $request, Proxy $proxy)
-    {
-        $session = new Session();
-        $em = $this->getDoctrine()->getManager();
-
-        $form = $this->getProxyDeleteForm($proxy);
-        $form->handleRequest($request);
-
-        if ($form->isSubmitted() && $form->isValid()) {
-            $em->remove($proxy);
-            $em->flush();
-
-            $session->getFlashBag()->add('success', 'La procuration a bien été supprimée !');
-        }
-
-        return $this->redirectToRoute('event_proxies_list', array('id'=>$proxy->getEvent()->getId()));
     }
 
     /**
@@ -373,6 +338,30 @@ class AdminEventController extends Controller
             'form' => $form->createView(),
             'delete_form' => $this->getProxyDeleteForm($proxy)->createView(),
         ));
+    }
+
+    /**
+     * Proxy delete
+     *
+     * @Route("/proxies/{id}", name="admin_proxy_delete", methods={"DELETE"})
+     * @Security("has_role('ROLE_SUPER_ADMIN')")
+     */
+    public function deleteProxyAction(Request $request, Proxy $proxy)
+    {
+        $session = new Session();
+        $em = $this->getDoctrine()->getManager();
+
+        $form = $this->getProxyDeleteForm($proxy);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $em->remove($proxy);
+            $em->flush();
+
+            $session->getFlashBag()->add('success', 'La procuration a bien été supprimée !');
+        }
+
+        return $this->redirectToRoute('event_proxies_list', array('id'=>$proxy->getEvent()->getId()));
     }
 
 

--- a/src/AppBundle/Controller/EventController.php
+++ b/src/AppBundle/Controller/EventController.php
@@ -348,10 +348,10 @@ class EventController extends Controller
     /**
      * Proxy remove
      *
-     * @Route("/{event}/proxy/remove/{proxy}", name="event_proxy_lite_remove", methods={"GET"})
+     * @Route("/{event}/proxy/{proxy}/remove", name="event_proxy_lite_delete", methods={"GET"})
      * @Security("has_role('ROLE_USER')")
      */
-    public function removeProxyLiteAction(Event $event, Proxy $proxy, Request $request)
+    public function deleteProxyLiteAction(Event $event, Proxy $proxy, Request $request)
     {
         $session = new Session();
         $em = $this->getDoctrine()->getManager();

--- a/src/AppBundle/Controller/EventController.php
+++ b/src/AppBundle/Controller/EventController.php
@@ -158,6 +158,12 @@ class EventController extends Controller
             return $this->redirectToRoute('homepage');
         }
 
+        // check if event is past
+        if ($event->getIsPast()) {
+            $session->getFlashBag()->add('error', 'Événement passé');
+            return $this->redirectToRoute('homepage');
+        }
+
         // default proxy form
         $form = $this->createFormBuilder()
             ->setAction($this->generateUrl('event_proxy_give', array('id' => $event->getId())))

--- a/src/AppBundle/Controller/EventController.php
+++ b/src/AppBundle/Controller/EventController.php
@@ -348,7 +348,7 @@ class EventController extends Controller
     /**
      * Proxy remove
      *
-     * @Route("/{event}/proxy/{proxy}/remove", name="event_proxy_lite_delete", methods={"GET"})
+     * @Route("/{id}/proxy/{proxy}/remove", name="event_proxy_lite_delete", methods={"GET"})
      * @Security("has_role('ROLE_USER')")
      */
     public function deleteProxyLiteAction(Event $event, Proxy $proxy, Request $request)

--- a/src/AppBundle/Entity/Event.php
+++ b/src/AppBundle/Entity/Event.php
@@ -316,6 +316,15 @@ class Event
     }
 
     /**
+     * @return boolean
+     */
+    public function getIsPast()
+    {
+        $now = new \DateTime('now');
+        return ($this->date < $now && !$this->end) || ($this->date < $now && $this->end < $now);
+    }
+
+    /**
      * Set description
      *
      * @param string $description


### PR DESCRIPTION
Suite de #1026

Quelques modifications autour des procurations :
- répare le bouton violet "je fais une procuration" qui avait disparu pour les petits écrans
- ne plus permettre de faire des procurations si l'événement est passé
- améliore les urls pour la suppression d'une procuration (super admin)
- répare un bug lors de la suppression d'une procuration