### PR TITLE
Créneaux : nouveau paramètre pour indiquer le délais de pré-reservation

### DIFF
--- a/app/Resources/views/emails/shift_reserved.html.twig
+++ b/app/Resources/views/emails/shift_reserved.html.twig
@@ -2,7 +2,7 @@ Bonjour {{ shift.lastShifter.firstname | lower | capitalize }},<br />
 <br />
 Tu viens de réaliser un créneau à l'épicerie, merci de rendre possible notre projet.<br />
 Nous te proposons de reprendre le même créneau dans {{ days }} jours, soit le {{ shift.displayDateLongWithTime }}.<br />
-Tu es prioritaire sur ce créneau pendant 7 jours, ensuite il deviendra disponible à la réservation pour les autres membres.<br />
+Tu es prioritaire sur ce créneau pendant {{ reserve_new_shift_to_prior_shifter_delay }} jours, ensuite il deviendra disponible à la réservation pour les autres membres.<br />
 <br />
 Merci de nous indiquer si tu souhaites le reprendre :<br />
 

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -98,13 +98,12 @@ parameters:
     new_users_start_as_beginner: true
     allow_extra_shifts: true
     max_time_in_advance_to_book_extra_shifts: '3 days'
-    display_gauge: true
     time_after_which_members_are_late_with_shifts: -9
     reserve_new_shift_to_prior_shifter: true
+    reserve_new_shift_to_prior_shifter_delay: 7
     forbid_shift_overlap_time: 30
     max_time_at_end_of_shift: 0
     display_name_shifters: false
-    max_nb_of_past_cycles_to_display: 3
 
     # Shifting: fly & fixed
     use_fly_and_fixed: false
@@ -122,11 +121,13 @@ parameters:
     time_log_saving_shift_free_allow_only_if_enough_saving: false
 
     # Profile configuration
+    display_gauge: true
     profile_display_task_list: true
     profile_display_time_log: true
     profile_display_shift_free_log: true
     display_freeze_account: true
     display_freeze_account_false_message: "Le gel de compte n'est pas autorisé."
+    max_nb_of_past_cycles_to_display: 3
 
     # User configuration
     user_account_not_enabled_material_icon: 'phonelink_off'

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -162,9 +162,6 @@ services:
             $logger: "@logger"
             $container: "@service_container"
             $mailer: "@mailer"
-            $memberEmail: "%emails.member%"
-            $shiftEmail: "%emails.shift%"
-            $wikiKeysUrl: "%wiki_keys_url%"
         tags:
             - { name: kernel.event_listener, event: code.new, method: onCodeNew }
             - { name: kernel.event_listener, event: shift.reserved, method: onShiftReserved }

--- a/src/AppBundle/Command/FreeReservedShiftsCommand.php
+++ b/src/AppBundle/Command/FreeReservedShiftsCommand.php
@@ -7,6 +7,10 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+/**
+ * Useful for coops with 'reserve_new_shift_to_prior_shifter' true.
+ * Note: should be run 'reserve_new_shift_to_prior_shifter_delay' days after ShiftGenerateCommand.
+ */
 class FreeReservedShiftsCommand extends ContainerAwareCommand
 {
     protected function configure()
@@ -41,5 +45,4 @@ class FreeReservedShiftsCommand extends ContainerAwareCommand
         $message = $count.' créneau'.(($count>1) ? 'x':'').' libéré'.(($count>1) ? 's':'');
         $output->writeln($message);
     }
-
 }

--- a/src/AppBundle/EventListener/EmailingEventListener.php
+++ b/src/AppBundle/EventListener/EmailingEventListener.php
@@ -42,6 +42,7 @@ class EmailingEventListener
         $this->member_email = $this->container->getParameter('emails.member');
         $this->shift_email = $this->container->getParameter('emails.shift');
         $this->wiki_keys_url = $this->container->getParameter('wiki_keys_url');
+        $this->reserve_new_shift_to_prior_shifter_delay = $this->container->getParameter('reserve_new_shift_to_prior_shifter_delay');
     }
 
     /**
@@ -237,7 +238,6 @@ class EmailingEventListener
         $beneficiary = $shift->getLastShifter();
 
         $router = $this->container->get('router');
-
         $d = (date_diff(new \DateTime('now'),$shift->getStart())->format("%a"));
 
         $mail = (new \Swift_Message('[ESPACE MEMBRES] Reprends ton créneau du '. $formerShift->getStart()->format("d F") .' dans '.$d.' jours'))
@@ -250,6 +250,7 @@ class EmailingEventListener
                         'shift' => $shift,
                         'oldshift' => $formerShift,
                         'days' => $d,
+                        'reserve_new_shift_to_prior_shifter_delay' => $this->reserve_new_shift_to_prior_shifter_delay,
                         'accept_url' => $router->generate('shift_accept_reserved', array('id' => $shift->getId(), 'token' => $shift->getTmpToken($beneficiary->getId())), UrlGeneratorInterface::ABSOLUTE_URL),
                         'reject_url' => $router->generate('shift_reject_reserved', array('id' => $shift->getId(), 'token' => $shift->getTmpToken($beneficiary->getId())), UrlGeneratorInterface::ABSOLUTE_URL),
                     )


### PR DESCRIPTION
Il existe déjà un paramètre `reserve_new_shift_to_prior_shifter` qui permet, lors de la génération des créneaux, de les pré-reserver aux membres précédemment inscrits.

Mais cela vient avec un délais, qui était arbitrairement de 7 jours. On souhaite rendre ce délais configurable.