### PR TITLE
Admin : nouvelle page qui liste les bénéficiaires fixes sans créneau fixe

### DIFF
--- a/app/Resources/views/admin/index.html.twig
+++ b/app/Resources/views/admin/index.html.twig
@@ -26,14 +26,12 @@
                 <a href="{{ path("user_index") }}" class="waves-effect waves-light btn white black-text">
                     <i class="material-icons left main-color-text">people</i>Gérer les membres
                 </a>
-                <a href="{{ path('ambassador_shifttimelog_list') }}" class="waves-effect waves-light btn">
-                    <i class="material-icons left">phone</i>Relances créneaux
-                </a>
                 <a href="{{ path("admin_membershipshiftexemption_index") }}" class="waves-effect waves-light btn">
                     <i class="material-icons left">{{ member_exempted_material_icon }}</i>Gérer les exemptions de bénévolat
                 </a>
             {% endif %}
             {% if is_granted("ROLE_ADMIN") %}
+                <br />
                 <a href="{{ path("member_join") }}" class="waves-effect waves-light btn">
                     <i class="material-icons left">call_merge</i>Joindre deux comptes
                 </a>
@@ -43,6 +41,17 @@
                 <a href="{{ path("formation_list") }}" class="waves-effect waves-light btn">
                     <i class="material-icons left">tune</i>Gérer les formations
                 </a>
+            {% endif %}
+            {% if is_granted("ROLE_USER_MANAGER") %}
+                <br />
+                <a href="{{ path('ambassador_shifttimelog_list') }}" class="waves-effect waves-light btn">
+                    <i class="material-icons left">phone</i>Relances créneaux
+                </a>
+                {% if use_fly_and_fixed %}
+                    <a href="{{ path('ambassador_shifttimelog_list') }}" class="waves-effect waves-light btn">
+                        <i class="material-icons left">phone</i>Relances postes fixes
+                    </a>
+                {% endif %}
             {% endif %}
 
             {% if is_granted("ROLE_SHIFT_MANAGER") %}

--- a/app/Resources/views/admin/index.html.twig
+++ b/app/Resources/views/admin/index.html.twig
@@ -48,7 +48,7 @@
                     <i class="material-icons left">phone</i>Relances créneaux
                 </a>
                 {% if use_fly_and_fixed %}
-                    <a href="{{ path('ambassador_shifttimelog_list') }}" class="waves-effect waves-light btn">
+                    <a href="{{ path('ambassador_noperiodposition_list') }}" class="waves-effect waves-light btn">
                         <i class="material-icons left">phone</i>Relances postes fixes
                     </a>
                 {% endif %}

--- a/app/Resources/views/admin/user/list.html.twig
+++ b/app/Resources/views/admin/user/list.html.twig
@@ -173,11 +173,11 @@
                             {{ form_widget(form.phone) }}
                             {{ form_label(form.phone) }}
                         </div>
-                        <div class="input-field">
-                            {{ form_widget(form.flying) }}
-                            {{ form_label(form.flying) }}
-                        </div>
                         {% if use_fly_and_fixed %}
+                            <div class="input-field">
+                                {{ form_widget(form.flying) }}
+                                {{ form_label(form.flying) }}
+                            </div>
                             <div class="input-field">
                                 {{ form_widget(form.has_period_position) }}
                                 {{ form_label(form.has_period_position) }}
@@ -262,22 +262,22 @@
                     </td>
                     <td>
                         {% for beneficiary in member.beneficiaries %}
-                            {{ beneficiary.user.username }}<br/>
+                            {{ beneficiary.user.username }}<br />
                         {% endfor %}
                     </td>
                     <td>
                         {% for beneficiary in member.beneficiaries %}
-                            {{ beneficiary.firstname }}<br/>
+                            {{ beneficiary.firstname }}<br />
                         {% endfor %}
                     </td>
                     <td>
                         {% for beneficiary in member.beneficiaries %}
-                            {{ beneficiary.lastname }}<br/>
+                            {{ beneficiary.lastname }}<br />
                         {% endfor %}
                     </td>
                     <td>
                         {% for beneficiary in member.beneficiaries %}
