### PR TITLE
Formulaires : ordre alphabétique pour les choix de certains champs (Formations, Commissions)

### DIFF
--- a/src/AppBundle/Form/BeneficiaryType.php
+++ b/src/AppBundle/Form/BeneficiaryType.php
@@ -5,6 +5,8 @@ namespace AppBundle\Form;
 use AppBundle\Entity\Beneficiary;
 use AppBundle\Entity\User;
 use AppBundle\EventListener\BeneficiaryInitializationSubscriber;
+use AppBundle\Repository\CommissionRepository;
+use AppBundle\Repository\FormationRepository;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
@@ -88,7 +90,11 @@ class BeneficiaryType extends AbstractType
                     'choice_label' => 'name',
                     'multiple' => true,
                     'required' => false,
-                    'label' => 'Formation(s)'
+                    'label' => 'Formation(s)',
+                    'query_builder' => function(FormationRepository $repository) {
+                        $qb = $repository->createQueryBuilder('f');
+                        return $qb->orderBy('f.name', 'ASC');
+                    }
                 ));
             } else if (is_object($user) && ($user->getBeneficiary() && count($user->getBeneficiary()->getOwnedCommissions()))) {
                 $form->add('commissions', EntityType::class, array(
@@ -97,7 +103,11 @@ class BeneficiaryType extends AbstractType
                     'choice_label' => 'name',
                     'multiple' => true,
                     'required' => true,
-                    'label' => 'Commission(s) / College(s)'
+                    'label' => 'Commission(s) / College(s)',
+                    'query_builder' => function(CommissionRepository $repository) {
+                        $qb = $repository->createQueryBuilder('c');
+                        return $qb->orderBy('c.name', 'ASC');
+                    }
                 ));
             }
         });

--- a/src/AppBundle/Service/SearchUserFormHelper.php
+++ b/src/AppBundle/Service/SearchUserFormHelper.php
@@ -2,6 +2,8 @@
 //DependencyInjection/SearchUserFormHelper.php
 namespace AppBundle\Service;
 
+use AppBundle\Repository\CommissionRepository;
+use AppBundle\Repository\FormationRepository;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\QueryBuilder;
@@ -230,7 +232,11 @@ class SearchUserFormHelper
                 'choice_label' => 'name',
                 'multiple' => true,
                 'required' => false,
-                'label'=>'Avec le(s) formations(s)'
+                'label' =>'Avec le(s) formations(s)',
+                'query_builder' => function(FormationRepository $repository) {
+                    $qb = $repository->createQueryBuilder('f');
+                    return $qb->orderBy('f.name', 'ASC');
+                }
             ])
             ->add('or_and_exp_formations', ChoiceType::class, [
                 'label' => 'Toutes ?',
@@ -245,21 +251,33 @@ class SearchUserFormHelper
                 'choice_label' => 'name',
                 'multiple' => true,
                 'required' => false,
-                'label'=>'Dans la/les commissions(s)'
+                'label'=>'Dans la/les commissions(s)',
+                'query_builder' => function(CommissionRepository $repository) {
+                    $qb = $repository->createQueryBuilder('c');
+                    return $qb->orderBy('c.name', 'ASC');
+                }
             ])
             ->add('not_formations', EntityType::class, [
                 'class' => 'AppBundle:Formation',
                 'choice_label' => 'name',
                 'multiple' => true,
                 'required' => false,
-                'label'=>'Sans le(s) formations(s)'
+                'label'=>'Sans le(s) formations(s)',
+                'query_builder' => function(FormationRepository $repository) {
+                    $qb = $repository->createQueryBuilder('f');
+                    return $qb->orderBy('f.name', 'ASC');
+                }
             ])
             ->add('not_commissions', EntityType::class, [
                 'class' => 'AppBundle:Commission',
                 'choice_label' => 'name',
                 'multiple' => true,
                 'required' => false,
-                'label'=>'Hors de la/les commissions(s)'
+                'label'=>'Hors de la/les commissions(s)',
+                'query_builder' => function(CommissionRepository $repository) {
+                    $qb = $repository->createQueryBuilder('c');
+                    return $qb->orderBy('c.name', 'ASC');
+                }
             ]);
         }
         $formBuilder->add('action', HiddenType::class, [


### PR DESCRIPTION
### Quoi ?

Actuellement sur certains formulaires les champs FK ne sont pas nécessairement ordonnés par nom (mais c'est le cas déjà pour d'autres). Ce qui peut être fastidieux pour retrouver une valeur.

### Capture d'écran

|Page|Avant|Après|
|---|---|---|
|Admin > Gérer les membres|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/9ddbb317-f34b-4dbf-8607-3a79aa2bdff5)|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/69f75be5-8d56-4ac2-a169-b30067c74bcb)|
|Beneficiary edit|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/ebdc280c-e44f-4e8f-9a68-46bc54ef44ab)|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/5e94b037-eb15-4073-911f-a062ed47c52c)|