### PR TITLE
Membre : pouvoir rajouter la notion de volant

### DIFF
--- a/app/DoctrineMigrations/Version20231027213416_membership_flying.php
+++ b/app/DoctrineMigrations/Version20231027213416_membership_flying.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20231027213416 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE membership ADD flying TINYINT(1) DEFAULT \'0\' NOT NULL');
+        $this->addSql('UPDATE membership LEFT OUTER JOIN beneficiary ON beneficiary.id = membership.main_beneficiary_id SET membership.flying=beneficiary.flying WHERE beneficiary.flying = 1');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE membership DROP flying');
+    }
+}

--- a/app/Resources/views/admin/member/_partial/status_icons.html.twig
+++ b/app/Resources/views/admin/member/_partial/status_icons.html.twig
@@ -12,3 +12,6 @@
 {% if member.mainBeneficiary and not member.mainBeneficiary.user.isEnabled %}
     <i class="material-icons" title="Compte pas encore activé">{{ user_account_not_enabled_material_icon }}</i>
 {% endif %}
+{% if use_fly_and_fixed and fly_and_fixed_entity_flying == 'Membership' and member.flying %}
+    <i class="material-icons" title="Compte volant">{{ member_flying_material_icon }}</i>
+{% endif %}

--- a/app/Resources/views/admin/period/index.html.twig
+++ b/app/Resources/views/admin/period/index.html.twig
@@ -204,7 +204,11 @@
                                             <li>{{ member_frozen_icon }} Membre gelé</li>
                                             <li>{{ member_exempted_icon }} Membre exempté de créneaux</li>
                                             <li>{{ member_registration_missing_icon }} Membre avec une adhésion expirée</li>
-                                            <li>{{ beneficiary_flying_icon }} Bénéficiaire avec un statut "volant"</li>
+                                            {% if fly_and_fixed_entity_flying == 'Membership' %}
+                                                <li>{{ beneficiary_flying_icon }} Membre avec un statut "volant"</li>
+                                            {% else %}
+                                                <li>{{ beneficiary_flying_icon }} Bénéficiaire avec un statut "volant"</li>
+                                            {% endif %}
                                         </ul>
                                     </td>
                                 </tr>

