### PR TITLE
Créneaux : Rappel : refactoring de l'envoi via l'EmailingEventListener

### DIFF
--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -165,6 +165,7 @@ services:
             - { name: kernel.event_listener, event: shift.reserved, method: onShiftReserved }
             - { name: kernel.event_listener, event: shift.booked, method: onShiftBooked }
             - { name: kernel.event_listener, event: shift.freed, method: onShiftFreed }
+            - { name: kernel.event_listener, event: shift.reminder, method: onShiftReminder }
             - { name: kernel.event_listener, event: shift.deleted, method: onShiftDeleted }
             - { name: kernel.event_listener, event: member.cycle.start, method: onMemberCycleStart }
             - { name: kernel.event_listener, event: member.cycle.half, method: onMemberCycleHalf }

--- a/src/AppBundle/Command/ShiftGenerateCommand.php
+++ b/src/AppBundle/Command/ShiftGenerateCommand.php
@@ -26,8 +26,6 @@ class ShiftGenerateCommand extends ContainerAwareCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $em = $this->getContainer()->get('doctrine')->getManager();
-        $mailer = $this->getContainer()->get('mailer');
-        $router = $this->getContainer()->get('router');
 
         $admin = $em->getRepository('AppBundle:User')->findSuperAdminAccount();
         $use_fly_and_fixed = $this->getContainer()->getParameter('use_fly_and_fixed');

--- a/src/AppBundle/Event/ShiftReminderEvent.php
+++ b/src/AppBundle/Event/ShiftReminderEvent.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace AppBundle\Event;
+
+use AppBundle\Entity\Shift;
+use Symfony\Component\EventDispatcher\Event;
+
+class ShiftReminderEvent extends Event
+{
+    const NAME = 'shift.reminder';
+
+    private $shift;
+
+    public function __construct(Shift $shift)
+    {
+        $this->shift = $shift;
+    }
+
+    public function getShift()
+    {
+        return $this->shift;
+    }
+}


### PR DESCRIPTION
Actuellement, les e-mails de rappels sont envoyés directement dans la commande `ShiftReminderCommand`.

Refactoring pour les envoyer dans `EmailingEventListener`, grâce à un dispatch.
Cela résoudra aussi (j'espère !) le locale du contenu de l'e-mail (il apparait en anglais depuis #1032)