### PR TITLE
Tableaux : généraliser l'ajout des id des objets

### DIFF
--- a/app/Resources/views/Profile/show_content.html.twig
+++ b/app/Resources/views/Profile/show_content.html.twig
@@ -113,7 +113,7 @@
                         </thead>
                         <tbody>
                         {% for client in app.user.clients %}
-                            <tr>
+                            <tr id="client_{{ client.id }}">
                                 <td>
                                     {% if client.service.logo %}
                                         <img src="{{ asset(vich_uploader_asset(client.service, 'logoFile')) | imagine_filter('service_logo') }}"

--- a/app/Resources/views/admin/closingexception/_partial/table.html.twig
+++ b/app/Resources/views/admin/closingexception/_partial/table.html.twig
@@ -12,7 +12,7 @@
     </thead>
     <tbody>
         {% for closingException in closingExceptions %}
-            <tr>
+            <tr id="closingexception_{{ closingException.id }}">
                 <td>{{ closingException.date | date_fr_full }}</td>
                 <td>{{ closingException.reason }}</td>
                 <td>

--- a/app/Resources/views/admin/commission/list.html.twig
+++ b/app/Resources/views/admin/commission/list.html.twig
@@ -14,7 +14,7 @@
     <div class="row">
         {% for commission in commissions %}
             <div class="col s12 m6">
-                <div class="card blue-grey darken-2 small">
+                <div id="commission_{{ commission.id }}" class="card blue-grey darken-2 small">
                     <div class="card-content white-text">
                         <span class="card-title">{{ commission.name }} <span class="chip right deep-purple lighten-5">x{{ commission.beneficiaries | length }}<i class="material-icons tiny left">person</i></span></span>
                         {{ commission.description | markdown | raw }}

--- a/app/Resources/views/admin/event/_partial/table.html.twig
+++ b/app/Resources/views/admin/event/_partial/table.html.twig
@@ -17,7 +17,7 @@
     </thead>
     <tbody>
         {% for event in events %}
-            <tr>
+            <tr id="event_{{ event.id }}">
                 <td>
                     {{ event.title }}
                     {% if event.displayedHome %}⭐️{% endif %}

--- a/app/Resources/views/admin/event/kind/list.html.twig
+++ b/app/Resources/views/admin/event/kind/list.html.twig
@@ -21,7 +21,7 @@
     </thead>
     <tbody>
         {% for eventKind in eventKinds %}
-            <tr>
+            <tr id="eventkind_{{ eventKind.id }}">
                 <td class="{{ eventKind.name }}">{{ eventKind.name }}</td>
                 <td>{{ eventKind.events | length }}</td>
                 <td>

--- a/app/Resources/views/admin/event/proxy/list.html.twig
+++ b/app/Resources/views/admin/event/proxy/list.html.twig
@@ -47,7 +47,7 @@
 
         <tbody>
             {% for proxy in proxies %}
-                <tr>
+                <tr id="proxy_{{ proxy.id }}">
                     {% if not event %}
                         <td>
                             {% if proxy.event %}

--- a/app/Resources/views/admin/formation/list.html.twig
+++ b/app/Resources/views/admin/formation/list.html.twig
@@ -24,7 +24,7 @@
         </thead>
         <tbody>
             {% for formation in formations %}
-                <tr>
+                <tr id="formation_{{ formation.id }}">
                     <td>{{ formation.name }}</td>
                     <td class="center-align">
                         {% if formation.description is not empty %}

--- a/app/Resources/views/admin/helloasso/browser.html.twig
+++ b/app/Resources/views/admin/helloasso/browser.html.twig
@@ -54,7 +54,7 @@
             </thead>
             <tbody>
             {% for payment in payments %}
-                <tr>
+                <tr id="helloassopayment_{{ payment.id }}">
                     <td>{{ payment.id }}</td>
                     <td>{{ payment.date }}</td>
                     <td>{{ payment.amount }}</td>

--- a/app/Resources/views/admin/helloasso/payments.html.twig
+++ b/app/Resources/views/admin/helloasso/payments.html.twig
@@ -27,7 +27,7 @@
         </thead>
         <tbody>
             {% for payment in payments %}