--- a/app/Resources/views/admin/period/index.html.twig
+++ b/app/Resources/views/admin/period/index.html.twig
@@ -238,7 +238,7 @@
                             <td>
                                 {% for period in periods_by_day[key] %}
                                     {% if ((filling_filter == null) and (beneficiary_filter == null))
-                                        or (filling_filter == "problematic" and period.isProblematic(week_filter))
+                                        or (filling_filter == "problematic" and period_service.hasWarningStatus(period, week_filter))
                                         or (filling_filter == "empty" and period.isEmpty(week_filter))
                                         or (filling_filter == "full" and period.isFull(week_filter))
                                         or (filling_filter == "partial" and period.isPartial(week_filter))

--- a/app/Resources/views/admin/user/list.html.twig
+++ b/app/Resources/views/admin/user/list.html.twig
@@ -23,32 +23,32 @@
                     <div class="col s12 m4">
                         <h5>Compte</h5>
                         <div class="row">
-                            <div class="col s4">
+                            <div class="col s3">
                                 <div class="input-field">
                                     {{ form_widget(form.withdrawn) }}
                                     {{ form_label(form.withdrawn) }}
                                 </div>
                             </div>
-                            <div class="col s4">
+                            <div class="col s3">
                                 <div class="input-field">
                                     {{ form_widget(form.enabled) }}
                                     {{ form_label(form.enabled) }}
                                 </div>
                             </div>
-                            <div class="col s4">
+                            <div class="col s3">
                                 <div class="input-field">
                                     {{ form_widget(form.frozen) }}
                                     {{ form_label(form.frozen) }}
                                 </div>
                             </div>
-                        </div>
-                        <div class="row">
-                            <div class="col s4">
+                            <div class="col s3">
                                 <div class="input-field">
                                     {{ form_widget(form.exempted) }}
                                     {{ form_label(form.exempted) }}
                                 </div>
                             </div>
+                        </div>
+                        <div class="row">
                             <div class="col s4">
                                 <div class="input-field">
                                     {{ form_widget(form.has_first_shift_date) }}
@@ -60,6 +60,14 @@
                                     <div class="input-field">
                                         {{ form_widget(form.beneficiary_count) }}
                                         {{ form_label(form.beneficiary_count) }}
+                                    </div>
+                                </div>
+                            {% endif %}
+                            {% if use_fly_and_fixed and fly_and_fixed_entity_flying == 'Membership' %}
+                                <div class="col s4">
+                                    <div class="input-field">
+                                        {{ form_widget(form.flying) }}
+                                        {{ form_label(form.flying) }}
                                     </div>
                                 </div>
                             {% endif %}
@@ -176,10 +184,12 @@
                             {{ form_label(form.phone) }}
                         </div>
                         {% if use_fly_and_fixed %}
-                            <div class="input-field">
-                                {{ form_widget(form.flying) }}
-                                {{ form_label(form.flying) }}
-                            </div>
+                            {% if fly_and_fixed_entity_flying == 'Beneficiary' %}
+                                <div class="input-field">
+                                    {{ form_widget(form.flying) }}
+                                    {{ form_label(form.flying) }}
+                                </div>
+                            {% endif %}
                             <div class="input-field">
                                 {{ form_widget(form.has_period_position) }}
                                 {{ form_label(form.has_period_position) }}

--- a/app/Resources/views/beneficiary/_partial/info.html.twig
+++ b/app/Resources/views/beneficiary/_partial/info.html.twig
@@ -7,6 +7,21 @@
     {% if beneficiary.isMain and maximum_nb_of_beneficiaries_in_membership > 1 %}
         <span class="badge main-color white-text">{{ beneficiary_main_icon }} principal</span>
     {% endif %}
+    {% if use_fly_and_fixed %}
+        {% if fly_and_fixed_entity_flying == 'Membership' %}
+            {% if beneficiary.membership.flying %}
+                <span class="badge teal white-text">{{ member_flying_icon }} Compte volant</span>
+            {% else %}
+                <span class="badge main-color white-text">Compte fixe</span>
+            {% endif %}
+        {% else %}
+            {% if beneficiary.flying %}
+                <span class="badge teal white-text">{{ beneficiary_flying_icon }} Equipe volante</span>
+            {% else %}
+                <span class="badge main-color white-text">Equipe fixe</span>
+            {% endif %}
+        {% endif %}
+    {% endif %}
     {% if beneficiary.membership.withdrawn %}
         <span class="badge red white-text">{{ member_withdrawn_icon }} fermé</span>
     {% endif %}
@@ -61,16 +76,6 @@
             {% endif %})
         {% endif %}
     </div>
-    {% if use_fly_and_fixed %}
-        <div class="col s12">
-            <i class="material-icons tiny">accessibility</i>
-            {% if beneficiary.flying %}
-                <div class="chip green-text">Equipe volante</div>
-            {% else %}
-                <div class="chip green-text">Equipe fixe</div>
-            {% endif %}
-        </div>
-    {% endif %}
     {% if beneficiary.formations | length %}
         <div class="col s12">
             <i class="material-icons tiny">assignment_ind</i>

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -87,6 +87,8 @@ twig:
     member_exempted_icon: '%member_exempted_icon%'
     member_exempted_material_icon: '%member_exempted_material_icon%'
     member_exempted_background_color: '%member_exempted_background_color%'
+    member_flying_icon: '%member_flying_icon%'
+    member_flying_material_icon: '%member_flying_material_icon%'
     member_registration_missing_icon: '%member_registration_missing_icon%'
     member_registration_missing_material_icon: '%member_registration_missing_material_icon%'
     member_registration_missing_background_color: '%member_registration_missing_background_color%'
@@ -105,6 +107,7 @@ twig:
     display_name_shifters: '%display_name_shifters%'
     use_card_reader_to_validate_shifts: '%use_card_reader_to_validate_shifts%'
     # fly and fixed
+    fly_and_fixed_entity_flying: '%fly_and_fixed_entity_flying%'
     fly_and_fixed_allow_fixed_shift_free: '%fly_and_fixed_allow_fixed_shift_free%'
     # time log saving
     time_log_saving_shift_free_min_time_in_advance_days: '%time_log_saving_shift_free_min_time_in_advance_days%'

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -107,6 +107,7 @@ parameters:
 
     # Shifting: fly & fixed
     use_fly_and_fixed: false
