### PR TITLE
Mieux afficher le contenu texte

### DIFF
--- a/app/Resources/FOSUserBundle/views/Resetting/check_email.html.twig
+++ b/app/Resources/FOSUserBundle/views/Resetting/check_email.html.twig
@@ -4,6 +4,6 @@
 
 {% block fos_user_content %}
 <p>
-{{ 'resetting.check_email'|trans({'%tokenLifetime%': tokenLifetime})|nl2br }}
+{{ 'resetting.check_email' | trans({'%tokenLifetime%': tokenLifetime}) | nl2br }}
 </p>
 {% endblock %}

--- a/app/Resources/views/admin/commission/list.html.twig
+++ b/app/Resources/views/admin/commission/list.html.twig
@@ -17,7 +17,7 @@
                 <div class="card blue-grey darken-2 small">
                     <div class="card-content white-text">
                         <span class="card-title">{{ commission.name }} <span class="chip right deep-purple lighten-5">x{{ commission.beneficiaries | length }}<i class="material-icons tiny left">person</i></span></span>
-                        {{ commission.description | markdown | raw }}
+                        {{ commission.description | nl2br | markdown | raw }}
                     </div>
                     <div class="card-action">
                         <a href="{{ path("commission_edit",{'id':commission.id}) }}"><i class="material-icons left">edit</i></a>

--- a/app/Resources/views/admin/event/_partial/card_content.html.twig
+++ b/app/Resources/views/admin/event/_partial/card_content.html.twig
@@ -30,6 +30,6 @@
     {% endif %}
     {% if not only_header %}
         <br />
-        {{ event.description | markdown | raw }}
+        {{ event.description | nl2br | markdown | raw }}
     {% endif %}
 </div>

--- a/app/Resources/views/booking/index.html.twig
+++ b/app/Resources/views/booking/index.html.twig
@@ -56,7 +56,7 @@
                             </li>
                             <li class="row">
                                 {% for job in jobs %}
-                                    <div class="col s12 m4 {% if job.description is not empty %}legend_job {% endif %}" data-description="{{ job.description | markdown | raw }}">
+                                    <div class="col s12 m4 {% if job.description is not empty %}legend_job {% endif %}" data-description="{{ job.description | nl2br | markdown | raw }}">
                                         <div class="{{ job.color }} z-depth-1 lighten-5 valign-wrapper" style="padding: 3px;margin:5px">
                                             <p>{{ job.name }}</p>
                                         </div>

--- a/app/Resources/views/default/tools/_postit.html.twig
+++ b/app/Resources/views/default/tools/_postit.html.twig
@@ -8,7 +8,7 @@
             <a href="#post-it_edit{{ note.id }}" class="black-text modal-trigger settings"><i class="material-icons tiny">settings</i></a>
             <div class="box">
                 <div class="content black-text">
-                    {{ note.textWithBr  | markdown | raw }}
+                    {{ note.text | nl2br | markdown | raw }}
                 </div>
             </div>
             {#<img src="{{ gravatar(note.author.email) }}" alt="" class="circle responsive-img" width="30px">#}
@@ -31,7 +31,7 @@
             </h6>
             <div class="content black-text">
                 <p>
-                    {{ child.textWithBr  | markdown | raw }}
+                    {{ child.text | nl2br | markdown | raw }}
                 </p>
             </div>
                 {{ form_start(note_delete_forms[child.id], {'attr': {'id': 'form_note_delete_'~child.id }}) }}

--- a/app/Resources/views/emails/coshifter_message.html.twig
+++ b/app/Resources/views/emails/coshifter_message.html.twig
@@ -1,7 +1,7 @@
 Bonjour {{ firstnames | join(', ') }},<br /></br>
 <strong>{{ shift.shifter.firstname|lower|capitalize }} {{ shift.shifter.lastname|first|upper }}</strong> t'a envoyé un message à propos du créneau {{ shift.job.name }} du {{ shift.displayDateLongWithTime }}.<br />
 <blockquote>
-    {{ message |nl2br }}
+    {{ message | nl2br }}
 </blockquote>
 <br />
 Tu peux lui répondre en répondant directement à cet email.<br /><br />

--- a/app/Resources/views/event/detail.html.twig
+++ b/app/Resources/views/event/detail.html.twig
@@ -15,7 +15,7 @@
 
 {% if event.description %}
     <div class="card-panel blue lighten-5">
-        {{ event.description | markdown | raw }}
+        {{ event.description | nl2br | markdown | raw }}
     </div>
 {% else %}
     <i>pas de description</i>

--- a/app/Resources/views/process/_partial/line.html.twig
+++ b/app/Resources/views/process/_partial/line.html.twig
@@ -24,7 +24,7 @@
         <div id="view_{{ processUpdate.id }}" class="modal">
             <div class="modal-content">
                 <h5>{{ processUpdate.title }}</h5>
-                {{ processUpdate.description | markdown | raw }}
+                {{ processUpdate.description | nl2br | markdown | raw }}
             </div>
             <div class="modal-footer">
                 {% if processUpdate.link %}

--- a/src/AppBundle/Entity/Note.php
+++ b/src/AppBundle/Entity/Note.php
@@ -113,11 +113,6 @@ class Note
         return $this->text;
     }
 
-    public function getTextWithBr()
-    {
-        return nl2br($this->getText());
-    }
-
     /**
      * Get createdAt
      *


### PR DESCRIPTION
### Quoi ?

On a pas mal de champs "texte libre" qui permettent que ce texte soit ensuite affiché : par exemple la description d'un événement.

Mais on doit souvent utiliser du formattage html, pour arriver à avoir les sauts de ligne, etc

Je propose d'utiliser `nl2br` à tous les endroits sauf les contenus dynamique, pour avoir rendu au plus proche du texte d'input.

### Capture d'écran

|Avant|Après|
|---|---|
|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/7df00f21-a23d-482d-a406-0d86d03e1d94)|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/b3989db4-96ce-4c47-b8bb-3be5cae313df)|