-                            {{ beneficiary.email }}<br/>
+                            {{ beneficiary.email }}<br />
                         {% endfor %}
                     </td>
                     <td class="hide-on-small-and-down">
@@ -286,7 +286,7 @@
                                 {% if registration.id == member.lastregistration.id %}<strong>{% else %}<del>{% endif %}
                                 {{ registration.date | date_short }}
                                 {% if registration.id == member.lastregistration.id %}</strong>{% else %}</del>{% endif %}
-                                <br/>
+                                <br />
                             {% else %}
                                 {{ registration.date | date_short }}
                                 /!\ need fix

--- a/app/Resources/views/ambassador/phone/list.html.twig
+++ b/app/Resources/views/ambassador/phone/list.html.twig
@@ -1,15 +1,15 @@
 {% extends 'layout.html.twig' %}
 
-{% block title %}Liste des membres en retard {{ reason }} - {{ site_name }}{% endblock %}
+{% block title %}Liste des membres {{ reason }} - {{ site_name }}{% endblock %}
 
 {% block breadcrumbs %}
 <a href="{{ path('homepage') }}"><i class="material-icons">home</i></a><i class="material-icons">chevron_right</i>
 <a href="{{ path('admin') }}"><i class="material-icons">build</i>&nbsp;Administration</a><i class="material-icons">chevron_right</i>
-<i class="material-icons">list</i>&nbsp;Liste des membres en retard {{ reason }}
+<i class="material-icons">list</i>&nbsp;Liste des membres {{ reason }}
 {% endblock %}
 
 {% block content %}
-    <h4>Liste des membres en retard {{ reason }} ({{ result_count }})</h4>
+    <h4>Liste des membres {{ reason }} ({{ result_count }})</h4>
 
     <ul class="collapsible">
         <li>

--- a/app/Resources/views/ambassador/phone/list.html.twig
+++ b/app/Resources/views/ambassador/phone/list.html.twig
@@ -21,30 +21,43 @@
                     <div class="col s12 m4">
                         <h5>Compte</h5>
                         <div class="row">
-                            <div class="col s6 input-field">
-                                {{ form_widget(form.withdrawn) }}
-                                {{ form_label(form.withdrawn) }}
-                                {{ form_errors(form.withdrawn) }}
+                            <div class="col s4">
+                                <div class="input-field">
+                                    {{ form_widget(form.withdrawn) }}
+                                    {{ form_label(form.withdrawn) }}
+                                </div>
                             </div>
-                            <div class="col s6 input-field">
-                                {{ form_widget(form.frozen) }}
-                                {{ form_label(form.frozen) }}
-                                {{ form_errors(form.frozen) }}
+                            <div class="col s4">
+                                <div class="input-field">
+                                    {{ form_widget(form.enabled) }}
+                                    {{ form_label(form.enabled) }}
+                                </div>
                             </div>
-                            <div class="col s4 input-field">
-                                {{ form_widget(form.membernumber) }}
-                                {{ form_label(form.membernumber) }}
-                                {{ form_errors(form.membernumber) }}
+                            <div class="col s4">
+                                <div class="input-field">
+                                    {{ form_widget(form.frozen) }}
+                                    {{ form_label(form.frozen) }}
+                                </div>
                             </div>
-                            <div class="col s4 input-field">
-                                {{ form_widget(form.membernumbergt) }}
-                                {{ form_label(form.membernumbergt) }}
-                                {{ form_errors(form.membernumbergt) }}
+                        </div>
+                        <div class="row">
+                            <div class="col s4">
+                                <div class="input-field">
+                                    {{ form_widget(form.membernumber) }}
+                                    {{ form_label(form.membernumber) }}
+                                </div>
                             </div>
-                            <div class="col s4 input-field">
-                                {{ form_widget(form.membernumberlt) }}
-                                {{ form_label(form.membernumberlt) }}
-                                {{ form_errors(form.membernumberlt) }}
+                            <div class="col s4">
+                                <div class="input-field">
+                                    {{ form_widget(form.membernumbergt) }}
+                                    {{ form_label(form.membernumbergt) }}
+                                </div>
+                            </div>
+                            <div class="col s4">
+                                <div class="input-field">
+                                    {{ form_widget(form.membernumberlt) }}
+                                    {{ form_label(form.membernumberlt) }}
+                                </div>
                             </div>
                         </div>
                         <h5>Compteur</h5>
