### PR TITLE
Badgeuse : être plus libre dans le choix des IP + refactoring

### DIFF
--- a/src/AppBundle/Helper/PlaceIP.php
+++ b/src/AppBundle/Helper/PlaceIP.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace AppBundle\Helper;
+
+use Symfony\Component\DependencyInjection\ContainerInterface as Container;
+
+class PlaceIP {
+
+    private $container;
+
+    public function __construct(Container $container) {
+        $this->container = $container;
+    }
+
+    public function isLocationOk()
+    {
+        $ip = $this->container->get('request_stack')->getCurrentRequest()->getClientIp();
+        $checkIps = $this->container->getParameter('enable_place_local_ip_address_check');
+        $ips = $this->container->getParameter('place_local_ip_address');
+        $ips = explode(',', $ips);
+
+        return (isset($checkIps) and !$checkIps) or (isset($ip) and in_array($ip, $ips));
+    }
+}

--- a/src/AppBundle/Helper/PlaceIP.php
+++ b/src/AppBundle/Helper/PlaceIP.php
@@ -12,13 +12,27 @@ class PlaceIP {
         $this->container = $container;
     }
 
+    /**
+     * If enable_place_local_ip_address_check is true & place_local_ip_address is set
+     * Then we check the client's IP against the IP list
+     */
     public function isLocationOk()
     {
-        $ip = $this->container->get('request_stack')->getCurrentRequest()->getClientIp();
         $checkIps = $this->container->getParameter('enable_place_local_ip_address_check');
-        $ips = $this->container->getParameter('place_local_ip_address');
-        $ips = explode(',', $ips);
 
-        return (isset($checkIps) and !$checkIps) or (isset($ip) and in_array($ip, $ips));
+        if (isset($checkIps) and $checkIps) {
+            $whitelist_ips = $this->container->getParameter('place_local_ip_address');
+            $whitelist_ips = explode(',', $whitelist_ips);
+            $current_ip = $this->container->get('request_stack')->getCurrentRequest()->getClientIp();
+
+            $current_ip_in_whitelist_ips = array_filter($whitelist_ips, function($whitelist_ip) use ($current_ip) {
+                return str_starts_with($current_ip, $whitelist_ip);
+            });
+            if (count($current_ip_in_whitelist_ips)) {
+                return True;
+            }
+        }
+
+        return False;
     }
 }

--- a/src/AppBundle/Security/CodeVoter.php
+++ b/src/AppBundle/Security/CodeVoter.php
@@ -99,7 +99,7 @@ class CodeVoter extends Voter
         $now = new \DateTime('now');
         if ($this->canView($code, $user)) { //can add only if last code can be seen
             if ($code->getRegistrar() != $user || $code->getCreatedAt()->format('Y m d') != ($now->format('Y m d'))) { // on ne change pas son propre code
-                if ($this->isLocationOk()) { // et si l'utilisateur est physiquement à l'épicerie
+                if ($this->container->get(PlaceIP::class)->isLocationOk()) { // et si l'utilisateur est physiquement à l'épicerie
                     return true;
                 }
             }
@@ -144,15 +144,5 @@ class CodeVoter extends Voter
     private function canDelete(Code $code, User $user)
     {
         return false;
-    }
-
-    //\AppBundle\Security\UserVoter::isLocationOk DUPLICATED
-    private function isLocationOk()
-    {
-        $ip = $this->container->get('request_stack')->getCurrentRequest()->getClientIp();
-        $checkIps = $this->container->getParameter('enable_place_local_ip_address_check');
-        $ips = $this->container->getParameter('place_local_ip_address');
-        $ips = explode(',', $ips);
-        return (isset($checkIps) and !$checkIps) or (isset($ip) and in_array($ip, $ips));
     }
 }

--- a/src/AppBundle/Security/CodeVoter.php
+++ b/src/AppBundle/Security/CodeVoter.php
@@ -4,6 +4,7 @@ namespace AppBundle\Security;
 
 use AppBundle\Entity\Code;
 use AppBundle\Entity\User;
+use AppBundle\Helper\PlaceIP;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;

--- a/src/AppBundle/Security/MembershipVoter.php
+++ b/src/AppBundle/Security/MembershipVoter.php
@@ -96,7 +96,7 @@ class MembershipVoter extends Voter
             case self::ACCESS_TOOLS:
             case self::BENEFICIARY_ADD:
             case self::CREATE:
-                return $this->isLocationOk();
+                return $this->container->get(PlaceIP::class)->isLocationOk();
             case self::VIEW:
             case self::ANNOTATE:
                 return $this->canView($subject, $token);
@@ -156,15 +156,5 @@ class MembershipVoter extends Voter
         }
 
         return false;
-
-    }
-
-    private function isLocationOk()
-    {
-        $ip = $this->container->get('request_stack')->getCurrentRequest()->getClientIp();
-        $checkIps = $this->container->getParameter('enable_place_local_ip_address_check');
-        $ips = $this->container->getParameter('place_local_ip_address');
-        $ips = explode(',', $ips);
-        return (isset($checkIps) and !$checkIps) or (isset($ip) and in_array($ip, $ips));
     }
 }

--- a/src/AppBundle/Security/MembershipVoter.php
+++ b/src/AppBundle/Security/MembershipVoter.php
@@ -4,6 +4,7 @@ namespace AppBundle\Security;
 
 use AppBundle\Entity\Membership;
 use AppBundle\Entity\User;
+use AppBundle\Helper\PlaceIP;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;


### PR DESCRIPTION
### Quoi ?

La badgeuse se connecte à l'espace membre sans compte grâce aux paramètres `enable_place_local_ip_address_check` & `place_local_ip_address`

Actuellement à l'elefan l'IP change régulièrement car nous avons internet via une box 4G.

J'ai donc ajouté la possibilité de définir des IP en vérifiant que l'IP actuelle "commence par" au lieu de "est exactement égale"