-                <tr class="{% if payment.registration and payment.registration.membership  %}teal{% else %}red{% endif %} lighten-5">
+                <tr id="helloasso_{{ payment.id }}" class="{% if payment.registration and payment.registration.membership  %}teal{% else %}red{% endif %} lighten-5">
                     <td>{{ payment.id }}</td>
                     <td><span class="{% if campaigns[payment.campaignId].url != helloasso_registration_campaign_url  %}red-text{% else %}green-text{% endif %}">{{ campaigns[payment.campaignId].name }}</span><br>({{ payment.paymentId }})</td>
                     <td title="reçu le {{ payment.createdAt | date_fr_full_with_time }}">{{ payment.date | date_short }}</td>

--- a/app/Resources/views/admin/job/list.html.twig
+++ b/app/Resources/views/admin/job/list.html.twig
@@ -46,7 +46,7 @@
         </thead>
         <tbody>
             {% for job in jobs %}
-                <tr>
+                <tr id="job_{{ job.id }}">
                     <td {% if not job.enabled %}style="text-decoration: line-through"{% endif %}>{{ job.name }}</td>
                     <td class="{{ job.color }} white-text">{{ job.color }}</td>
                     <td class="center-align">

--- a/app/Resources/views/admin/mail/template/list.html.twig
+++ b/app/Resources/views/admin/mail/template/list.html.twig
@@ -13,7 +13,7 @@
 
     <div class="row">
         {% for emailTemplate in emailTemplates %}
-            <div class="col s12 m4">
+            <div id="emailtemplate_{{ emailTemplate.id }}" class="col s12 m4">
                 <div class="card blue-grey darken-1">
                     <div class="card-content white-text">
                         <span class="card-title"><i class="material-icons left">content_paste</i>{{ emailTemplate.name }}</span>

--- a/app/Resources/views/admin/membershipshiftexemption/index.html.twig
+++ b/app/Resources/views/admin/membershipshiftexemption/index.html.twig
@@ -55,7 +55,7 @@
         </thead>
         <tbody>
         {% for membershipShiftExemption in membershipShiftExemptions %}
-            <tr class="{% if membershipShiftExemption.isPast() %}grey lighten-2{% elseif membershipShiftExemption.isCurrent() %}exempted{% endif %}">
+            <tr id="membershipshiftexemption_{{ membershipShiftExemption.id }}" class="{% if membershipShiftExemption.isPast() %}grey lighten-2{% elseif membershipShiftExemption.isCurrent() %}exempted{% endif %}">
                 <td>
                     {% if membershipShiftExemption.isPast() %}
                         <i class="material-icons" title="Passé">close</i>

--- a/app/Resources/views/admin/openinghour/index.html.twig
+++ b/app/Resources/views/admin/openinghour/index.html.twig
@@ -45,7 +45,7 @@
     </thead>
     <tbody>
     {% for openingHour in openingHours %}
-        <tr>
+        <tr id="openinghour_{{ openingHour.id }}">
             <td>{{ openingHour.dayOfWeekString | capitalize }}</td>
             {% if openingHour.closed %}
                 <td colspan="2">Fermé</td>

--- a/app/Resources/views/admin/openinghour/kind/list.html.twig
+++ b/app/Resources/views/admin/openinghour/kind/list.html.twig
@@ -23,7 +23,7 @@
     </thead>
     <tbody>
         {% for openingHourKind in openingHourKinds %}
-            <tr class="{% if not openingHourKind.enabled %}grey lighten-2{% endif %}">
+            <tr id="openinghourkind_{{ openingHourKind.id }}" class="{% if not openingHourKind.enabled %}grey lighten-2{% endif %}">
                 <td>
                     {% if not openingHourKind.enabled %}
                         <i class="material-icons" title="Inactif">close</i>

--- a/app/Resources/views/admin/periodposition/_partial/edit_collapsible.html.twig
+++ b/app/Resources/views/admin/periodposition/_partial/edit_collapsible.html.twig
@@ -1,5 +1,5 @@
 
-<li id="position{{ position.id }}">
+<li id="position_{{ position.id }}">
     <div class="collapsible-header">
         <div class="row" style="margin-bottom: 0; width: 100%;">
             <div class="col s12">

