### PR TITLE
Compte épargne : nouveau paramètre permettant au membre d'annuler son créneau même si il n'a pas suffisamment d'épargne

### DIFF
--- a/app/Resources/views/booking/_partial/home_shift_card.html.twig
+++ b/app/Resources/views/booking/_partial/home_shift_card.html.twig
@@ -34,12 +34,18 @@
                             {{ form_errors(shift_free_forms[shift.id].reason) }}
                             {{ form_widget(shift_free_forms[shift.id].reason) }}
                         </div>
-                        {% if use_time_log_saving %}
+                        {% if use_time_log_saving and use_card_reader_to_validate_shifts %}
                             <div class="card-panel blue lighten-3">
                                 <i class="material-icons left">info</i>
-                                Grâce au compteur épargne, ce créneau sera tout de même comptabilisé.
-                                <br />
-                                En échange, <strong>{{ shift.duration | duration_from_minutes }}</strong> seront décrémentés de votre compteur épargne (<strong>{{ member.savingTimeCount | duration_from_minutes }}</strong>).
+                                {% if not time_log_saving_shift_free_allow_only_if_enough_saving and shift.duration > member.savingTimeCount %}
+                                    Vous <strong>n'avez pas assez de temps sur votre compteur épargne</strong> (durée du créneau : <strong>{{ shift.duration | duration_from_minutes }}</strong> ; compteur épargne : <strong>{{ member.savingTimeCount | duration_from_minutes }}</strong>).
+                                    <br />
+                                    Ce créneau ne sera donc pas comptabilisé, et votre compteur épargne ne sera pas utilisé.
+                                {% else %}
+                                    Grâce au compteur épargne, ce créneau sera tout de même comptabilisé.
+                                    <br />
+                                    En échange, <strong>{{ shift.duration | duration_from_minutes }}</strong> seront décrémentés de votre compteur épargne (<strong>{{ member.savingTimeCount | duration_from_minutes }}</strong>).
+                                {% endif %}
                             </div>
                         {% endif %}
                     </div>

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -102,6 +102,7 @@ twig:
     fly_and_fixed_allow_fixed_shift_free: '%fly_and_fixed_allow_fixed_shift_free%'
     # time log saving
     time_log_saving_shift_free_min_time_in_advance_days: '%time_log_saving_shift_free_min_time_in_advance_days%'
+    time_log_saving_shift_free_allow_only_if_enough_saving: '%time_log_saving_shift_free_allow_only_if_enough_saving%'
     # opening hours
     display_opening_hour_open_closed_header: '%display_opening_hour_open_closed_header%'
     opening_hour_open_closed_header_open_message: '%opening_hour_open_closed_header_open_message%'

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -162,6 +162,7 @@ parameters:
 
     # Time log saving
     time_log_saving_shift_free_min_time_in_advance_days: null
+    time_log_saving_shift_free_allow_only_if_enough_saving: false
 
     # Opening hours
     display_opening_hour_open_closed_header: true

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -52,6 +52,7 @@ services:
             - "%use_fly_and_fixed%"
             - "%use_time_log_saving%"
             - "%time_log_saving_shift_free_min_time_in_advance_days%"
+            - "%time_log_saving_shift_free_allow_only_if_enough_saving%"
     AppBundle\Controller\TimeLogController:
         arguments:
             - "%forbid_own_timelog_new_admin%"

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -216,6 +216,7 @@ services:
             - "%fly_and_fixed_allow_fixed_shift_free%"
             - "%use_time_log_saving%"
             - "%time_log_saving_shift_free_min_time_in_advance_days%"
+            - "%time_log_saving_shift_free_allow_only_if_enough_saving%"
     shift_free_log_service:
         class: AppBundle\Service\ShiftFreeLogService
         public: true

--- a/src/AppBundle/Repository/TimeLogRepository.php
+++ b/src/AppBundle/Repository/TimeLogRepository.php
@@ -2,6 +2,9 @@
 
 namespace AppBundle\Repository;
 
+use AppBundle\Entity\Membership;
+use AppBundle\Entity\Shift;
+
 /**
  * TimeLogRepository
  *
@@ -10,4 +13,34 @@ namespace AppBundle\Repository;
  */
 class TimeLogRepository extends \Doctrine\ORM\EntityRepository
 {
+    public function findAll(Membership $member = null, Shift $shift = null, $type = null)
+    {
+        $qb = $this->createQueryBuilder('tl')
+            ->join('tl.membership', 'm')
+            ->addSelect('m')
+            ->join('tl.shift', 's')
+            ->addSelect('s');
+
+        if ($member) {
+            $qb
+                ->andWhere('tl.membership = :member')
+                ->setParameter('member', $member);
+        }
+
+        if ($shift) {
+            $qb
+                ->andWhere('tl.shift = :shift')
+                ->setParameter('shift', $shift);
+        }
+
+        if ($type) {
+            $qb
+                ->andWhere('tl.type = :type')
+                ->setParameter('type', $type);
+        }
+
+        return $qb
+            ->getQuery()
+            ->getResult();
+    }
 }

--- a/src/AppBundle/Service/ShiftService.php
+++ b/src/AppBundle/Service/ShiftService.php
@@ -296,7 +296,7 @@ class ShiftService
 
             // Time log saving:
             // - check if there is a min time in advance rule
