### PR TITLE
Admin : petites améliorations sur la page filtre des ambassadeurs

### DIFF
--- a/app/Resources/views/admin/index.html.twig
+++ b/app/Resources/views/admin/index.html.twig
@@ -47,8 +47,8 @@
                 <a href="{{ path('ambassador_shifttimelog_list') }}" class="waves-effect waves-light btn">
                     <i class="material-icons left">phone</i>Relances créneaux
                 </a>
-                {% if use_fly_and_fixed %}
-                    <a href="{{ path('ambassador_noperiodposition_list') }}" class="waves-effect waves-light btn">
+                {% if use_fly_and_fixed and fly_and_fixed_entity_flying == 'Beneficiary' %}
+                    <a href="{{ path('ambassador_beneficiary_fixe_without_periodposition_list') }}" class="waves-effect waves-light btn">
                         <i class="material-icons left">phone</i>Relances postes fixes
                     </a>
                 {% endif %}

--- a/app/Resources/views/admin/index.html.twig
+++ b/app/Resources/views/admin/index.html.twig
@@ -47,10 +47,12 @@
                 <a href="{{ path('ambassador_shifttimelog_list') }}" class="waves-effect waves-light btn">
                     <i class="material-icons left">phone</i>Relances créneaux
                 </a>
-                {% if use_fly_and_fixed and fly_and_fixed_entity_flying == 'Beneficiary' %}
-                    <a href="{{ path('ambassador_beneficiary_fixe_without_periodposition_list') }}" class="waves-effect waves-light btn">
-                        <i class="material-icons left">phone</i>Relances postes fixes
-                    </a>
+                {% if use_fly_and_fixed %}
+                    {% if fly_and_fixed_entity_flying == 'Beneficiary' %}
+                        <a href="{{ path('ambassador_beneficiary_fixe_without_periodposition_list') }}" class="waves-effect waves-light btn">
+                            <i class="material-icons left">phone</i>Relances postes fixes
+                        </a>
+                    {% endif %}
                 {% endif %}
             {% endif %}
 

--- a/app/Resources/views/ambassador/phone/list.html.twig
+++ b/app/Resources/views/ambassador/phone/list.html.twig
@@ -118,10 +118,12 @@
                             {{ form_label(form.email) }}
                         </div>
                         {% if use_fly_and_fixed %}
-                            <div class="input-field">
-                                {{ form_widget(form.flying) }}
-                                {{ form_label(form.flying) }}
-                            </div>
+                            {% if fly_and_fixed_entity_flying == 'Beneficiary' %}
+                                <div class="input-field">
+                                    {{ form_widget(form.flying) }}
+                                    {{ form_label(form.flying) }}
+                                </div>
+                            {% endif %}
                             <div class="input-field">
                                 {{ form_widget(form.has_period_position) }}
                                 {{ form_label(form.has_period_position) }}

--- a/app/Resources/views/ambassador/phone/list.html.twig
+++ b/app/Resources/views/ambassador/phone/list.html.twig
@@ -1,15 +1,15 @@
 {% extends 'layout.html.twig' %}
 
-{% block title %}Liste des membres {{ reason }} - {{ site_name }}{% endblock %}
+{% block title %}{{ reason }} - {{ site_name }}{% endblock %}
 
 {% block breadcrumbs %}
 <a href="{{ path('homepage') }}"><i class="material-icons">home</i></a><i class="material-icons">chevron_right</i>
 <a href="{{ path('admin') }}"><i class="material-icons">build</i>&nbsp;Administration</a><i class="material-icons">chevron_right</i>
-<i class="material-icons">list</i>&nbsp;Liste des membres {{ reason }}
+<i class="material-icons">list</i>&nbsp;{{ reason }}
 {% endblock %}
 
 {% block content %}
-    <h4>Liste des membres {{ reason }} ({{ result_count }})</h4>
+    <h4>{{ reason }} ({{ result_count }})</h4>
 
     <ul class="collapsible">
         <li>

--- a/src/AppBundle/Controller/AmbassadorController.php
+++ b/src/AppBundle/Controller/AmbassadorController.php
@@ -223,7 +223,7 @@ class AmbassadorController extends Controller
         $form = $formHelper->createBeneficiaryFixeWithoutPeriodPositionForm($this->createFormBuilder(), $defaults, $disabledFields);
         $form->handleRequest($request);
 
-        $qb = $formHelper->initSearchQuery($this->getDoctrine()->getManager(), 'noperiodposition');
+        $qb = $formHelper->initSearchQuery($this->getDoctrine()->getManager(), 'fixe_without_periodposition');
         $qb = $formHelper->processSearchFormAmbassadorData($form, $qb);
 
         $sort = $form->get('sort')->getData();