--- a/app/Resources/views/admin/pre_user/list.html.twig
+++ b/app/Resources/views/admin/pre_user/list.html.twig
@@ -36,7 +36,7 @@
 
         <tbody>
         {% for anonymousBeneficiary in anonymousBeneficiaries %}
-            <tr class="{% if app.user.id == anonymousBeneficiary.registrar.id %}myself{% endif %}">
+            <tr id="anonymousbeneficiary_{{ anonymousBeneficiary.id }}" class="{% if app.user.id == anonymousBeneficiary.registrar.id %}myself{% endif %}">
                 <td>{{ anonymousBeneficiary.createdAt | date_time }}</td>
                 <td>{{ anonymousBeneficiary.email }}</td>
                 <td>

--- a/app/Resources/views/admin/service/list.html.twig
+++ b/app/Resources/views/admin/service/list.html.twig
@@ -25,7 +25,7 @@
         </thead>
         <tbody>
         {% for service in services %}
-            <tr>
+            <tr id="service_{{ service.id }}">
                 <td>
                     {% if service.logo %}
                         <img src="{{ service|img('logoFile','service_logo') }}" />

--- a/app/Resources/views/admin/shiftexemption/index.html.twig
+++ b/app/Resources/views/admin/shiftexemption/index.html.twig
@@ -22,7 +22,7 @@
 
         <tbody>
         {% for shiftExemption in shiftExemptions %}
-            <tr>
+            <tr id="shiftexemption_{{ shiftExemption.id }}">
                 <td>{{ shiftExemption.name }}</td>
                 <td>{{ shiftExemption.membershipShiftExemptions | length }}</td>
                 <td>

--- a/app/Resources/views/admin/socialnetwork/list.html.twig
+++ b/app/Resources/views/admin/socialnetwork/list.html.twig
@@ -23,7 +23,7 @@
         </thead>
         <tbody>
         {% for socialNetwork in socialNetworks %}
-            <tr>
+            <tr id="socialnetwork_{{ socialNetwork.id }}">
                 <td>{{ socialNetwork.name }}</td>
                 <td class="center-align">
                     {% if socialNetwork.description is not empty %}

--- a/app/Resources/views/admin/user/admin_list.html.twig
+++ b/app/Resources/views/admin/user/admin_list.html.twig
@@ -25,7 +25,7 @@
         </thead>
         <tbody>
             {% for admin in admins %}
-                <tr>
+                <tr id="user_{{ admin.id }}">
                     <td>
                         {% if admin.beneficiary and admin.beneficiary.membership.withdrawn %}
                             <i class="material-icons" title="Compte fermé">{{ member_withdrawn_material_icon }}</i>

--- a/app/Resources/views/admin/user/list.html.twig
+++ b/app/Resources/views/admin/user/list.html.twig
@@ -252,7 +252,7 @@
         <tbody>
         {% for member in members %}
             {% if member.mainBeneficiary %}
-                <tr data-url="{{ path('member_show', { 'member_number': member.memberNumber }) }}" class="{% if member.withdrawn %}withdrawn{% elseif member.frozen %}frozen{% elseif member.isCurrentlyExemptedFromShifts() %}exempted{% endif %}">
+                <tr id="member_{{ member.id }}" data-url="{{ path('member_show', { 'member_number': member.memberNumber }) }}" class="{% if member.withdrawn %}withdrawn{% elseif member.frozen %}frozen{% elseif member.isCurrentlyExemptedFromShifts() %}exempted{% endif %}">
                     <td class="hide-on-med-and-down">
                         {% include "admin/member/_partial/status_icons.html.twig" with { member: member } %}
                     </td>
@@ -312,7 +312,7 @@
                     </td>
                 </tr>
             {% else %}
-                <tr data-url="{{ path('member_show', { 'member_number': member.memberNumber }) }}" class="{% if member.withdrawn %}withdrawn{% endif %} {% if member.frozen %}frozen{% endif %}">
+                <tr id="member_{{ member.id }}" data-url="{{ path('member_show', { 'member_number': member.memberNumber }) }}" class="{% if member.withdrawn %}withdrawn{% endif %} {% if member.frozen %}frozen{% endif %}">
                     <td colspan="9">{{ member }}</td>
                 </tr>
             {% endif %}

