### PR TITLE
Ajout de set_locale pour les commandes

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -6,7 +6,7 @@ imports:
 # Put parameters here that don't need to change on each machine where the app is deployed
 # https://symfony.com/doc/current/best_practices/configuration.html#application-related-configuration
 parameters:
-  locale: fr
+  locale: fr_FR.utf8
   registration_period: '15 days ago'
   remainder_warning_delay: '15'
   images_tmp_dir: '%kernel.project_dir%/web/tmp'
@@ -14,7 +14,6 @@ parameters:
   github_current_release: 'v1.45.5'
 
 framework:
-  translator: { fallbacks: ['%locale%'] }
   secret: '%secret%'
   router:
     resource: '%kernel.project_dir%/app/config/routing.yml'
@@ -24,7 +23,6 @@ framework:
   validation: { enable_annotations: true }
   templating:
     engines: ['twig']
-  default_locale: '%locale%'
   trusted_hosts: ~
   session:
     # https://symfony.com/doc/current/reference/configuration/framework.html#handler-id

--- a/src/AppBundle/Command/AmbassadorShiftTimeLogCommand.php
+++ b/src/AppBundle/Command/AmbassadorShiftTimeLogCommand.php
@@ -23,6 +23,8 @@ class AmbassadorShiftTimeLogCommand extends ContainerAwareCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $locale = $this->getContainer()->getParameter('locale');
+        setlocale(LC_TIME, $locale);
         $email_template = $input->getOption('emailTemplate');
 
         $time_after_which_members_are_late_with_shifts = $this->getContainer()->getParameter('time_after_which_members_are_late_with_shifts');

--- a/src/AppBundle/EventListener/EmailingEventListener.php
+++ b/src/AppBundle/EventListener/EmailingEventListener.php
@@ -47,6 +47,8 @@ class EmailingEventListener
         $this->shift_email = $this->container->getParameter('emails.shift');
         $this->wiki_keys_url = $this->container->getParameter('wiki_keys_url');
         $this->reserve_new_shift_to_prior_shifter_delay = $this->container->getParameter('reserve_new_shift_to_prior_shifter_delay');
+        $locale = $this->container->getParameter('locale');
+        setlocale(LC_TIME, $locale);
     }
 
     /**

--- a/src/AppBundle/EventListener/MattermostEventListener.php
+++ b/src/AppBundle/EventListener/MattermostEventListener.php
@@ -19,6 +19,8 @@ class MattermostEventListener
         $this->em = $entityManager;
         $this->logger = $logger;
         $this->container = $container;
+        $locale = $this->container->getParameter('locale');
+        setlocale(LC_TIME, $locale);
     }
 
     /**


### PR DESCRIPTION
La configuration dans web/app.php ne concerne pas les commandes. Il est nécessaire de le faire pour chaque commande.

Note: une configuration via le php.ini du système est aussi possible.