--- a/src/AppBundle/Controller/AmbassadorController.php
+++ b/src/AppBundle/Controller/AmbassadorController.php
@@ -77,7 +77,7 @@ class AmbassadorController extends Controller
             ->setMaxResults($limitPerPage); // set the limit
 
         return $this->render('ambassador/phone/list.html.twig', array(
-            'reason' => "sans adhésion",
+            'reason' => "Liste des membres sans adhésion",
             'members' => $paginator,
             'form' => $form->createView(),
             'result_count' => $resultCount,
@@ -137,7 +137,7 @@ class AmbassadorController extends Controller
             ->setMaxResults($limitPerPage); // set the limit
 
         return $this->render('ambassador/phone/list.html.twig', array(
-            'reason' => "en retard de ré-adhésion",
+            'reason' => "Liste des membres en retard de ré-adhésion",
             'members' => $paginator,
             'form' => $form->createView(),
             'result_count' => $resultCount,
@@ -189,7 +189,7 @@ class AmbassadorController extends Controller
             ->setMaxResults($limitPerPage); // set the limit
 
         return $this->render('ambassador/phone/list.html.twig', array(
-            'reason' => "en retard de créneaux",
+            'reason' => "Liste des membres en retard de créneaux",
             'members' => $paginator,
             'form' => $form->createView(),
             'result_count' => $resultCount,
@@ -200,13 +200,14 @@ class AmbassadorController extends Controller
 
     /**
      * List all beneficiaries "fixe" without periodposition
+     * Useful for use_fly_and_fixed and fly_and_fixed_entity_flying == 'Beneficiary'
      *
-     * @Route("/noperiodposition", name="ambassador_noperiodposition_list", methods={"GET","POST"})
+     * @Route("/beneficiary_fixe_without_periodposition", name="ambassador_beneficiary_fixe_without_periodposition_list", methods={"GET","POST"})
      * @Security("has_role('ROLE_USER_MANAGER')")
      * @param request $request , searchuserformhelper $formhelper
      * @return response
      */
-    public function beneficiaryFixeNoPeriodPosition(Request $request, SearchUserFormHelper $formHelper)
+    public function beneficiaryFixeWithoutPeriodPosition(Request $request, SearchUserFormHelper $formHelper)
     {
         $defaults = [
             'withdrawn' => 1,
@@ -219,7 +220,7 @@ class AmbassadorController extends Controller
         ];
         $disabledFields = ['withdrawn', 'registration', 'flying', 'has_period_position'];
 
-        $form = $formHelper->createBeneficiaryFixeNoPeriodPositionForm($this->createFormBuilder(), $defaults, $disabledFields);
+        $form = $formHelper->createBeneficiaryFixeWithoutPeriodPositionForm($this->createFormBuilder(), $defaults, $disabledFields);
         $form->handleRequest($request);
 
         $qb = $formHelper->initSearchQuery($this->getDoctrine()->getManager(), 'noperiodposition');
@@ -242,7 +243,7 @@ class AmbassadorController extends Controller
             ->setMaxResults($limitPerPage); // set the limit
 
         return $this->render('ambassador/phone/list.html.twig', array(
-            'reason' => "fixes sans poste fixe",
+            'reason' => "Liste des bénéficiaires fixes sans poste fixe",
             'members' => $paginator,
             'form' => $form->createView(),
             'result_count' => $resultCount,

--- a/src/AppBundle/Service/SearchUserFormHelper.php
+++ b/src/AppBundle/Service/SearchUserFormHelper.php
@@ -344,7 +344,7 @@ class SearchUserFormHelper
         return $form;
     }
 
-    public function createBeneficiaryFixeNoPeriodPositionForm($formBuilder, $defaults = [], $disabledFields = []) {
+    public function createBeneficiaryFixeWithoutPeriodPositionForm($formBuilder, $defaults = [], $disabledFields = []) {
         $form = $this->getSearchForm($formBuilder, 'noperiodposition', $disabledFields);
         foreach ($defaults as $k => $v) {
             $form->get($k)->setData($v);

--- a/src/AppBundle/Service/SearchUserFormHelper.php
+++ b/src/AppBundle/Service/SearchUserFormHelper.php
@@ -345,7 +345,7 @@ class SearchUserFormHelper
     }
 
     public function createBeneficiaryFixeWithoutPeriodPositionForm($formBuilder, $defaults = [], $disabledFields = []) {
-        $form = $this->getSearchForm($formBuilder, 'noperiodposition', $disabledFields);
+        $form = $this->getSearchForm($formBuilder, 'fixe_without_periodposition', $disabledFields);
         foreach ($defaults as $k => $v) {
             $form->get($k)->setData($v);
         }
@@ -366,7 +366,7 @@ class SearchUserFormHelper
             ->leftJoin("b.commissions", "c")->addSelect("c")
             ->leftJoin("b.formations", "f")->addSelect("f");
 
-        if (in_array($type, ['noregistration', 'lateregistration', 'shifttimelog', 'noperiodposition'])) {
+        if (in_array($type, ['noregistration', 'lateregistration', 'shifttimelog', 'fixe_without_periodposition'])) {
             $qb = $qb->leftJoin("m.registrations", "lr", Join::WITH,'lr.date > r.date')->addSelect("lr")
                 ->where('lr.id IS NULL') // registration is the last one registered
                 ->addSelect("(SELECT SUM(ti.time) FROM AppBundle\Entity\TimeLog ti WHERE ti.type != 20 AND ti.membership = m.id) AS HIDDEN time")


### PR DESCRIPTION
Suite de #1039

Modifications apportées : 
- la page "Liste des bénéficiaires fixes sans créneau fixe" ne s'affiche que si `fly_and_fixed_entity_flying == 'Beneficiary'` (en attendant de faire son pendant pour les "membres fixes sans créneau fixe")
- amélioré le naming