--- a/app/Resources/views/admin/user/non_member_list.html.twig
+++ b/app/Resources/views/admin/user/non_member_list.html.twig
@@ -22,7 +22,7 @@
         </thead>
         <tbody>
             {% for non_member in non_members %}
-                <tr>
+                <tr id="user_{{ non_member.id }}">
                     <td>
                         {% if not non_member.enabled %}
                             <i class="material-icons" title="Utilisateur désactivé">{{ member_withdrawn_material_icon }}</i>

--- a/app/Resources/views/ambassador/phone/list.html.twig
+++ b/app/Resources/views/ambassador/phone/list.html.twig
@@ -155,7 +155,7 @@
         </thead>
         <tbody>
         {% for member in members %}
-            <tr class="{% if member.withdrawn %}withdrawn{% elseif member.frozen %}frozen{% elseif member.isCurrentlyExemptedFromShifts() %}exempted{% endif %}">
+            <tr id="member_{{ member.id }}" class="{% if member.withdrawn %}withdrawn{% elseif member.frozen %}frozen{% elseif member.isCurrentlyExemptedFromShifts() %}exempted{% endif %}">
                 <td class="hide-on-med-and-down">
                     {% include "admin/member/_partial/status_icons.html.twig" with { member: member } %}
                 </td>

--- a/app/Resources/views/beneficiary/_partial/beneficiary_card.html.twig
+++ b/app/Resources/views/beneficiary/_partial/beneficiary_card.html.twig
@@ -1,5 +1,5 @@
 <div class="col s12 m6 l6 xl6">
-    <div class="card">
+    <div id="beneficiary_{{ beneficiary.id }}" class="card">
         <div class="card-content">
             {% include "beneficiary/_partial/info.html.twig" with { beneficiary: beneficiary } %}
         </div>

--- a/app/Resources/views/default/code/_list.html.twig
+++ b/app/Resources/views/default/code/_list.html.twig
@@ -25,7 +25,7 @@
             <tbody>
             {% for code in codes %}
                 {% if is_granted("view", code) %}
-                    <tr>
+                    <tr id="code_{{ code.id }}">
                         <td>
                             {% if code.closed %}<del>{% endif %}
                             <b>{{ code.value }}</b>
@@ -50,7 +50,7 @@
                         </td>
                     </tr>
                 {% else %}
-                    <tr>
+                    <tr id="code_{{ code.id }}">
                         <td>
                             {% if code.closed %}<del>{% endif %}
                             <b>XXXX</b>
@@ -93,7 +93,7 @@
             <tbody>
             {% for code in old_codes %}
                 {% if is_granted("view",code)  %}
-                    <tr>
+                    <tr id="code_{{ code.id }}">
                         <td>
                             {% if code.closed %}<del>{% endif %}
                             <b>{{ code.value }}</b>

--- a/app/Resources/views/default/task/list.html.twig
+++ b/app/Resources/views/default/task/list.html.twig
@@ -29,7 +29,7 @@
                     </thead>
                     <tbody>
                         {% for task in commission.tasks %}
-                            <tr>
+                            <tr id="task_{{ task.id }}">
                                 <td>{% if task.closed %}<del>{% endif %}
                                     {{ task.title }}
                                     {% if task.closed %}</del>{% endif %}

--- a/app/Resources/views/member/_partial/period_position_free_logs.html.twig
+++ b/app/Resources/views/member/_partial/period_position_free_logs.html.twig
@@ -20,7 +20,7 @@
 
         <tbody>
         {% for periodPositionFreeLog in periodPositionFreeLogs %}
-            <tr>
+            <tr id="periodpositionfreelog_{{ periodPositionFreeLog.id }}">
                 <td title="{{ periodPositionFreeLog.createdAt | date_fr_full_with_time }}">
                     {{ periodPositionFreeLog.createdAt | date_short }}
                 </td>

--- a/app/Resources/views/member/_partial/registrations.html.twig
+++ b/app/Resources/views/member/_partial/registrations.html.twig
@@ -7,7 +7,7 @@
 {% if member.registrations | length > 0 %}
     <ul class="collapsible">
         {% for registration in member.registrations %}