-            // - check if the shifter has enough time on its time log saving account
+            // - check if the shifter has enough time on its savingTime
             if ($this->use_time_log_saving) {
                 $member = $shift->getShifter()->getMembership();
                 $member_saving_now = $member->getSavingTimeCount();

--- a/src/AppBundle/Service/ShiftService.php
+++ b/src/AppBundle/Service/ShiftService.php
@@ -34,8 +34,8 @@ class ShiftService
 
     public function __construct(EntityManagerInterface $em, BeneficiaryService $beneficiaryService, MembershipService $membershipService,
         $due_duration_by_cycle, $min_shift_duration, $newUserStartAsBeginner, $allowExtraShifts, $maxTimeInAdvanceToBookExtraShifts, $forbidShiftOverlapTime,
-        $use_fly_and_fixed, $fly_and_fixed_allow_fixed_shift_free,
-        $use_time_log_saving, $time_log_saving_shift_free_min_time_in_advance_days, $time_log_saving_shift_free_allow_only_if_enough_saving)
+        bool $use_fly_and_fixed, bool $fly_and_fixed_allow_fixed_shift_free,
+        bool $use_time_log_saving, $time_log_saving_shift_free_min_time_in_advance_days, bool $time_log_saving_shift_free_allow_only_if_enough_saving)
     {
         $this->em = $em;
         $this->beneficiaryService = $beneficiaryService;

--- a/src/AppBundle/Service/ShiftService.php
+++ b/src/AppBundle/Service/ShiftService.php
@@ -30,11 +30,12 @@ class ShiftService
     private $fly_and_fixed_allow_fixed_shift_free;
     private $use_time_log_saving;
     private $time_log_saving_shift_free_min_time_in_advance_days;
+    private $time_log_saving_shift_free_allow_only_if_enough_saving;
 
     public function __construct(EntityManagerInterface $em, BeneficiaryService $beneficiaryService, MembershipService $membershipService,
         $due_duration_by_cycle, $min_shift_duration, $newUserStartAsBeginner, $allowExtraShifts, $maxTimeInAdvanceToBookExtraShifts, $forbidShiftOverlapTime,
         $use_fly_and_fixed, $fly_and_fixed_allow_fixed_shift_free,
-        $use_time_log_saving, $time_log_saving_shift_free_min_time_in_advance_days)
+        $use_time_log_saving, $time_log_saving_shift_free_min_time_in_advance_days, $time_log_saving_shift_free_allow_only_if_enough_saving)
     {
         $this->em = $em;
         $this->beneficiaryService = $beneficiaryService;
@@ -49,6 +50,7 @@ class ShiftService
         $this->fly_and_fixed_allow_fixed_shift_free = $fly_and_fixed_allow_fixed_shift_free;
         $this->use_time_log_saving = $use_time_log_saving;
         $this->time_log_saving_shift_free_min_time_in_advance_days = $time_log_saving_shift_free_min_time_in_advance_days;
+        $this->time_log_saving_shift_free_allow_only_if_enough_saving = $time_log_saving_shift_free_allow_only_if_enough_saving;
     }
 
     /**
@@ -272,7 +274,7 @@ class ShiftService
             $result = false;
             $message = "Impossible de libérer le créneau car il n'est actuellement pas réservé.";
         }
-        // can only free your own shift
+        // can only free shift "owned" by beneficiary
         elseif ($shift->getShifter() != $beneficiary) {
             $result = false;
             $message = "Impossible de libérer le créneau car il n'est pas réservé par ce membre.";
@@ -286,7 +288,8 @@ class ShiftService
                 $message = "Impossible de libérer un créneau dans le passé.";
             }
 
-            // Fly & fixed: check if there is a rule allowing to free fixed shifts
+            // Fly & fixed:
+            // - check if there is a rule allowing to free fixed shifts
             if ($this->use_fly_and_fixed) {
                 if ($shift->isFixe() && !$this->fly_and_fixed_allow_fixed_shift_free) {
                     $result = false;
@@ -294,21 +297,23 @@ class ShiftService
                 }
             }
 
-            // Time log saving:
-            // - check if there is a min time in advance rule
-            // - check if the shifter has enough time on its savingTime
+            // Saving account mode
+            // - check if there is a min time in advance rule & that it is respected
+            // - check if there is a min savingTime amount rule & shifter has enough time on its savingTime
             if ($this->use_time_log_saving) {
                 $member = $shift->getShifter()->getMembership();
-                $member_saving_now = $member->getSavingTimeCount();
                 if ($this->time_log_saving_shift_free_min_time_in_advance_days) {
                     if ($shift->isBefore($this->time_log_saving_shift_free_min_time_in_advance_days . ' days')) {
                         $result = false;
                         $message = "Impossible de libérer un créneau si peu de temps en avance (minumum " . $this->time_log_saving_shift_free_min_time_in_advance_days . " jours).";
                     }
                 }
-                if ($shift->getDuration() > $member_saving_now) {
-                    $result = false;
-                    $message = "Impossible de libérer le créneau car sa durée dépasse la capacité du compteur épargne du membre.";
+                if ($this->time_log_saving_shift_free_allow_only_if_enough_saving) {
+                    $member_saving_now = $member->getSavingTimeCount();
+                    if ($shift->getDuration() > $member_saving_now) {
+                        $result = false;
+                        $message = "Impossible de libérer le créneau car sa durée dépasse la capacité du compteur épargne du membre.";
+                    }
                 }
             }
         }


### PR DESCRIPTION
### Quoi ?

Nouveau paramètre `time_log_saving_shift_free_allow_only_if_enough_saving`

Si `false`, alors le membre peut annuler un créneau dont la durée dépasserait son compteur épargne.

### Capture d'écran

Message différent qui apparaît dans ce cas là

![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/d169ab53-d91d-4e59-a0d9-c8868bb48843)
