### PR TITLE
Répare la suppression des membres

### DIFF
--- a/src/AppBundle/Entity/Membership.php
+++ b/src/AppBundle/Entity/Membership.php
@@ -375,7 +375,7 @@ class Membership
     /**
      * Set withdrawnDate
      *
-     * @param \DateTime $createdAt
+     * @param \DateTime $date
      *
      * @return Membership
      */
@@ -790,5 +790,4 @@ class Membership
             return $membershipShiftExemption->isCurrent($date);
         });
     }
-
 }

--- a/src/AppBundle/Entity/User.php
+++ b/src/AppBundle/Entity/User.php
@@ -54,7 +54,7 @@ class User extends BaseUser
 
     /**
      * @ORM\OneToMany(targetEntity="Note", mappedBy="author",cascade={"persist", "remove"})
-     * @OrderBy({"created_at" = "DESC"})
+     * @OrderBy({"createdAt" = "DESC"})
      */
     private $annotations;
 


### PR DESCRIPTION
Actuellement, lorsqu'en tant que SUPER_ADMIN on souhaite supprimer un membre, il y a une erreur "Unrecognized field: created_at"

C'était dû à un oubli lorsque on avait homogénéisé les champs `createdAt`, dans la PR #566 (modèle `Note`)