### PR TITLE
Améliorer la commande d'anonymisation de la base de données

### DIFF
--- a/app/DoctrineMigrations/Version20231107150336.php
+++ b/app/DoctrineMigrations/Version20231107150336.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20231107150336 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE note DROP FOREIGN KEY FK_CFBDFA14727ACA70');
+        $this->addSql('ALTER TABLE note ADD CONSTRAINT FK_CFBDFA14727ACA70 FOREIGN KEY (parent_id) REFERENCES note (id) ON DELETE SET NULL');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE note DROP FOREIGN KEY FK_CFBDFA14727ACA70');
+        $this->addSql('ALTER TABLE note ADD CONSTRAINT FK_CFBDFA14727ACA70 FOREIGN KEY (parent_id) REFERENCES note (id)');
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,7 @@ services:
       PMA_PORT: 3306
       PMA_USER: root
       PMA_PASSWORD: secret
+      UPLOAD_LIMIT: 50000000
     ports:
       - "8080:80"
     depends_on:

--- a/src/AppBundle/Command/AnonymizeDataCommand.php
+++ b/src/AppBundle/Command/AnonymizeDataCommand.php
@@ -5,6 +5,7 @@ namespace AppBundle\Command;
 use AppBundle\Entity\Beneficiary;
 use AppBundle\Entity\Client;
 use AppBundle\Entity\Commission;
+use AppBundle\Entity\Event;
 use AppBundle\Entity\Note;
 use AppBundle\Entity\Shift;
 use AppBundle\Entity\User;
@@ -117,6 +118,14 @@ class AnonymizeDataCommand extends ContainerAwareCommand
             $comission->setName('comission '.$comission->getId());
             $comission->setDescription($this->randomValue($texts));
             $em->persist($comission);
+        }
+
+        $output->writeln('<info>Anonymising Event data</>');
+        $events = $em->getRepository(Event::class)->findAll();
+        foreach ($events as $event) {
+            $event->setTitle('event '.$event->getId());
+            $event->setDescription($this->randomValue($texts));
+            $em->persist($event);
         }
 
         $output->writeln('<info>Deleting Client data</>');

--- a/src/AppBundle/Command/AnonymizeDataCommand.php
+++ b/src/AppBundle/Command/AnonymizeDataCommand.php
@@ -19,6 +19,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Validator\Constraints\Date;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 class AnonymizeDataCommand extends ContainerAwareCommand
 {
@@ -39,6 +41,19 @@ class AnonymizeDataCommand extends ContainerAwareCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+
+        // Create a new question helper instance
+        $helper = $this->getHelper('question');
+
+        // Create the question with the default answer of 'no'
+        $question = new ConfirmationQuestion('Are you sure you want to proceed ? It will change the current database. (y/N) ', false);
+
+        // Ask the question
+        if (!$helper->ask($input, $output, $question)) {
+            $output->writeln('Command aborted.');
+            return 0;
+        }
+        
         $firstnames = [
             'sophie','marie','noemie','hélène','chloé','laura','lily','celeste','capucine','zoé','julie','mimi','charlotte',
             'paul','stephane','manu','jean-paul','tim','pierre','florian','clement','julien','baptiste','bruno','arthur',
@@ -168,5 +183,7 @@ class AnonymizeDataCommand extends ContainerAwareCommand
 
         $em->flush();
         $output->writeln('<info>Done!</>');
+
+        return 0;
     }
 }

--- a/src/AppBundle/Command/AnonymizeDataCommand.php
+++ b/src/AppBundle/Command/AnonymizeDataCommand.php
@@ -126,14 +126,15 @@ class AnonymizeDataCommand extends ContainerAwareCommand
             $user->setEmail($email);
             $em->persist($user);
 
-            // anonymize User registrations via Helloasso
-            $user_registrations = $user->getRecordedRegistrations();
-            foreach ($user_registrations as $user_registration) {
-                if ($user_registration->getHelloassoPayment()) {
-                    $helloassopayment = $user_registration->getHelloassoPayment();
-                    $helloassopayment->setEmail($user->getEmail());
-                    $helloassopayment->setPayerFirstName($user->getFirstname());
-                    $helloassopayment->setPayerLastName($user->getLastname());
+            // anonymize Membership registrations via Helloasso
+            $member_registrations = $beneficiary->getMembership()->getRegistrations();
+            foreach ($member_registrations as $member_registration) {
+                if ($member_registration->getHelloassoPayment()) {
+                    $helloassopayment = $member_registration->getHelloassoPayment();
+                    $helloassopayment->setEmail($email);
+                    $helloassopayment->setPayerFirstName($firstname);
+                    $helloassopayment->setPayerLastName($lastname);
+                    $em->persist($helloassopayment);
                 }
             }
 

--- a/src/AppBundle/Entity/Note.php
+++ b/src/AppBundle/Entity/Note.php
@@ -45,7 +45,7 @@ class Note
 
     /**
      * @ORM\ManyToOne(targetEntity="Note", inversedBy="children")
-     * @ORM\JoinColumn(name="parent_id", referencedColumnName="id")
+     * @ORM\JoinColumn(name="parent_id", referencedColumnName="id", onDelete="SET NULL")
      */
     private $parent;
 


### PR DESCRIPTION
Améliorations de la commande `AnonymizeDataCommand.php`
- le faire aussi pour les entités `HelloassoPayment`, `AnonymousBeneficiary` et `Event`
- supprimer toutes les `Note` et `Client`
- ajout d'une confirmation avant de lancer la commande

Fix sur les notes pour pouvoir en supprimer une sans nécessairement supprimer ses réponses