@@ -67,23 +80,26 @@
                     <div class="col s12 m4">
                         <h5>Adhésion(s)</h5>
                         <div class="row">
-                            <div class="col s6 input-field">
-                                {{ form_widget(form.registration) }}
-                                {{ form_label(form.registration) }}
-                                {{ form_errors(form.registration) }}
+                            <div class="col s6">
+                                <div class="input-field">
+                                    {{ form_widget(form.registration) }}
+                                    {{ form_label(form.registration) }}
+                                </div>
                             </div>
                         </div>
                         <h5>Dernière Adhésion</h5>
                         <div class="row">
-                            <div class="col s6 input-field">
-                                {{ form_widget(form.lastregistrationdatelt) }}
-                                {{ form_label(form.lastregistrationdatelt) }}
-                                {{ form_errors(form.lastregistrationdatelt) }}
+                            <div class="col s6">
+                                <div class="input-field">
+                                    {{ form_widget(form.lastregistrationdategt) }}
+                                    {{ form_label(form.lastregistrationdategt) }}
+                                </div>
                             </div>
-                            <div class="col s6 input-field">
-                                {{ form_widget(form.lastregistrationdategt) }}
-                                {{ form_label(form.lastregistrationdategt) }}
-                                {{ form_errors(form.lastregistrationdategt) }}
+                            <div class="col s6">
+                                <div class="input-field">
+                                    {{ form_widget(form.lastregistrationdatelt) }}
+                                    {{ form_label(form.lastregistrationdatelt) }}
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -92,18 +108,25 @@
                         <div class="input-field">
                             {{ form_widget(form.firstname) }}
                             {{ form_label(form.firstname) }}
-                            {{ form_errors(form.firstname) }}
                         </div>
                         <div class="input-field">
                             {{ form_widget(form.lastname) }}
                             {{ form_label(form.lastname) }}
-                            {{ form_errors(form.lastname) }}
                         </div>
                         <div class="input-field">
                             {{ form_widget(form.email) }}
                             {{ form_label(form.email) }}
-                            {{ form_errors(form.email) }}
                         </div>
+                        {% if use_fly_and_fixed %}
+                            <div class="input-field">
+                                {{ form_widget(form.flying) }}
+                                {{ form_label(form.flying) }}
+                            </div>
+                            <div class="input-field">
+                                {{ form_widget(form.has_period_position) }}
+                                {{ form_label(form.has_period_position) }}
+                            </div>
+                        {% endif %}
                         <br />
                         <h5>Actions</h5>
                         {{ form_widget(form.submit) }}
@@ -152,12 +175,12 @@
                 </td>
                 <td>
                     {% for beneficiary in member.beneficiaries %}
-                        {{ beneficiary.firstname }}
+                        {{ beneficiary.firstname }}<br />
                     {% endfor %}
                 </td>
                 <td>
                     {% for beneficiary in member.beneficiaries %}
-                        {{ beneficiary.lastname }}
+                        {{ beneficiary.lastname }}<br />
                     {% endfor %}
                 </td>
                 <td>

