### PR TITLE
Membre (coté admin) : pouvoir afficher l'historique de ses postes fixes annulés

### DIFF
--- a/app/Resources/views/member/show.html.twig
+++ b/app/Resources/views/member/show.html.twig
@@ -116,19 +116,19 @@
                     <i class="material-icons">delete_sweep</i>Historique des créneaux annulés
                 </div>
                 <div class="collapsible-body">
-                    {% include "member/_partial/shift_free_logs.html.twig" with { shiftFreeLogs: membership_service.getShiftFreeLogs(member), custom_styles: "max-height:500px;overflow:scroll;" } %}
+                    {% include "member/_partial/shift_free_logs.html.twig" with { shiftFreeLogs: membership_service.getShiftFreeLogs(member), from_admin: true, custom_styles: "max-height:500px;overflow:scroll;" } %}
                 </div>
             </li>
         {% endif %}
 
         <!-- Postes fixes annulés -->
-        {% if use_fly_and_fixed %}
+        {% if use_fly_and_fixed and admin_member_display_period_position_free_log %}
             <li id="periodpositionfreelogs">
                 <div class="collapsible-header {% if frontend_cookie and frontend_cookie.periodpositionfreelogs_show is defined and frontend_cookie.user_show.shifts_open is defined and frontend_cookie.user_show.periodpositionfreelogs_open %}active{% endif %}">
                     <i class="material-icons">delete_sweep</i>Historique des postes fixes annulés
                 </div>
                 <div class="collapsible-body">
-                    {% include "member/_partial/period_position_free_logs.html.twig" with { periodPositionFreeLogs: membership_service.getPeriodPositionFreeLogs(member), custom_styles: "max-height:500px;overflow:scroll;" } %}
+                    {% include "member/_partial/period_position_free_logs.html.twig" with { periodPositionFreeLogs: membership_service.getPeriodPositionFreeLogs(member), from_admin: true, custom_styles: "max-height:500px;overflow:scroll;" } %}
                 </div>
             </li>
         {% endif %}

--- a/app/Resources/views/member/show.html.twig
+++ b/app/Resources/views/member/show.html.twig
@@ -121,6 +121,18 @@
             </li>
         {% endif %}
 
+        <!-- Postes fixes annulés -->
+        {% if use_fly_and_fixed %}
+            <li id="periodpositionfreelogs">
+                <div class="collapsible-header {% if frontend_cookie and frontend_cookie.periodpositionfreelogs_show is defined and frontend_cookie.user_show.shifts_open is defined and frontend_cookie.user_show.periodpositionfreelogs_open %}active{% endif %}">
+                    <i class="material-icons">delete_sweep</i>Historique des postes fixes annulés
+                </div>
+                <div class="collapsible-body">
+                    {% include "member/_partial/period_position_free_logs.html.twig" with { periodPositionFreeLogs: membership_service.getPeriodPositionFreeLogs(member), custom_styles: "max-height:500px;overflow:scroll;" } %}
+                </div>
+            </li>
+        {% endif %}
+
         <!-- Badges -->
         {% if is_granted("ROLE_USER_MANAGER") %}
             <li id="badges">

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -92,6 +92,7 @@ twig:
     beneficiary_flying_icon: '%beneficiary_flying_icon%'
     # admin: member
     admin_member_display_shift_free_log: '%admin_member_display_shift_free_log%'
+    admin_member_display_period_position_free_log: '%admin_member_display_period_position_free_log%'
     # swipe card
     display_swipe_cards_settings: '%display_swipe_cards_settings%'
     display_freeze_account: '%display_freeze_account%'

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -157,6 +157,7 @@ parameters:
 
     # Admin: member
     admin_member_display_shift_free_log: true
+    admin_member_display_period_position_free_log: true
     forbid_own_shift_book_admin: false
     forbid_own_shift_free_admin: false
     forbid_own_shift_validate_admin: false


### PR DESCRIPTION
similaire à #1037

### Quoi ?

:information_source: pour les coops qui ont `use_fly_and_fixed`

Le membre peut déjà voir l'historique de ses postes fixes annulés dans son profil.
On rajoute ce tableau coté admin.

Un paramètre permet de cacher cette section : `admin_member_display_period_position_free_log`

### Capture d'écran

![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/a4a47b3f-77aa-4334-887f-1e9a063bac91)