-            <li>
+            <li id="registration_{{ registration.id }}">
                 <div class="collapsible-header" style="cursor: default;">
                     {% if registration.mode == constant('TYPE_CREDIT_CARD', registration) or registration.mode == constant('TYPE_HELLOASSO', registration) %}
                         <i class="material-icons tiny">credit_card</i>

--- a/app/Resources/views/member/_partial/shift_free_logs.html.twig
+++ b/app/Resources/views/member/_partial/shift_free_logs.html.twig
@@ -23,7 +23,7 @@
         </thead>
         <tbody>
             {% for shiftFreeLog in shiftFreeLogs %}
-                <tr>
+                <tr id="shiftfreelog_{{ shiftFreeLog.id }}">
                     <td title="{{ shiftFreeLog.createdAt | date_fr_full_with_time }}">
                         {{ shiftFreeLog.createdAt | date_short }}
                     </td>

--- a/app/Resources/views/process/_partial/line.html.twig
+++ b/app/Resources/views/process/_partial/line.html.twig
@@ -1,4 +1,4 @@
-<tr class="{% if check_date < processUpdate.date %}new {% else %}{% endif %}">
+<tr id="processupdate_{{ processUpdate.id }}" class="{% if check_date < processUpdate.date %}new {% else %}{% endif %}">
     <td>
         <i class="material-icons left">content_paste</i><a href="#view_{{ processUpdate.id }}" class="modal-trigger" title="Détails">{{ processUpdate.date | date_fr_full_with_time }}</a>
     </td>

--- a/app/Resources/views/swipeCard/_partial/image.html.twig
+++ b/app/Resources/views/swipeCard/_partial/image.html.twig
@@ -1,5 +1,5 @@
 {% set with_badge_card = with_badge_card ?? false %}
 
-<div {% if with_badge_card %}class="badge_card"{% endif %}>
+<div id="swipecard_{{ card.id }}" {% if with_badge_card %}class="badge_card"{% endif %}>
     <img src="{{ absolute_url(path('swipe_br', {"code": card.code | vigenere_encode | url_encode})) }}" alt="barcode">
 </div>

--- a/app/Resources/views/swipeCard/_partial/list.html.twig
+++ b/app/Resources/views/swipeCard/_partial/list.html.twig
@@ -29,18 +29,17 @@
     </div>
     <table class="hide-on-small-only">
         <thead>
-        <tr>
-            <th>Badge n°</th>
-            <th>Code</th>
-            <th>Date d'association</th>
-            <th>Date de désactivation</th>
-            <th>Actions</th>
-        </tr>
+            <tr>
+                <th>Badge n°</th>
+                <th>Code</th>
+                <th>Date d'association</th>
+                <th>Date de désactivation</th>
+                <th>Actions</th>
+            </tr>
         </thead>
-
         <tbody>
         {% for swipeCard in swipeCards %}
-            <tr>
+            <tr id="swipecard_{{ swipecard.id }}">
                 <td>{{ swipeCard.number }}</td>
                 <td>
                     {% include "swipeCard/_partial/image.html.twig" with { card: swipeCard } %}

--- a/app/Resources/views/swipeCard/_partial/list.html.twig
+++ b/app/Resources/views/swipeCard/_partial/list.html.twig
@@ -39,7 +39,7 @@
         </thead>
         <tbody>
         {% for swipeCard in swipeCards %}
-            <tr id="swipecard_{{ swipecard.id }}">
+            <tr id="swipecard_{{ swipeCard.id }}">
                 <td>{{ swipeCard.number }}</td>
                 <td>
                     {% include "swipeCard/_partial/image.html.twig" with { card: swipeCard } %}

--- a/app/Resources/views/timelog/_partial/table.html.twig
+++ b/app/Resources/views/timelog/_partial/table.html.twig
@@ -20,7 +20,7 @@
     </thead>
     <tbody>
         {% for timeLog in timeLogs %}
