### PR TITLE
Semaine type : mieux afficher la formation nécessaire

### DIFF
--- a/app/Resources/views/admin/period/edit.html.twig
+++ b/app/Resources/views/admin/period/edit.html.twig
@@ -56,7 +56,7 @@
     <ul class="collapsible">
         <li>
             <div class="collapsible-header">
-                <i class="material-icons">add</i>Ajouter un poste
+                <i class="material-icons">add</i>Ajouter un poste type
             </div>
             <div class="collapsible-body">
                 {{ form_start(position_add_form) }}

--- a/app/Resources/views/admin/periodposition/_partial/edit_collapsible.html.twig
+++ b/app/Resources/views/admin/periodposition/_partial/edit_collapsible.html.twig
@@ -32,14 +32,14 @@
         {% if use_fly_and_fixed %}
             {% if position.shifter %}
                 <p>
-                    Créneau fixe réservé
+                    Poste type réservé
                     pour <a href="{{ path("member_show", { 'member_number': position.shifter.membership.memberNumber }) }}" target="_blank">{{ position.shifter }}</a>
                     le <i>{{ position.bookedTime | date_fr_full_with_time }}</i>
                     par {% include "admin/member/_partial/member_or_user_link.html.twig" with { user: position.booker, target_blank: true } %}.
                 </p>
                 {{ form_start(position_free_form) }}
                 {{ form_widget(position_free_form) }}
-                <a href="#" class="btn waves-effect waves-light orange" onclick="var r = confirm('Etes-vous sûr de vouloir libérer ce poste ?!'); if (r == true) {$(this).closest('form').submit();}; event.stopPropagation();" title="Libérer ce poste">
+                <a href="#" class="btn waves-effect waves-light orange" onclick="var r = confirm('Etes-vous sûr de vouloir libérer ce poste ?!'); if (r == true) {$(this).closest('form').submit();}; event.stopPropagation();" title="Libérer ce poste type">
                     <i class="material-icons left">lock_open</i>Libérer
                 </a>
                 {{ form_end(position_free_form) }}
@@ -65,12 +65,15 @@
                 <div class="row">
                     {{ form_start(position_delete_form) }}
                     {{ form_widget(position_delete_form) }}
-                    <a href="#" class="btn waves-effect waves-light red" onclick="var r = confirm('Etes-vous sûr de vouloir supprimer ce poste ?!'); if (r == true) {$(this).closest('form').submit();}; event.stopPropagation();" title="Supprimer ce poste">
+                    <a href="#" class="btn waves-effect waves-light red" onclick="var r = confirm('Etes-vous sûr de vouloir supprimer ce poste ?!'); if (r == true) {$(this).closest('form').submit();}; event.stopPropagation();" title="Supprimer ce poste type">
                         <i class="material-icons left">delete</i>Supprimer
                     </a>
                     {{ form_end(position_delete_form) }}
                 </div>
             {% endif %}
+        {% endif %}
+        {% if position.formation %}
+            <p>Ce poste type nécessite la formation <strong>{{ position.formation }}</strong>.</p>
         {% endif %}
         {% if position.createdBy %}
             <p>

--- a/src/AppBundle/Controller/AdminPeriodController.php
+++ b/src/AppBundle/Controller/AdminPeriodController.php
@@ -284,13 +284,13 @@ class AdminPeriodController extends Controller
         if ($form->isSubmitted() && $form->isValid()) {
             if ($position->getShifter()) {
                 $session->getFlashBag()->add("error", "Désolé, ce créneau est déjà réservé");
-                return new Response($this->generateUrl('admin_period_edit',array('id'=>$period->getId())), 205);
+                return $this->redirectToRoute('admin_period_edit',array('id'=>$period->getId()));
             }
 
             $beneficiary = $form->get("shifter")->getData();
             if ($position->getFormation() && !$beneficiary->getFormations()->contains($position->getFormation())) {
                 $session->getFlashBag()->add("error", "Désolé, ce bénévole n'a pas la qualification nécessaire (" . $position->getFormation()->getName() . ")");
-                return new Response($this->generateUrl('admin_period_edit',array('id'=>$period->getId())), 205);
+                return $this->redirectToRoute('admin_period_edit',array('id'=>$period->getId()));
             }
 
             if (!$position->getBooker()) {

--- a/src/AppBundle/Form/AutocompleteBeneficiaryType.php
+++ b/src/AppBundle/Form/AutocompleteBeneficiaryType.php
@@ -5,7 +5,6 @@ namespace AppBundle\Form;
 use AppBundle\Form\DataTransformer\BeneficiaryToStringTransformer;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\AbstractType;
-
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 


### PR DESCRIPTION
### Quoi ?

Dans la semaine type, certains postes peuvent nécessiter une formation.

Améliorations : 
- rajouter un message pour rappeler que le bénéficiaire doit avoir cette formation pour être inscrit
- réparé le message d'erreur si un bénéficiaire sans cette formation est tenté d'être inscrit

### Captures d'écran

||Image|
|---|---|
|use_fly_and_fixed: true|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/75a9a6d0-80c8-4327-bc7f-dc90e6812adf)|
|use_fly_and_fixed: false|![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/ba8679c7-5a8a-46e4-9da5-ec42ee4b341d)|