### PR TITLE
Langue : forcer le Français en langue par défaut

### DIFF
--- a/src/AppBundle/Command/AmbassadorShiftTimeLogCommand.php
+++ b/src/AppBundle/Command/AmbassadorShiftTimeLogCommand.php
@@ -44,7 +44,6 @@ class AmbassadorShiftTimeLogCommand extends ContainerAwareCommand
         $mailer = $this->getContainer()->get('mailer');
         $recipients = $input->getOption('emails') ? explode(',', $input->getOption('emails')) : null;
         if ($recipients) {
-            setlocale(LC_TIME, 'fr_FR.UTF8');
             $subject = '[ALERTE RETARDS] Membres en retard de créneaux';
             $shiftEmail = $this->getContainer()->getParameter('emails.shift');
 

--- a/src/AppBundle/Command/SendShiftAlertsCommand.php
+++ b/src/AppBundle/Command/SendShiftAlertsCommand.php
@@ -89,7 +89,6 @@ class SendShiftAlertsCommand extends ContainerAwareCommand
         $mailer = $this->getContainer()->get('mailer');
         $recipients = $input->getOption('emails') ? explode(',', $input->getOption('emails')) : null;
         if ($recipients) {
-            setlocale(LC_TIME, 'fr_FR.UTF8');
             $dateFormatted = strftime("%A %e %B", $date->getTimestamp());
             $subject = '[ALERTE CRENEAUX] ' . $dateFormatted;
 

--- a/src/AppBundle/Entity/OpeningHour.php
+++ b/src/AppBundle/Entity/OpeningHour.php
@@ -115,7 +115,6 @@ class OpeningHour
      */
     public function getDayOfWeekString()
     {
-        setlocale(LC_TIME, 'fr_FR.UTF8');
         return strftime("%A", strtotime("Monday + {$this->dayOfWeek} days"));
     }
 

--- a/src/AppBundle/Entity/Period.php
+++ b/src/AppBundle/Entity/Period.php
@@ -168,7 +168,6 @@ class Period
      */
     public function getDayOfWeekString()
     {
-        setlocale(LC_TIME, 'fr_FR.UTF8');
         return strftime("%A", strtotime("Monday + {$this->dayOfWeek} days"));
     }
 

--- a/src/AppBundle/Entity/Shift.php
+++ b/src/AppBundle/Entity/Shift.php
@@ -136,7 +136,6 @@ class Shift
      */
     public function __toString()
     {
-        setlocale(LC_TIME, 'fr_FR.UTF8');
         return strftime("%A %e %B", $this->getStart()->getTimestamp()) . ' de ' . $this->getStart()->format('G\\hi') . ' à ' . $this->getEnd()->format('G\\hi') . ' [' . $this->getShifter() . ']';
     }
 
@@ -635,7 +634,6 @@ class Shift
      */
     public function getDisplayDateSeperateTime()
     {
-        setlocale(LC_TIME, 'fr_FR.UTF8');
         return $this->getStart()->format('d/m/Y') . ' - ' . $this->getStart()->format('G\\hi') . ' à ' . $this->getEnd()->format('G\\hi');
     }
 
@@ -644,7 +642,6 @@ class Shift
      */
     public function getDisplayDateWithTime()
     {
-        setlocale(LC_TIME, 'fr_FR.UTF8');
         return $this->getStart()->format('d/m/Y') . ' de ' . $this->getStart()->format('G\\hi') . ' à ' . $this->getEnd()->format('G\\hi');
     }
 
@@ -653,7 +650,6 @@ class Shift
      */
     public function getDisplayDateLongWithTime()
     {
-        setlocale(LC_TIME, 'fr_FR.UTF8');
         return strftime("%A %e %B", $this->getStart()->getTimestamp()) . ' de ' . $this->getStart()->format('G\\hi') . ' à ' . $this->getEnd()->format('G\\hi');
     }
 
@@ -662,7 +658,6 @@ class Shift
      */
     public function getDisplayDateFullWithTime()
     {
-        setlocale(LC_TIME, 'fr_FR.UTF8');
         return strftime("%A %e %B %Y", $this->getStart()->getTimestamp()) . ' de ' . $this->getStart()->format('G\\hi') . ' à ' . $this->getEnd()->format('G\\hi');
     }
 }

--- a/src/AppBundle/Entity/ShiftBucket.php
+++ b/src/AppBundle/Entity/ShiftBucket.php
@@ -246,7 +246,6 @@ class ShiftBucket
      */
     public function getDisplayDateLongWithTime()
     {
-        setlocale(LC_TIME, 'fr_FR.UTF8');
         return strftime("%A %e %B", $this->getStart()->getTimestamp()) . ' de ' . $this->getStart()->format('G\\hi') . ' à ' . $this->getEnd()->format('G\\hi');
     }
 }

--- a/src/AppBundle/EventListener/EmailingEventListener.php
+++ b/src/AppBundle/EventListener/EmailingEventListener.php
@@ -241,8 +241,8 @@ class EmailingEventListener
         $router = $this->container->get('router');
         $d = (date_diff(new \DateTime('now'),$shift->getStart())->format("%a"));
 