+    fly_and_fixed_entity_flying: 'Beneficiary'
     fly_and_fixed_allow_fixed_shift_free: false
 
     # Shifting: card reader
@@ -146,6 +147,8 @@ parameters:
     member_exempted_icon: '☂'
     member_exempted_material_icon: 'beach_access'
     member_exempted_background_color: rgb(0, 150, 136, 0.1)
+    member_flying_icon: '✈'
+    member_flying_material_icon: 'flightsmode'
     member_registration_missing_icon: '$'
     member_registration_missing_material_icon: 'attach_money'
     member_registration_missing_background_color: rgb(0, 150, 136, 0.1)

--- a/src/AppBundle/Command/ImportUsersCommand.php
+++ b/src/AppBundle/Command/ImportUsersCommand.php
@@ -143,6 +143,7 @@ class ImportUsersCommand extends CsvCommand
                             $membership = new Membership();
                             $output->writeln("<info>No Membership with number <fg=cyan>$member_number</> found, create one</info>",OutputInterface::VERBOSITY_DEBUG);
                             $membership->setMemberNumber($member_number);
+                            $membership->setFlying(false);
                             $membership->setWithdrawn(false);
                             $membership->setFrozen(false);
                             $membership->setFrozenChange(false);

--- a/src/AppBundle/Controller/AdminController.php
+++ b/src/AppBundle/Controller/AdminController.php
@@ -12,7 +12,6 @@ use AppBundle\Entity\Registration;
 use AppBundle\Entity\Formation;
 use AppBundle\Entity\User;
 use AppBundle\Event\HelloassoEvent;
-use AppBundle\Form\BeneficiaryType;
 use AppBundle\Service\SearchUserFormHelper;
 use Doctrine\ORM\Query\ResultSetMappingBuilder;
 use Doctrine\ORM\QueryBuilder;

--- a/src/AppBundle/Controller/BeneficiaryController.php
+++ b/src/AppBundle/Controller/BeneficiaryController.php
@@ -143,6 +143,7 @@ class BeneficiaryController extends Controller
                 $new_member->setMainBeneficiary($beneficiary);
             }
             // init other fields
+            $new_member->setFlying(false);
             $new_member->setWithdrawn(false);
             $new_member->setFrozen(false);
             $new_member->setFrozenChange(false);

--- a/src/AppBundle/Controller/MembershipController.php
+++ b/src/AppBundle/Controller/MembershipController.php
@@ -774,6 +774,7 @@ class MembershipController extends Controller
                 $member->removeRegistration($registration); //no registration yet
             }
 
+            $member->setFlying(false);
             $member->setWithdrawn(false);
             $member->setFrozen(false);
             $member->setFrozenChange(false);

--- a/src/AppBundle/Controller/NoteController.php
+++ b/src/AppBundle/Controller/NoteController.php
@@ -11,7 +11,6 @@ use AppBundle\Entity\Registration;
 use AppBundle\Entity\Shift;
 use AppBundle\Entity\TimeLog;
 use AppBundle\Entity\User;
-use AppBundle\Form\BeneficiaryType;
 use AppBundle\Form\NoteType;
 use Symfony\Component\Form\Form;
 use Symfony\Component\HttpFoundation\Session\Session;

--- a/src/AppBundle/Controller/RegistrationsController.php
+++ b/src/AppBundle/Controller/RegistrationsController.php
@@ -12,7 +12,6 @@ use AppBundle\Entity\Registration;
 use AppBundle\Entity\Formation;
 use AppBundle\Entity\User;
 use AppBundle\Event\HelloassoEvent;
-use AppBundle\Form\BeneficiaryType;
 use AppBundle\Form\RegistrationType;
 use Doctrine\ORM\Query\ResultSetMappingBuilder;
 use Doctrine\ORM\QueryBuilder;