--- a/src/AppBundle/Controller/AdminController.php
+++ b/src/AppBundle/Controller/AdminController.php
@@ -75,9 +75,9 @@ class AdminController extends Controller
     public function usersAction(Request $request, SearchUserFormHelper $formHelper)
     {
         $defaults = [
-            'sort' => 'm.member_number',
-            'dir' => 'ASC',
             'withdrawn' => 1,
+            'sort' => 'm.member_number',
+            'dir' => 'ASC'
         ];
         $form = $formHelper->createMemberFilterForm($this->createFormBuilder(), $defaults);
         $form->handleRequest($request);

--- a/src/AppBundle/Controller/AmbassadorController.php
+++ b/src/AppBundle/Controller/AmbassadorController.php
@@ -20,7 +20,7 @@ use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Validator\Constraints\DateTime;
 
 /**
- * Ambassador controller.
+ * Ambassador controller
  *
  * @Route("ambassador")
  */
@@ -36,7 +36,7 @@ class AmbassadorController extends Controller
     }
 
     /**
-     * List all members without a registration.
+     * List all members without a registration
      *
      * @Route("/noregistration", name="ambassador_noregistration_list", methods={"GET","POST"})
      * @Security("has_role('ROLE_USER_VIEWER')")
@@ -77,7 +77,7 @@ class AmbassadorController extends Controller
             ->setMaxResults($limitPerPage); // set the limit
 
         return $this->render('ambassador/phone/list.html.twig', array(
-            'reason' => "adhésion",
+            'reason' => "sans adhésion",
             'members' => $paginator,
             'form' => $form->createView(),
             'result_count' => $resultCount,
@@ -87,7 +87,7 @@ class AmbassadorController extends Controller
     }
 
     /**
-     * List all members with a registration date older than one year.
+     * List all members with a registration date older than one year
      *
      * @Route("/lateregistration", name="ambassador_lateregistration_list", methods={"GET","POST"})
      * @Security("has_role('ROLE_USER_VIEWER')")
@@ -137,7 +137,7 @@ class AmbassadorController extends Controller
             ->setMaxResults($limitPerPage); // set the limit
 
         return $this->render('ambassador/phone/list.html.twig', array(
-            'reason' => "de ré-adhésion",
+            'reason' => "en retard de ré-adhésion",
             'members' => $paginator,
             'form' => $form->createView(),
             'result_count' => $resultCount,
@@ -147,7 +147,7 @@ class AmbassadorController extends Controller
     }
 
     /**
-     * List all members with negative shift time count.
+     * List all members with negative shift time count
      *
      * @Route("/shifttimelog", name="ambassador_shifttimelog_list", methods={"GET","POST"})
      * @Security("has_role('ROLE_USER_MANAGER')")
@@ -189,7 +189,7 @@ class AmbassadorController extends Controller
             ->setMaxResults($limitPerPage); // set the limit
 
         return $this->render('ambassador/phone/list.html.twig', array(
-            'reason' => "de créneaux",
+            'reason' => "en retard de créneaux",
             'members' => $paginator,
             'form' => $form->createView(),
             'result_count' => $resultCount,
@@ -199,7 +199,7 @@ class AmbassadorController extends Controller
     }
 
     /**
-     * display a member phones.
+     * Display a member phones
      *
      * @Route("/phone/{member_number}", name="ambassador_phone_show", methods={"GET"})
      * @param Membership $member
@@ -211,7 +211,7 @@ class AmbassadorController extends Controller
     }
 
     /**
-     * Creates a form to delete a note entity.
+     * Creates a form to delete a note entity
      *
      * @param Note $note the note entity
      *
@@ -226,6 +226,7 @@ class AmbassadorController extends Controller
     }
 
     /**
+     * Create a note
      *
      * @Route("/note/{member_number}", name="ambassador_new_note", methods={"POST"})
      * @param Membership $member

--- a/src/AppBundle/Controller/AmbassadorController.php
+++ b/src/AppBundle/Controller/AmbassadorController.php
@@ -46,10 +46,10 @@ class AmbassadorController extends Controller
     public function memberNoRegistrationAction(Request $request, SearchUserFormHelper $formHelper)
     {
         $defaults = [
-            'sort' => 'r.date',
-            'dir' => 'DESC',
             'withdrawn' => 1,
             'registration' => 1,
+            'sort' => 'r.date',
+            'dir' => 'DESC'
         ];
         $disabledFields = ['withdrawn', 'registration', 'lastregistrationdatelt', 'lastregistrationdategt'];
 
@@ -104,13 +104,13 @@ class AmbassadorController extends Controller
         $endLastRegistration->setTime(0,0);
 
         $defaults = [
-            'sort' => 'r.date',
-            'dir' => 'DESC',
             'withdrawn' => 1,
-            'lastregistrationdatelt' => $endLastRegistration,
             'registration' => 2,
+            'lastregistrationdatelt' => $endLastRegistration,
+            'sort' => 'r.date',
+            'dir' => 'DESC'
         ];
-        $disabledFields = ['withdrawn', 'lastregistrationdatelt', 'registration'];
+        $disabledFields = ['withdrawn', 'registration', 'lastregistrationdatelt'];
 
         $form = $formHelper->createMemberLateRegistrationFilterForm($this->createFormBuilder(), $defaults, $disabledFields);
         $form->handleRequest($request);
@@ -157,12 +157,12 @@ class AmbassadorController extends Controller
     public function memberShiftTimeLogAction(Request $request, SearchUserFormHelper $formHelper)
     {
         $defaults = [
-            'sort' => 'time',
-            'dir' => 'ASC',
             'withdrawn' => 1,
             'frozen' => 1,
-            'compteurlt' => 0,
             'registration' => 2,
+            'compteurlt' => 0,
+            'sort' => 'time',
+            'dir' => 'ASC'
         ];
         $disabledFields = ['withdrawn', 'registration'];
 
@@ -190,6 +190,59 @@ class AmbassadorController extends Controller
 
         return $this->render('ambassador/phone/list.html.twig', array(
             'reason' => "en retard de créneaux",
+            'members' => $paginator,
+            'form' => $form->createView(),
+            'result_count' => $resultCount,
+            'current_page' => $currentPage,
+            'page_count' => $pageCount
+        ));
+    }
+
+    /**
+     * List all beneficiaries "fixe" without periodposition
+     *
+     * @Route("/noperiodposition", name="ambassador_noperiodposition_list", methods={"GET","POST"})
+     * @Security("has_role('ROLE_USER_MANAGER')")
+     * @param request $request , searchuserformhelper $formhelper
+     * @return response
+     */
+    public function beneficiaryFixeNoPeriodPosition(Request $request, SearchUserFormHelper $formHelper)
+    {
+        $defaults = [
+            'withdrawn' => 1,
+            'frozen' => 1,
+            'registration' => 2,
+            'flying' => 1,
+            'has_period_position' => 1,
+            'sort' => 'm.member_number',
+            'dir' => 'ASC'
+        ];
+        $disabledFields = ['withdrawn', 'registration', 'flying', 'has_period_position'];
+
+        $form = $formHelper->createBeneficiaryFixeNoPeriodPositionForm($this->createFormBuilder(), $defaults, $disabledFields);
+        $form->handleRequest($request);
+
+        $qb = $formHelper->initSearchQuery($this->getDoctrine()->getManager(), 'noperiodposition');
+        $qb = $formHelper->processSearchFormAmbassadorData($form, $qb);
+
+        $sort = $form->get('sort')->getData();
+        $order = $form->get('dir')->getData();
+        $currentPage = $form->get('page')->getData();
+
+        $limitPerPage = 25;
+        $qb = $qb->orderBy($sort, $order);
+        $paginator = new Paginator($qb);
+        $resultCount = count($paginator);
+        $pageCount = ($resultCount == 0) ? 1 : ceil($resultCount / $limitPerPage);
+        $currentPage = ($currentPage > $pageCount) ? $pageCount : $currentPage;
+
+        $paginator
+            ->getQuery()
+            ->setFirstResult($limitPerPage * ($currentPage-1)) // set the offset
+            ->setMaxResults($limitPerPage); // set the limit
+
+        return $this->render('ambassador/phone/list.html.twig', array(
+            'reason' => "fixe sans poste fixe",
             'members' => $paginator,
             'form' => $form->createView(),
             'result_count' => $resultCount,

--- a/src/AppBundle/Controller/AmbassadorController.php
+++ b/src/AppBundle/Controller/AmbassadorController.php
@@ -242,7 +242,7 @@ class AmbassadorController extends Controller
             ->setMaxResults($limitPerPage); // set the limit
 
         return $this->render('ambassador/phone/list.html.twig', array(
-            'reason' => "fixe sans poste fixe",
+            'reason' => "fixes sans poste fixe",
             'members' => $paginator,
             'form' => $form->createView(),
             'result_count' => $resultCount,


### PR DESCRIPTION
Suite de #872

### Quoi ?

:information_source: pour les coop qui ont `use_fly_and_fixed`

- nouvelle page "Relance postes fixes" qui liste les bénéficiaires fixes sans poste fixe
- la mettre à coté de la page "Relance créneaux"
- amélioration générales dans `AmbassadorController` & `SearchUserFormHelper`

### Capture d'écran

![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/41a18320-3a75-4bba-89d5-3414c7df0be1)