-        $mail = (new \Swift_Message('[ESPACE MEMBRES] Reprends ton créneau du '. $formerShift->getStart()->format("d F") .' dans '.$d.' jours'))
-            ->setFrom($this->shift_email['address'], $this->shift_email['from_name'])
+        $mail = (new \Swift_Message('[ESPACE MEMBRES] Reprends ton créneau du '. strftime("%e %B", $formerShift->getStart()->getTimestamp()) .' dans ' . $d . ' jours'))
+            ->setFrom($this->shiftEmail['address'], $this->shiftEmail['from_name'])
             ->setTo($beneficiary->getEmail())
             ->setBody(
                 $this->renderView(

--- a/src/AppBundle/EventListener/EmailingEventListener.php
+++ b/src/AppBundle/EventListener/EmailingEventListener.php
@@ -242,7 +242,7 @@ class EmailingEventListener
         $d = (date_diff(new \DateTime('now'),$shift->getStart())->format("%a"));
 
         $mail = (new \Swift_Message('[ESPACE MEMBRES] Reprends ton créneau du '. strftime("%e %B", $formerShift->getStart()->getTimestamp()) .' dans ' . $d . ' jours'))
-            ->setFrom($this->shiftEmail['address'], $this->shiftEmail['from_name'])
+            ->setFrom($this->shift_email['address'], $this->shift_email['from_name'])
             ->setTo($beneficiary->getEmail())
             ->setBody(
                 $this->renderView(

--- a/src/AppBundle/Twig/Extension/AppExtension.php
+++ b/src/AppBundle/Twig/Extension/AppExtension.php
@@ -135,7 +135,6 @@ class AppExtension extends AbstractExtension
      */
     public function date_fr(\DateTime $date)
     {
-        setlocale(LC_TIME, 'fr_FR.UTF8');
         return strftime("%e %B %Y", $date->getTimestamp());
     }
 
@@ -144,7 +143,6 @@ class AppExtension extends AbstractExtension
      */
     public function date_fr_long(\DateTime $date)
     {
-        setlocale(LC_TIME, 'fr_FR.UTF8');
         return strftime("%A %e %B", $date->getTimestamp());
     }
 
@@ -153,7 +151,6 @@ class AppExtension extends AbstractExtension
      */
     public function date_fr_full(\DateTime $date)
     {
-        setlocale(LC_TIME, 'fr_FR.UTF8');
         return strftime("%A %e %B %Y", $date->getTimestamp());
     }
 
@@ -162,7 +159,6 @@ class AppExtension extends AbstractExtension
      */
     public function date_fr_with_time(\DateTime $date)
     {
-        setlocale(LC_TIME, 'fr_FR.UTF8');
         return strftime("%e %B %Y à %kh%M", $date->getTimestamp());
     }
 
@@ -173,7 +169,6 @@ class AppExtension extends AbstractExtension
      */
     public function date_fr_long_with_time(\DateTime $date)
     {
-        setlocale(LC_TIME, 'fr_FR.UTF8');
         return strftime("%A %e %B à %kh%M", $date->getTimestamp());
     }
 
@@ -184,7 +179,6 @@ class AppExtension extends AbstractExtension
      */
     public function date_fr_full_with_time($date)
     {
-        setlocale(LC_TIME, 'fr_FR.UTF8');
         return strftime("%A %e %B %Y à %kh%M", $date->getTimestamp());
     }
 
@@ -193,7 +187,6 @@ class AppExtension extends AbstractExtension
      */
     public function date_short($date)  # \DateTime or \DateTimeImmutable
     {
-        setlocale(LC_TIME, 'fr_FR.UTF8');
         return strftime("%d/%m/%Y", $date->getTimestamp());
     }
 
@@ -202,7 +195,6 @@ class AppExtension extends AbstractExtension
      */
     public function date_time(\DateTime $date)
     {
-        setlocale(LC_TIME, 'fr_FR.UTF8');
         return strftime("%d/%m/%Y %kh%M", $date->getTimestamp());
     }
 
@@ -219,7 +211,6 @@ class AppExtension extends AbstractExtension
      */
     public function time_short(\DateTime $date)
     {
-        setlocale(LC_TIME, 'fr_FR.UTF8');
         $time_minutes = $date->format('i');
         if ($time_minutes == "00") {
             return strftime("%kh", $date->getTimestamp());

--- a/web/app.php
+++ b/web/app.php
@@ -2,6 +2,8 @@
 
 use Symfony\Component\HttpFoundation\Request;
 
+setlocale(LC_TIME, 'fr_FR.UTF8');
+
 require __DIR__.'/../vendor/autoload.php';
 if (PHP_VERSION_ID < 70000) {
     include_once __DIR__.'/../var/bootstrap.php.cache';

--- a/web/app_dev.php
+++ b/web/app_dev.php
@@ -3,6 +3,8 @@
 use Symfony\Component\Debug\Debug;
 use Symfony\Component\HttpFoundation\Request;
 
+setlocale(LC_TIME, 'fr_FR.UTF8');
+
 // If you don't want to setup permissions the proper way, just uncomment the following PHP line
 // read https://symfony.com/doc/current/setup.html#checking-symfony-application-configuration-and-setup
 // for more information


### PR DESCRIPTION
Dans le fichier `config/config.yml` la langue par défaut est déjà le français.

Mais pour autant, on doit régulièrement faire appel à `setLocale(LC_TIME, 'fr_FR.UTF8')` car PHP ne prend pas en compte les réglages Symfony.

Simplification grâce à cette réponse : https://stackoverflow.com/a/25297211/4293684