--- a/src/AppBundle/Entity/Membership.php
+++ b/src/AppBundle/Entity/Membership.php
@@ -71,6 +71,13 @@ class Membership
     private $frozen_change;
 
     /**
+     * @var bool
+     *
+     * @ORM\Column(name="flying", type="boolean", options={"default" : 0}, nullable=false)
+     */
+    private $flying;
+
+    /**
      * @ORM\OneToMany(targetEntity="Registration", mappedBy="membership",cascade={"persist", "remove"})
      * @OrderBy({"date" = "DESC"})
      */
@@ -117,17 +124,17 @@ class Membership
     private $timeLogs;
 
     /**
+     * @ORM\OneToMany(targetEntity="MembershipShiftExemption", mappedBy="membership", cascade={"persist", "remove"})
+     * @OrderBy({"createdAt" = "DESC"})
+     */
+    private $membershipShiftExemptions;
+
+    /**
      * @var \DateTime
      *
      * @ORM\Column(name="created_at", type="datetime")
      */
     private $createdAt;
-
-    /**
-     * @ORM\OneToMany(targetEntity="MembershipShiftExemption", mappedBy="membership", cascade={"persist", "remove"})
-     * @OrderBy({"createdAt" = "DESC"})
-     */
-    private $membershipShiftExemptions;
 
     /**
      * Membership constructor.
@@ -487,6 +494,20 @@ class Membership
     public function getFrozenChange()
     {
         return $this->frozen_change;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isFlying(): ?bool {
+        return $this->flying;
+    }
+
+    /**
+     * @param bool $flying
+     */
+    public function setFlying(?bool $flying): void {
+        $this->flying = $flying;
     }
 
     /**

--- a/src/AppBundle/Entity/Period.php
+++ b/src/AppBundle/Entity/Period.php
@@ -461,31 +461,6 @@ class Period
     }
 
     /**
-     * Return true if at least one shifter (a.k.a. beneficiary) registered for
-     * this period is "problematic", meaning with a withdrawn or frozen membership
-     * of if the shifter is member of the flying team.
-     *
-     * useful only if the use_fly_and_fixed is activated
-     *
-     * @param String|null $weekCycle a string of the week to keep or null if no filter
-     * @return bool
-     */
-    public function isProblematic(?String $weekCycle=null): bool
-    {
-        foreach ($this->positions as $position) {
-            if($shifter = $position->getShifter()){
-                if((($weekCycle && $position->getWeekCycle()==$weekCycle) or !$weekCycle)
-                    and ($shifter->isFlying()
-                    or $shifter->getMembership()->isFrozen()
-                    or $shifter->getMembership()->isWithdrawn())){
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    /**
      * Return true if 0 periods have been assigned to a shifter (a.k.a. beneficiary)
      * Note: useful only if the use_fly_and_fixed is activated
      *

--- a/src/AppBundle/Form/BeneficiaryType.php
+++ b/src/AppBundle/Form/BeneficiaryType.php
@@ -120,6 +120,4 @@ class BeneficiaryType extends AbstractType
     {
         return 'appbundle_beneficiary';
     }
-
-
 }

--- a/src/AppBundle/Security/MembershipVoter.php
+++ b/src/AppBundle/Security/MembershipVoter.php
@@ -20,6 +20,7 @@ class MembershipVoter extends Voter
     const CLOSE = 'close';
     const FREEZE = 'freeze';
     const FREEZE_CHANGE = 'freeze_change';
+    const FLYING = 'flying';
     const ROLE_REMOVE = 'role_remove';
     const ROLE_ADD = 'role_add';
     const ANNOTATE = 'annotate';
@@ -46,6 +47,7 @@ class MembershipVoter extends Voter
                 self::ROLE_ADD,
                 self::FREEZE,
                 self::FREEZE_CHANGE,
+                self::FLYING,
                 self::CREATE,
                 self::ANNOTATE,
                 self::ACCESS_TOOLS,
@@ -103,6 +105,8 @@ class MembershipVoter extends Voter
             case self::ROLE_ADD:
             case self::ROLE_REMOVE:
             case self::EDIT:
+                return $this->canEdit($subject, $token);
+            case self::FLYING:
                 return $this->canEdit($subject, $token);
         }
 

--- a/src/AppBundle/Service/BeneficiaryService.php
+++ b/src/AppBundle/Service/BeneficiaryService.php
@@ -16,14 +16,18 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class BeneficiaryService
 {
     private $container;
-    protected $em;
+    private $em;
     private $membershipService;
+    private $use_fly_and_fixed;
+    private $fly_and_fixed_entity_flying;
 
     public function __construct(ContainerInterface $container, EntityManagerInterface $em, MembershipService $membershipService)
     {
         $this->container = $container;
         $this->em = $em;
         $this->membershipService = $membershipService;
+        $this->use_fly_and_fixed = $this->container->getParameter('use_fly_and_fixed');
+        $this->fly_and_fixed_entity_flying = $this->container->getParameter('fly_and_fixed_entity_flying');
     }
 
     /**
@@ -71,7 +75,7 @@ class BeneficiaryService
     {
         $hasWarningStatus = $this->membershipService->hasWarningStatus($beneficiary->getMembership());
 
-        if ($this->container->getParameter('use_fly_and_fixed')) {
+        if ($this->use_fly_and_fixed && $this->fly_and_fixed_entity_flying == 'Beneficiary') {
             $hasWarningStatus = $hasWarningStatus || $beneficiary->isFlying();
         }
         
@@ -96,8 +100,13 @@ class BeneficiaryService
         if ($beneficiary->getMembership()->getFrozen()) {
             $symbols[] = $this->container->getParameter('member_frozen_icon');
         }
-        if ($beneficiary->isFlying()) {
-            $symbols[] = $this->container->getParameter('beneficiary_flying_icon');;
+        if ($this->use_fly_and_fixed) {
+            if ($this->fly_and_fixed_entity_flying == 'Beneficiary' && $beneficiary->isFlying()) {
+                $symbols[] = $this->container->getParameter('beneficiary_flying_icon');;
+            }
+            if ($this->fly_and_fixed_entity_flying == 'Membership' && $beneficiary->getMembership()->isFlying()) {
+                $symbols[] = $this->container->getParameter('member_flying_icon');;
+            }
         }
         if ($beneficiary->getMembership()->isCurrentlyExemptedFromShifts()) {
             $symbols[] = $this->container->getParameter('member_exempted_icon');

--- a/src/AppBundle/Service/PeriodService.php
+++ b/src/AppBundle/Service/PeriodService.php
@@ -3,11 +3,22 @@
 namespace AppBundle\Service;
 
 use AppBundle\Entity\Period;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class PeriodService
 {
-    public function __construct()
+    private $container;
+    private $em;
+    private $use_fly_and_fixed;
+    private $fly_and_fixed_entity_flying;
+
+    public function __construct(ContainerInterface $container, EntityManagerInterface $em)
     {
+        $this->container = $container;
+        $this->em = $em;
+        $this->use_fly_and_fixed = $this->container->getParameter('use_fly_and_fixed');
+        $this->fly_and_fixed_entity_flying = $this->container->getParameter('fly_and_fixed_entity_flying');
     }
 
     public function getDaysOfWeekArray()
@@ -18,5 +29,34 @@ class PeriodService
     public function getWeekCycleArray()
     {
         return Period::WEEK_CYCLE;
+    }
+
+    /**
+     * Return true if at least one shifter (a.k.a. beneficiary) registered for
+     * this period has a warning status, meaning with a withdrawn or frozen membership
+     * of if the shifter is member of the flying team.
+     *
+     * useful only if the use_fly_and_fixed is activated
+     *
+     * @param String|null $weekCycle a string of the week to keep or null if no filter
+     * @return bool
+     */
+    public function hasWarningStatus(Period $period, ?String $weekCycle=null): bool
+    {
+        if ($this->use_fly_and_fixed) {
+            foreach ($period->getPositions() as $position) {
+                if ($shifter = $position->getShifter()) {
+                    $shifterIsFlying = ($this->fly_and_fixed_entity_flying == 'Beneficiary' and $shifter->isFlying()) or ($this->fly_and_fixed_entity_flying == 'Membership' and $shifter->getMembership()->isFlying());
+                    if ((($weekCycle && $position->getWeekCycle()==$weekCycle) or !$weekCycle)
+                        and ($shifterIsFlying
+                        or $shifter->getMembership()->isFrozen()
+                        or $shifter->getMembership()->isWithdrawn())) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
     }
 }

--- a/src/AppBundle/Service/SearchUserFormHelper.php
+++ b/src/AppBundle/Service/SearchUserFormHelper.php
@@ -22,12 +22,14 @@ class SearchUserFormHelper
 {
     private $container;
     private $use_fly_and_fixed;
+    private $fly_and_fixed_entity_flying;
     private $maximum_nb_of_beneficiaries_in_membership;
 
     public function __construct(ContainerInterface $container)
     {
         $this->container = $container;
         $this->use_fly_and_fixed = $this->container->getParameter('use_fly_and_fixed');
+        $this->fly_and_fixed_entity_flying = $this->container->getParameter('fly_and_fixed_entity_flying');
         $this->maximum_nb_of_beneficiaries_in_membership = $this->container->getParameter('maximum_nb_of_beneficiaries_in_membership');
     }
 
@@ -204,15 +206,15 @@ class SearchUserFormHelper
         }
         if ($this->use_fly_and_fixed) {
             $formBuilder->add('flying', ChoiceType::class, [
-                'label' => $this->container->getParameter('beneficiary_flying_icon') . ' volant',
+                'label' => (($this->fly_and_fixed_entity_flying == 'Membership') ? $this->container->getParameter('member_flying_icon') : $this->container->getParameter('beneficiary_flying_icon')) . ' volant',
                 'required' => false,
                 'disabled' => in_array('flying', $disabledFields) ? true : false,
                 'choices' => [
                     'Oui' => 2,
                     'Non (fixe)' => 1,
                 ],
-            ])
-            ->add('has_period_position', ChoiceType::class, [
+            ]);
+            $formBuilder->add('has_period_position', ChoiceType::class, [
                 'label' => 'créneau fixe',
                 'required' => false,
                 'disabled' => in_array('has_period_position', $disabledFields) ? true : false,
@@ -456,8 +458,13 @@ class SearchUserFormHelper
 
         if ($this->use_fly_and_fixed) {
             if ($form->get('flying')->getData() > 0) {
-                $qb = $qb->andWhere('b.flying = :flying')
-                    ->setParameter('flying', $form->get('flying')->getData()-1);
+                if ($this->fly_and_fixed_entity_flying == 'Membership') {
+                    $qb = $qb->andWhere('m.flying = :flying')
+                        ->setParameter('flying', $form->get('flying')->getData()-1);
+                } else {
+                    $qb = $qb->andWhere('b.flying = :flying')
+                        ->setParameter('flying', $form->get('flying')->getData()-1);
+                }
             }
             if ($form->get('has_period_position')->getData() > 0) {
                 $qb = $qb->leftJoin("b.periodPositions", "pp")->addSelect("pp");
@@ -631,8 +638,13 @@ class SearchUserFormHelper
 
         if ($this->use_fly_and_fixed) {
             if ($form->get('flying')->getData() > 0) {
-                $qb = $qb->andWhere('b.flying = :flying')
-                    ->setParameter('flying', $form->get('flying')->getData()-1);
+                if ($this->fly_and_fixed_entity_flying == 'Membership') {
+                    $qb = $qb->andWhere('m.flying = :flying')
+                        ->setParameter('flying', $form->get('flying')->getData()-1);
+                } else {
+                    $qb = $qb->andWhere('b.flying = :flying')
+                        ->setParameter('flying', $form->get('flying')->getData()-1);
+                }
             }
             if ($form->get('has_period_position')->getData() > 0) {
                 $qb = $qb->leftJoin("b.periodPositions", "pp")->addSelect("pp");


### PR DESCRIPTION
v3 de #956

### Quoi ?

- nouveau champ `Membership.flying`
- nouveau paramètre `fly_and_fixed_entity_flying` pour pouvoir choisir l'entité qui porte la notion de volant : `Beneficiary` ou `Membership`
- mettre à jour l'interface et les différentes logiques

### Captures d'écran

||Image|
|---|---|
|Compte fixe|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/1d937a5d-cb4b-4e01-96ab-0c18de31edb0)|
|Compte volant|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/472f560a-700c-4bd7-a2c2-6f6f2699f61a)|