### PR TITLE
Script pour réparer les créneaux sans poste type

### DIFF
--- a/src/AppBundle/Command/FixShiftMissingPositionCommand.php
+++ b/src/AppBundle/Command/FixShiftMissingPositionCommand.php
@@ -7,12 +7,12 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class FixShiftPositionCommand extends ContainerAwareCommand
+class FixShiftMissingPositionCommand extends ContainerAwareCommand
 {
     protected function configure()
     {
         $this
-            ->setName('app:user:fix_shift_position')
+            ->setName('app:shift:fix_missing_position')
             ->setDescription('Fix shifts without position (find and attach corresponding position)')
             ->setHelp('This command allows you to fix missing shift position data (most likely deleted by the migration Version20211223205749')
             ->addOption('dry_run', null, InputOption::VALUE_NONE, 'Dry run');

--- a/src/AppBundle/Command/FixShiftPositionCommand.php
+++ b/src/AppBundle/Command/FixShiftPositionCommand.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace AppBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class FixShiftPositionCommand extends ContainerAwareCommand
+{
+    protected function configure()
+    {
+        $this
+            ->setName('app:user:fix_shift_position')
+            ->setDescription('Fix shifts without position (find and attach corresponding position)')
+            ->setHelp('This command allows you to fix missing shift position data (most likely deleted by the migration Version20211223205749');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $em = $this->getContainer()->get('doctrine')->getManager();
+
+        $shifts_without_position = $em->getRepository('AppBundle:Shift')->findBy(array('position' => null));
+        $output->writeln(count($shifts_without_position) . ' créneau' . ((count($shifts_without_position)>1) ? 'x':'') . ' sans poste type trouvé' . ((count($shifts_without_position)>1) ? 's':''));
+
+        if ($shifts_without_position) {
+            $output->writeln('Premier créneau trouvé : ' . $shifts_without_position[0]->getDisplayDateFullWithTime());
+            $output->writeln('Dernier créneau trouvé : ' . end($shifts_without_position)->getDisplayDateFullWithTime());
+
+            $shifts_without_position_fixed = 0;
+            // faster to loop on periodPositions
+            $period_positions = $em->getRepository('AppBundle:PeriodPosition')
+                ->createQueryBuilder('pp')
+                ->leftJoin('pp.period', 'p')->addSelect('p')
+                ->getQuery()
+                ->getResult();
+            $output->writeln('Boucle sur chacun des ' . count($period_positions) . ' postes types');
+            foreach ($period_positions as $period_position) {
+                // find shifts_without_position corresponding to this period_position
+                $period_position_shifts_without_position = $em->getRepository('AppBundle:Shift')->createQueryBuilder('s')
+                    // ->set('DATEFIRST', 1)
+                    ->where('s.position is null')
+                    ->andWhere("DATE_FORMAT(s.start, '%H:%i') = :period_start_time")
+                    ->andWhere("DATE_FORMAT(s.end, '%H:%i') = :period_end_time")
+                    ->andWhere("DATE_FORMAT(s.start, '%w') = :period_day_of_week")
+                    // ->andWhere()  // week cycle
+                    ->andWhere('s.job = :job')
+                    ->setParameter('period_start_time', $period_position->getPeriod()->getStart()->format('H:i'))
+                    ->setParameter('period_end_time', $period_position->getPeriod()->getEnd()->format('H:i'))
+                    ->setParameter('period_day_of_week', ($period_position->getPeriod()->getDayOfWeek() == 6) ? 0 : ($period_position->getPeriod()->getDayOfWeek() + 1))
+                    // ->setParameter('period_position_week_cycle', $period_position->getWeekCycle())
+                    ->setParameter('job', $period_position->getPeriod()->getJob())
+                    ->getQuery()
+                    ->getResult();
+                $shifts_without_position_fixed += count($period_position_shifts_without_position);
+
+                // update them
+                $em->createQuery("UPDATE AppBundle:Shift s SET s.position = :position WHERE s.id in (:ids)")
+                    ->setParameter('position', $period_position->getId())
+                    ->setParameter('ids', $period_position_shifts_without_position)
+                    ->execute();
+            }
+
+            $output->writeln($shifts_without_position_fixed . ' créneau' . (($shifts_without_position_fixed>1) ? 'x':''));
+        }
+    }
+}

--- a/src/AppBundle/Command/FixShiftPositionCommand.php
+++ b/src/AppBundle/Command/FixShiftPositionCommand.php
@@ -4,6 +4,7 @@ namespace AppBundle\Command;
 
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class FixShiftPositionCommand extends ContainerAwareCommand
@@ -13,15 +14,29 @@ class FixShiftPositionCommand extends ContainerAwareCommand
         $this
             ->setName('app:user:fix_shift_position')
             ->setDescription('Fix shifts without position (find and attach corresponding position)')
-            ->setHelp('This command allows you to fix missing shift position data (most likely deleted by the migration Version20211223205749');
+            ->setHelp('This command allows you to fix missing shift position data (most likely deleted by the migration Version20211223205749')
+            ->addOption('dry_run', null, InputOption::VALUE_NONE, 'Dry run');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $em = $this->getContainer()->get('doctrine')->getManager();
+        $cycle_type = $this->getContainer()->getParameter('cycle_type');
+        $dry_run = $input->getOption('dry_run');
 
-        $shifts_without_position = $em->getRepository('AppBundle:Shift')->findBy(array('position' => null));
-        $output->writeln(count($shifts_without_position) . ' créneau' . ((count($shifts_without_position)>1) ? 'x':'') . ' sans poste type trouvé' . ((count($shifts_without_position)>1) ? 's':''));
+        if ($dry_run) {
+            $output->writeln("<comment>Dry run: won't impact the database</comment>");
+        }
+
+        $shifts_without_position = $em->getRepository('AppBundle:Shift')->findBy(array('position' => null), array('start' => 'ASC'));
+        $output->writeln(count($shifts_without_position) . ' créneau' . ((count($shifts_without_position)>1) ? 'x':'') . ' sans poste type trouvé' . ((count($shifts_without_position)>1) ? 's':'') . '...');
+
+        if ($cycle_type == 'abcd') {
+            // TODO : add filter on weekCycle
+            // what if the cycle changed ?
+            $output->writeln('<error>Currently only works for coops without cycle_type.</error>');
+            return;
+        }
 
         if ($shifts_without_position) {
             $output->writeln('Premier créneau trouvé : ' . $shifts_without_position[0]->getDisplayDateFullWithTime());
@@ -35,6 +50,7 @@ class FixShiftPositionCommand extends ContainerAwareCommand
                 ->getQuery()
                 ->getResult();
             $output->writeln('Boucle sur chacun des ' . count($period_positions) . ' postes types');
+
             foreach ($period_positions as $period_position) {
                 // find shifts_without_position corresponding to this period_position
                 $period_position_shifts_without_position = $em->getRepository('AppBundle:Shift')->createQueryBuilder('s')
@@ -45,23 +61,45 @@ class FixShiftPositionCommand extends ContainerAwareCommand
                     ->andWhere("DATE_FORMAT(s.start, '%w') = :period_day_of_week")
                     // ->andWhere()  // week cycle
                     ->andWhere('s.job = :job')
+                    ->andWhere('s.formation = :formation')
                     ->setParameter('period_start_time', $period_position->getPeriod()->getStart()->format('H:i'))
                     ->setParameter('period_end_time', $period_position->getPeriod()->getEnd()->format('H:i'))
                     ->setParameter('period_day_of_week', ($period_position->getPeriod()->getDayOfWeek() == 6) ? 0 : ($period_position->getPeriod()->getDayOfWeek() + 1))
                     // ->setParameter('period_position_week_cycle', $period_position->getWeekCycle())
                     ->setParameter('job', $period_position->getPeriod()->getJob())
+                    ->setParameter('formation', $period_position->getFormation())
+                    ->orderBy('s.start')
                     ->getQuery()
                     ->getResult();
-                $shifts_without_position_fixed += count($period_position_shifts_without_position);
 
-                // update them
-                $em->createQuery("UPDATE AppBundle:Shift s SET s.position = :position WHERE s.id in (:ids)")
-                    ->setParameter('position', $period_position->getId())
-                    ->setParameter('ids', $period_position_shifts_without_position)
-                    ->execute();
+                if (count($period_position_shifts_without_position)) {
+                    $output->writeln('Poste ' . $period_position->getId());
+                    $output->writeln('Premier créneau trouvé : ' . $period_position_shifts_without_position[0]->getDisplayDateFullWithTime() . ' |Dernier créneau trouvé : ' . end($period_position_shifts_without_position)->getDisplayDateFullWithTime());
+                    $output->writeln('Nombre de créneau correspondants : ' . count($period_position_shifts_without_position));
+                    // we only want 1 shift per week
+                    // why ? period can have identical positions, which generate identical shifts...
+                    $period_position_shifts_without_position_unique_days = array();
+                    $period_position_shifts_without_position_filtered = array();
+                    foreach($period_position_shifts_without_position as $s) {
+                        if (!in_array($s->getStart()->format('Y-m-d'), $period_position_shifts_without_position_unique_days)) {
+                            array_push($period_position_shifts_without_position_unique_days, $s->getStart()->format('Y-m-d'));
+                            array_push($period_position_shifts_without_position_filtered, $s);
+                        }
+                    }
+
+                    if (!$dry_run) {
+                        $em->createQuery("UPDATE AppBundle:Shift s SET s.position = :position WHERE s.id in (:ids)")
+                            ->setParameter('position', $period_position)
+                            ->setParameter('ids', $period_position_shifts_without_position_filtered)
+                            ->execute();
+                    }
+                    $shifts_without_position_fixed += count($period_position_shifts_without_position_filtered);
+                }
             }
 
-            $output->writeln($shifts_without_position_fixed . ' créneau' . (($shifts_without_position_fixed>1) ? 'x':''));
+            if (!$dry_run) {
+                $output->writeln('<info>' . $shifts_without_position_fixed . ' créneau' . (($shifts_without_position_fixed>1) ? 'x':'') . ' réparé' . (($shifts_without_position_fixed>1) ? 's':'') . '</info>');
+            }
         }
     }
 }

