### PR TITLE
Bénéficiaire : afficher le champ "équipe volante" en fonction des paramètres choisis

### DIFF
--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -15,8 +15,9 @@ services:
         public: false
         bind:
             $local_currency_name: '%local_currency_name%'
-            $use_fly_and_fixed: '%use_fly_and_fixed%'
             $cycle_type: '%cycle_type%'
+            $use_fly_and_fixed: '%use_fly_and_fixed%'
+            $fly_and_fixed_entity_flying: '%fly_and_fixed_entity_flying%'
 
     # makes classes in src/AppBundle available to be used as services
     # this creates a service per class whose id is the fully-qualified class name

--- a/src/AppBundle/Form/BeneficiaryType.php
+++ b/src/AppBundle/Form/BeneficiaryType.php
@@ -22,22 +22,16 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class BeneficiaryType extends AbstractType
 {
+    private $use_fly_and_fixed;
+    private $fly_and_fixed_entity_flying;
     private $tokenStorage;
-    /**
-     * @var ValidatorInterface
-     */
     private $validator;
-    /**
-     * @var EntityManager
-     */
-    private $em;
-    /**
-     * @var BeneficiaryInitializationSubscriber
-     */
     private $beneficiaryInitializationSubscriber;
 
-    public function __construct(TokenStorageInterface $tokenStorage, ValidatorInterface $validator, BeneficiaryInitializationSubscriber $beneficiaryInitializationSubscriber)
+    public function __construct(bool $use_fly_and_fixed, string $fly_and_fixed_entity_flying, TokenStorageInterface $tokenStorage, ValidatorInterface $validator, BeneficiaryInitializationSubscriber $beneficiaryInitializationSubscriber)
     {
+        $this->use_fly_and_fixed = $use_fly_and_fixed;
+        $this->fly_and_fixed_entity_flying = $fly_and_fixed_entity_flying;
         $this->tokenStorage = $tokenStorage;
         $this->validator = $validator;
         $this->beneficiaryInitializationSubscriber = $beneficiaryInitializationSubscriber;
@@ -65,15 +59,17 @@ class BeneficiaryType extends AbstractType
 
         $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) use ($user) {
             $form = $event->getForm();
-            if (is_object($user)&&($user->hasRole('ROLE_USER_MANAGER') || $user->hasRole('ROLE_ADMIN') || $user->hasRole('ROLE_SUPER_ADMIN'))) {
-                $form->add('flying', ChoiceType::class, array(
-                    'choices'  => array(
-                        'Oui' => true,
-                        'Non' => false,
-                    ),
-                    'required' => true,
-                    'label' => 'Equipe volante'
-                ));
+            if (is_object($user) && ($user->hasRole('ROLE_USER_MANAGER') || $user->hasRole('ROLE_ADMIN') || $user->hasRole('ROLE_SUPER_ADMIN'))) {
+                if ($this->use_fly_and_fixed && $this->fly_and_fixed_entity_flying == 'Beneficiary') {
+                    $form->add('flying', ChoiceType::class, array(
+                        'choices'  => array(
+                            'Oui' => true,
+                            'Non' => false,
+                        ),
+                        'required' => true,
+                        'label' => 'Equipe volante'
+                    ));
+                }
                 $form->add('commissions', EntityType::class, array(
                     'class' => 'AppBundle:Commission',
                     'choice_label' => 'name',

--- a/src/AppBundle/Form/BeneficiaryWithoutUserType.php
+++ b/src/AppBundle/Form/BeneficiaryWithoutUserType.php
@@ -9,9 +9,12 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class BeneficiaryWithoutUserType extends BeneficiaryType
 {
-    public function __construct(TokenStorageInterface $tokenStorage, ValidatorInterface $validator, BeneficiaryInitializationSubscriber $beneficiaryInitializationSubscriber)
+    private $use_fly_and_fixed;
+    private $fly_and_fixed_entity_flying;
+
+    public function __construct(bool $use_fly_and_fixed, string $fly_and_fixed_entity_flying, TokenStorageInterface $tokenStorage, ValidatorInterface $validator, BeneficiaryInitializationSubscriber $beneficiaryInitializationSubscriber)
     {
-         parent::__construct($tokenStorage, $validator, $beneficiaryInitializationSubscriber);
+        parent::__construct($use_fly_and_fixed, $fly_and_fixed_entity_flying, $tokenStorage, $validator, $beneficiaryInitializationSubscriber);
     }
 
     /**

--- a/src/AppBundle/Form/MemberType.php
+++ b/src/AppBundle/Form/MemberType.php
@@ -15,7 +15,6 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
 
 class MemberType extends AbstractType
 {
-
     private $tokenStorage;
 
     public function __construct(TokenStorageInterface $tokenStorage)
@@ -40,13 +39,13 @@ class MemberType extends AbstractType
             $form = $event->getForm();
             $memberData = $event->getData();
 
-            if (is_object($user) && ($user->hasRole('ROLE_ADMIN')||$user->hasRole('ROLE_SUPER_ADMIN'))){
+            if (is_object($user) && ($user->hasRole('ROLE_ADMIN') || $user->hasRole('ROLE_SUPER_ADMIN'))) {
                 $form->add('member_number', IntegerType::class, array('label'=> 'Numéro d\'adhérent'));
             }else{
                 $form->add('member_number', IntegerType::class, array('label'=> 'Numéro d\'adhérent', 'disabled' => true));
             }
 
-            if (is_object($user)){
+            if (is_object($user)) {
                 if ($user->hasRole('ROLE_USER_MANAGER') || $user->hasRole('ROLE_ADMIN') || $user->hasRole('ROLE_SUPER_ADMIN')){
                     if ($memberData && $memberData->getId()) { //in not new
                         $form->add('withdrawn', CheckboxType::class, array(
@@ -61,12 +60,11 @@ class MemberType extends AbstractType
                 }
             }
 
-            $form->add('mainBeneficiary', BeneficiaryType::class,array('label'=>' '));
+            $form->add('mainBeneficiary', BeneficiaryType::class, array('label'=>' '));
 
-            if ($memberData && !$memberData->getId()){
+            if ($memberData && !$memberData->getId()) {
                 $form->add('lastRegistration', RegistrationType::class,array('label'=>' ','data_class'=>Registration::class));
             }
-
         });
     }
 
@@ -87,6 +85,4 @@ class MemberType extends AbstractType
     {
         return 'appbundle_membership';
     }
-
-
 }

--- a/src/AppBundle/Form/UserWithBeneficiaryType.php
+++ b/src/AppBundle/Form/UserWithBeneficiaryType.php
@@ -20,7 +20,6 @@ class UserWithBeneficiaryType extends UserType
         parent::__construct($tokenStorage);
     }
 
-
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         parent::buildForm($builder, $options);
@@ -44,6 +43,4 @@ class UserWithBeneficiaryType extends UserType
     {
         return 'appbundle_user';
     }
-
-
 }


### PR DESCRIPTION
### Quoi ?

Actuellement le champ "Equipe volante" (`flying` dans le code) est affiché à chaque fois. Or : 
- les épiceries qui n'ont pas de notion d'équipe fixe ne s'en servent pas
- les épiceries avec équipe fixe mais dont l'info est stocké sur le Membership ne s'en servent pas (fonctionnalité depuis #1058)

Modifications pour cacher ce champ lorsqu'il n'est pas utile.

### Capture d'écran

Exemple pour une épicerie avec les paramètres : 
- `use_fly_and_fixed: true`
- `fly_and_fixed_entity_flying: Membership`

||Image|
|---|---|
|Avant|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/ca046449-692c-4989-8c4b-aa3761676b00)|
|Après|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/2e21bcef-9800-4a15-a569-b5d12f2281e0)|