### PR TITLE
Répare le formulaire de création d'un nouveau membre

### DIFF
--- a/src/AppBundle/Controller/AdminController.php
+++ b/src/AppBundle/Controller/AdminController.php
@@ -25,7 +25,6 @@ use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\EventDispatcher\EventDispatcher;
-use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\FileType;

--- a/src/AppBundle/Form/BeneficiaryType.php
+++ b/src/AppBundle/Form/BeneficiaryType.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
@@ -69,6 +70,11 @@ class BeneficiaryType extends AbstractType
                         'required' => true,
                         'label' => 'Equipe volante'
                     ));
+                } else {
+                    $form->add('flying', HiddenType::class, [
+                        'data' => '0',
+                        'label' => false
+                    ]);
                 }
                 $form->add('commissions', EntityType::class, array(
                     'class' => 'AppBundle:Commission',

--- a/src/AppBundle/Form/NoteType.php
+++ b/src/AppBundle/Form/NoteType.php
@@ -4,7 +4,6 @@ namespace AppBundle\Form;
 
 use AppBundle\Entity\Note;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;

--- a/src/AppBundle/Form/ShiftType.php
+++ b/src/AppBundle/Form/ShiftType.php
@@ -3,10 +3,10 @@
 namespace AppBundle\Form;
 
 use AppBundle\Entity\Shift;
+use AppBundle\Form\JobHiddenType;
 use AppBundle\Repository\JobRepository;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\FormBuilderInterface;

--- a/src/AppBundle/Form/TimeLogType.php
+++ b/src/AppBundle/Form/TimeLogType.php
@@ -4,7 +4,6 @@ namespace AppBundle\Form;
 
 use AppBundle\Entity\TimeLog;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;


### PR DESCRIPTION
### Quoi ?

Il y avait un soucis dans la création de nouveaux membres, suite à #1072

Le champ "Equipe volante" est caché, mais il faut quand même fournir une valeur par défaut pour valider le formulaire.

### Capture d'écran

![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/f25860f7-3775-4d9f-aa12-2900d1a077ed)
