### PR TITLE
Semaine type : mieux afficher les postes avec formation

### DIFF
--- a/app/Resources/views/period/_partial/period_card.html.twig
+++ b/app/Resources/views/period/_partial/period_card.html.twig
@@ -59,7 +59,7 @@
                                 <h6>Semaine {{ week }}</h6>
                             {% endif %}
                             {% for position in positions %}
-                                {% include 'period/_partial/position_shifter_display.html.twig' with { 'position': position, 'anonymized': anonymized } %}
+                                {% include "period/_partial/position_shifter_display.html.twig" with { position: position, anonymized: anonymized } %}
                             {% endfor %}
                         {% endif %}
                     {% endfor %}

--- a/app/Resources/views/period/_partial/position_shifter_display.html.twig
+++ b/app/Resources/views/period/_partial/position_shifter_display.html.twig
@@ -5,33 +5,31 @@
 
 {% set anonymized = anonymized ?? true %}
 {% set shifter = position.shifter %}
-{% set formation = position.formation ?? "Sans formation" %}
+{% set icon = position.formation ? "account_circle" : "person" %}
+{% set tooltip_formation = position.formation ? "Formation : " ~ position.formation : "Sans formation" %}
 
-{% if shifter %}
-    {# sombody is registered for this PeriodPosition #}
-
+{% if shifter %} {# sombody is registered for this PeriodPosition #}
     {% if anonymized %}
-        {# sombody is registered for this periodposition #}
-        <div class="tooltipped truncate black-text" data-position="bottom" data-tooltip="Formation : {{ formation }}">
-            <i class="material-icons">person</i>
+        <div class="tooltipped truncate black-text" data-position="bottom" data-tooltip="{{ tooltip_formation }}">
+            <i class="material-icons">{{ icon }}</i>
             Réservé
         </div>
     {% else %}
         {% set warning = beneficiary_service.hasWarningStatus(shifter) %}
         <a href="{{ path('member_show', { 'member_number': shifter.membership.memberNumber }) }}" target="_blank"
            class="black-text tooltipped editable-box truncate" data-position="bottom"
-           data-tooltip="{{ shifter | print_with_number_and_status_icon | raw }} &#013;&#010; ({{ formation }})">
+           data-tooltip="{{ shifter | print_with_number_and_status_icon | raw }} &#013;&#010; ({{ tooltip_formation }})">
             {% if warning %}
                 <i class="red-text material-icons warning-animation">warning</i>
             {% else %}
-                <i class="material-icons">person</i>
+                <i class="material-icons">{{ icon }}</i>
             {% endif %}
             {{ shifter.getFirstname() }} {{ shifter.getLastname() | first }}
         </a>
     {% endif %}
-{% else %} {# free PeriodPosition #}
-    <div class="tooltipped truncate black-text" data-position="bottom" data-tooltip="{{ formation }}">
-        <i class="material-icons">person</i>
+{% else %} {# this PeriodPosition is free #}
+    <div class="tooltipped truncate black-text" data-position="bottom" data-tooltip="{{ tooltip_formation }}">
+        <i class="material-icons">{{ icon }}</i>
         <strong><i>Libre</i></strong>
     </div>
 {% endif %}


### PR DESCRIPTION
### Quoi ?

Dans la semaine type, on ne peut pas facilement voir les postes qui ont besoin d'une formation.

J'ai modifié l'icone (comme sur les créneaux dans le planning)

### Captures d'écran

||Avant|Après|
|---|---|---|
|Poste avec formation|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/60dacdc6-752c-4c64-9447-e6192e80618c)|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/d1c26f17-2df2-4d59-9d69-24baab4f9cda)|
|Poste sans formation (pas de changement)|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/bd189e42-3d5f-403f-839d-b830791a4874)|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/ed6a183f-f7c5-486c-b3c9-60f438fbe5f7)|