### PR TITLE
Créneaux : Admin : fix temporaire pour accélérer le chargement de la page

### DIFF
--- a/app/Resources/views/admin/booking/_partial/bucket_calendar.html.twig
+++ b/app/Resources/views/admin/booking/_partial/bucket_calendar.html.twig
@@ -8,7 +8,7 @@
 
         {# New week --------- #}
         {% if not date and previousWeekIndex != weekIndex %}
-        {% include "booking/_partial/week_title.html.twig" with { first_shift: buckets|first } %}
+            {% include "booking/_partial/week_title.html.twig" with { first_shift: buckets|first } %}
             {% set previousWeekIndex = weekIndex %}
         {% endif %}
 

--- a/src/AppBundle/Repository/ShiftRepository.php
+++ b/src/AppBundle/Repository/ShiftRepository.php
@@ -73,9 +73,9 @@ class ShiftRepository extends \Doctrine\ORM\EntityRepository
                 ->leftJoin('s.shifter', 'b')
                 ->addSelect('b')
                 ->leftJoin('b.formations', 'bf')
-                ->addSelect('bf')
-                ->leftJoin('b.shifts', 'bs')  // for Beneficiary.isNew()
-                ->addSelect('bs');
+                ->addSelect('bf');
+                // ->leftJoin('b.shifts', 'bs')  // for Beneficiary.isNew()
+                // ->addSelect('bs');
         }
 
         $qb->orderBy('s.start', 'ASC');


### PR DESCRIPTION
### Quoi ?

Le chargement de la page admin de gestion des créneaux est particulièrement lent.
Ces changements ont été introduits dans la PR #849 où l'on souhaitait diminuer le nombre de requêtes.

Mais en cherchant si le membre est "nouveau", on va récupérer l'ensemble des créneaux passés des membres, ce qui est chronophage en mémoire.

Désactivation de cette option