-            <tr id="{{ timeLog.id }}" class="{% if timeLog.type == 20 %}blue{% elseif timeLog.time > 0 %}green{% elseif timeLog.time < 0 %}red{% else %}grey{% endif %} lighten-5">
+            <tr id="timelog_{{ timeLog.id }}" class="{% if timeLog.type == 20 %}blue{% elseif timeLog.time > 0 %}green{% elseif timeLog.time < 0 %}red{% else %}grey{% endif %} lighten-5">
                 <td title="{{ timeLog.createdAt | date_fr_full_with_time }}">
                     {{ timeLog.createdAt | date_short }}
                     {% if timeLog.createdAt > date() %}<span>(futur)</span>{% endif %}

--- a/app/Resources/views/user/_partial/note.html.twig
+++ b/app/Resources/views/user/_partial/note.html.twig
@@ -1,5 +1,5 @@
 
-<div class="card-panel {% if note.parent %}grey lighten-4{% else %}grey lighten-5{% endif %} z-depth-1 note">
+<div id="note_{{ note.id }}" class="card-panel {% if note.parent %}grey lighten-4{% else %}grey lighten-5{% endif %} z-depth-1 note">
     <div class="row valign-wrapper" style="margin-bottom: 0;">
         <div class="col s2">
             <img src="{{ gravatar(note.author.email) }}" alt="" class="circle responsive-img">

--- a/app/Resources/views/user/_partial/period_position_card.html.twig
+++ b/app/Resources/views/user/_partial/period_position_card.html.twig
@@ -1,4 +1,4 @@
-<div class="card center">
+<div id="periodposition_{{ period_position.id }}" class="card center">
     <div class="card-content">
         <span class="card-title">
             {{ period_position.period.dayOfWeekString }} de {{ period_position.period.start | date('G\\hi') }} à {{ period_position.period.end | date('G\\hi') }}

--- a/app/Resources/views/user/_partial/shift_card.html.twig
+++ b/app/Resources/views/user/_partial/shift_card.html.twig
@@ -1,6 +1,6 @@
 {% set shift_member = shift.shifter.membership %}
 
-<div class="card center {% if (shift.isCurrent) %}deep-purple white-text{% elseif (shift.isPast) %}grey lighten-2{% else %}cyan darken-4 white-text{% endif %}">
+<div id="shift_{{ shift.id }}" class="card center {% if (shift.isCurrent) %}deep-purple white-text{% elseif (shift.isPast) %}grey lighten-2{% else %}cyan darken-4 white-text{% endif %}">
     <div class="card-content">
         {% include "user/_partial/shift_card_header.html.twig" with { shift: shift } %}
     </div>

--- a/src/AppBundle/Controller/DynamicContentController.php
+++ b/src/AppBundle/Controller/DynamicContentController.php
@@ -16,16 +16,6 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
  */
 class DynamicContentController extends Controller
 {
-    private $_current_app_user;
-
-    public function getCurrentAppUser()
-    {
-        if (!$this->_current_app_user) {
-            $this->_current_app_user = $this->get('security.token_storage')->getToken()->getUser();
-        }
-        return $this->_current_app_user;
-    }
-
     /**
      * Lists all dynamic contents.
      *
@@ -83,5 +73,4 @@ class DynamicContentController extends Controller
             'form' => $form->createView()
         ));
     }
-
 }

--- a/src/AppBundle/Entity/DynamicContent.php
+++ b/src/AppBundle/Entity/DynamicContent.php
@@ -239,13 +239,14 @@ class DynamicContent
     /**
      * Set createdBy
      *
-     * @param \AppBundle\Entity\User $createBy
+     * @param \AppBundle\Entity\User $user
      *
      * @return DynamicContent
      */
     public function setCreatedBy(\AppBundle\Entity\User $user = null)
     {
         $this->createdBy = $user;
+
         return $this;
     }
 
@@ -272,7 +273,7 @@ class DynamicContent
     /**
      * Set updatedBy
      *
-     * @param \AppBundle\Entity\User $createBy
+     * @param \AppBundle\Entity\User $user
      *
      * @return DynamicContent
      */


### PR DESCRIPTION
### Quoi ?

Lorsqu'on affiche un tableau, on a souvent pas mal d'info sur l'objet (par exemple timelog type / created_at / ...), mais pas son id.

Or si on fait des manip en SQL (rares...), c'est plus d'avoir cette info.

On l'avait déjà en place à certains endroits, j'ai généralisé sa présence. `<tr id=timelog_{{ timelog.id }}`