--- a/src/AppBundle/Command/FixTimeLogCommand.php
+++ b/src/AppBundle/Command/FixTimeLogCommand.php
@@ -22,9 +22,10 @@ class FixTimeLogCommand extends ContainerAwareCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $countShiftLogs = 0;
         $em = $this->getContainer()->get('doctrine')->getManager();
         $members = $em->getRepository('AppBundle:Membership')->findAll();
+
+        $countShiftLogs = 0;
 
         foreach ($members as $member) {
             if ($member->getFirstShiftDate()) {


### PR DESCRIPTION
### Quoi ?

Commande pour re-attacher les `Shift` à leur `PeriodPosition`

### Pourquoi ?

Un commit en Novembre 2021 - https://github.com/elefan-grenoble/gestion-compte/commit/f074ada813a7f3475db63b2ff2b21d8c9d2faff9 - a supprimé la table `PeriodPosition`. Il faut donc que les coops la recréé. Mais les liens avec la table `Shift` ont été vidés, or ils servent à des fonctionnalités comme la pré-reservation de créneau.

Ce script regarde tous les PeriodPosition, et pour chacun tente de retrouver les Shift correspondant : 
- le shift ne doit pas pas avoir de position
- on prend seulement 1 seul shift par jour (car certaines position sont quasi identiques, donc on généré des créneaux identiques, elles seront matchés dans la prochaine itération de la boucle)