### PR TITLE
Créneaux : Alertes : refactoring de l'envoi via l'EmailingEventListener & MattermostEventListener

### DIFF
--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -184,7 +184,6 @@ services:
             $entityManager: "@doctrine.orm.entity_manager"
             $logger: "@logger"
             $container: "@service_container"
-            $mailer: "@mailer"
         tags:
             - { name: kernel.event_listener, event: shift.alerts.mattermost, method: onShiftAlerts }
 

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -177,6 +177,15 @@ services:
             - { name: kernel.event_listener, event: helloasso.registration_success, method: onHelloassoRegistrationSuccess }
             - { name: kernel.event_listener, event: helloasso.too_early, method: onHelloassoTooEarly }
             - { name: kernel.event_listener, event: code.new, method: onCodeNew }
+    mattermost_event_listener:
+        class: AppBundle\EventListener\MattermostEventListener
+        arguments:
+            $entityManager: "@doctrine.orm.entity_manager"
+            $logger: "@logger"
+            $container: "@service_container"
+            $mailer: "@mailer"
+        tags:
+            - { name: kernel.event_listener, event: shift.alerts, method: onShiftAlerts }
 
     # subscribers
     beneficiary_initialization_subscriber:

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -167,6 +167,7 @@ services:
             - { name: kernel.event_listener, event: shift.freed, method: onShiftFreed }
             - { name: kernel.event_listener, event: shift.reminder, method: onShiftReminder }
             - { name: kernel.event_listener, event: shift.deleted, method: onShiftDeleted }
+            - { name: kernel.event_listener, event: shift.alerts, method: onShiftAlerts }
             - { name: kernel.event_listener, event: member.cycle.start, method: onMemberCycleStart }
             - { name: kernel.event_listener, event: member.cycle.half, method: onMemberCycleHalf }
             - { name: kernel.event_listener, event: member.created, method: onMemberCreated }
@@ -185,7 +186,7 @@ services:
             $container: "@service_container"
             $mailer: "@mailer"
         tags:
-            - { name: kernel.event_listener, event: shift.alerts, method: onShiftAlerts }
+            - { name: kernel.event_listener, event: shift.alerts.mattermost, method: onShiftAlerts }
 
     # subscribers
     beneficiary_initialization_subscriber:

--- a/src/AppBundle/Event/ShiftAlertsEvent.php
+++ b/src/AppBundle/Event/ShiftAlertsEvent.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace AppBundle\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+
+class ShiftAlertsEvent extends Event
+{
+    const NAME = 'shift.alert';
+
+    private $alerts;
+    private $date;
+    private $email_template;
+    private $mattermost_hook_url;
+
+    public function __construct(array $alerts, \DateTime $date, $email_template = null, $mattermost_hook_url = null)
+    {
+        $this->alerts = $alerts;
+        $this->date = $date;
+        $this->email_template = $email_template;
+        $this->mattermost_hook_url = $mattermost_hook_url;
+    }
+
+    /**
+     * @return array
+     */
+    public function getAlerts()
+    {
+        return $this->alerts;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getDate()
+    {
+        return $this->date;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getEmailTemplate()
+    {
+        return $this->email_template;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getMattermostHookUrl()
+    {
+        return $this->mattermost_hook_url;
+    }
+}

--- a/src/AppBundle/Event/ShiftAlertsMattermostEvent.php
+++ b/src/AppBundle/Event/ShiftAlertsMattermostEvent.php
@@ -4,21 +4,21 @@ namespace AppBundle\Event;
 
 use Symfony\Component\EventDispatcher\Event;
 
-class ShiftAlertsEvent extends Event
+class ShiftAlertsMattermostEvent extends Event
 {
-    const NAME = 'shift.alerts';
+    const NAME = 'shift.alerts.mattermost';
 
     private $alerts;
     private $date;
     private $template;
-    private $recipients;
+    private $mattermost_hook_url;
 
-    public function __construct(array $alerts, \DateTime $date, $template = null, $recipients = null)
+    public function __construct(array $alerts, \DateTime $date, $template = null, $mattermost_hook_url = null)
     {
         $this->alerts = $alerts;
         $this->date = $date;
         $this->template = $template;
-        $this->recipients = $recipients;
+        $this->mattermost_hook_url = $mattermost_hook_url;
     }
 
     /**
@@ -46,10 +46,10 @@ class ShiftAlertsEvent extends Event
     }
 
     /**
-     * @return array|null
+     * @return string|null
      */
-    public function getRecipients()
+    public function getMattermostHookUrl()
     {
-        return $this->recipients;
+        return $this->mattermost_hook_url;
     }
 }

--- a/src/AppBundle/EventListener/MattermostEventListener.php
+++ b/src/AppBundle/EventListener/MattermostEventListener.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace AppBundle\EventListener;
+
+use AppBundle\Event\ShiftAlertsEvent;
+use Doctrine\ORM\EntityManagerInterface;
+use Monolog\Logger;
+use Swift_Mailer;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\HttpClient\HttpClient;
+
+class MattermostEventListener
+{
+    protected $em;
+    protected $logger;
+    protected $container;
+    protected $mailer;
+
+    public function __construct(EntityManagerInterface $entityManager, Logger $logger, Container $container, Swift_Mailer $mailer)
+    {
+        $this->em = $entityManager;
+        $this->logger = $logger;
+        $this->container = $container;
+        $this->mailer = $mailer;
+    }
+
+    /**
+     * @param ShiftAlertsEvent $event
+     * @throws \Exception
+     */
+    public function onShiftAlerts(ShiftAlertsEvent $event)
+    {
+        $this->logger->info("Mattermost Listener: onShiftAlerts");
+
+        $alerts = $event->getAlerts();
+        $date = $event->getDate();
+
+        if ($event->getMattermostHookUrl()) {
+            $template = null;
+            $dynamicContent = $this->em->getRepository('AppBundle:DynamicContent')->findOneByCode($event->getEmailTemplate());
+            if ($dynamicContent) {
+                $template = $this->container->get('twig')->createTemplate($dynamicContent->getContent());
+            } else {
+                $template = 'markdown/shift_alerts_default.md.twig';
+            }
+            $content = $this->container->get('twig')->render(
+                $template,
+                array('alerts' => $alerts, 'date' => $date)
+            );
+
+            $client = HttpClient::create();
+            $response = $client->request('POST', $event->getMattermostHookUrl(), [
+                'json' => ['text' => $content]
+            ]);
+        }
+    }
+}

--- a/src/AppBundle/EventListener/MattermostEventListener.php
+++ b/src/AppBundle/EventListener/MattermostEventListener.php
@@ -5,7 +5,6 @@ namespace AppBundle\EventListener;
 use AppBundle\Event\ShiftAlertsMattermostEvent;
 use Doctrine\ORM\EntityManagerInterface;
 use Monolog\Logger;
-use Swift_Mailer;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpClient\HttpClient;
 
@@ -14,14 +13,12 @@ class MattermostEventListener
     protected $em;
     protected $logger;
     protected $container;
-    protected $mailer;
 
-    public function __construct(EntityManagerInterface $entityManager, Logger $logger, Container $container, Swift_Mailer $mailer)
+    public function __construct(EntityManagerInterface $entityManager, Logger $logger, Container $container)
     {
         $this->em = $entityManager;
         $this->logger = $logger;
         $this->container = $container;
-        $this->mailer = $mailer;
     }
 
     /**

--- a/src/AppBundle/EventListener/MattermostEventListener.php
+++ b/src/AppBundle/EventListener/MattermostEventListener.php
@@ -2,7 +2,7 @@
 
 namespace AppBundle\EventListener;
 
-use AppBundle\Event\ShiftAlertsEvent;
+use AppBundle\Event\ShiftAlertsMattermostEvent;
 use Doctrine\ORM\EntityManagerInterface;
 use Monolog\Logger;
 use Swift_Mailer;
@@ -25,19 +25,19 @@ class MattermostEventListener
     }
 
     /**
-     * @param ShiftAlertsEvent $event
+     * @param ShiftAlertsMattermostEvent $event
      * @throws \Exception
      */
-    public function onShiftAlerts(ShiftAlertsEvent $event)
+    public function onShiftAlerts(ShiftAlertsMattermostEvent $event)
     {
         $this->logger->info("Mattermost Listener: onShiftAlerts");
 
         $alerts = $event->getAlerts();
         $date = $event->getDate();
 
-        if ($event->getMattermostHookUrl()) {
+        if ($alerts && $event->getMattermostHookUrl()) {
             $template = null;
-            $dynamicContent = $this->em->getRepository('AppBundle:DynamicContent')->findOneByCode($event->getEmailTemplate());
+            $dynamicContent = $this->em->getRepository('AppBundle:DynamicContent')->findOneByCode($event->getTemplate());
             if ($dynamicContent) {
                 $template = $this->container->get('twig')->createTemplate($dynamicContent->getContent());
             } else {


### PR DESCRIPTION
Dans la commande `SendShiftAlertsCommand`
- sortir l'envoi d'e-mail et le faire dans `EmailingEventListener`, grâce à un nouvel event `ShiftAlertsEvent`
- sortir l'envoi de message à Mattermost et le faire dans `MattermostEventListener` (nouveau !), grâce à un nouvel event `ShiftAlertsMattermostEvent`
- cela devrait résoudre le locale du contenu du message Mattermost (il apparait en anglais depuis #1032)