### PR TITLE
Evenements : widget : pouvoir filtrer sur plusieurs types d'événements

### DIFF
--- a/app/Resources/views/event/_partial/widget.html.twig
+++ b/app/Resources/views/event/_partial/widget.html.twig
@@ -3,9 +3,8 @@
 {% block content %}
 {% if title %}
     <p style="margin-top:0;">
-        liste des prochains événements
-        {% if eventKind %}<strong>{{ eventKind.name }}</strong>{% endif %}
-        {% if maxDate %}(jusqu'au {{ maxDate | date_short }}){% endif %}
+        Liste des prochains événements
+        {% if date_max %}(jusqu'au {{ date_max | date_short }}){% endif %}
     </p>
 {% endif %}
 <ul style="margin:0;">
@@ -20,7 +19,7 @@
                     <span>[en cours]</span>
                 {% endif %}
             {% endif %}
-            {# {% if not eventKind %}[{{ event.kind }}] {% endif %} #}
+            {# {% if not event_kind_id_list %}[{{ event.kind }}] {% endif %} #}
         </li>
     {% endfor %}
 </ul>

--- a/src/AppBundle/Controller/AdminEventController.php
+++ b/src/AppBundle/Controller/AdminEventController.php
@@ -431,7 +431,7 @@ class AdminEventController extends Controller
                 'label' => "Quel type d'événement ?",
                 'class' => 'AppBundle:EventKind',
                 'choice_label' => 'name',
-                'multiple' => false,
+                'multiple' => true,
                 'required' => false
             ))
             ->add('date_max', TextType::class, array(
@@ -461,8 +461,13 @@ class AdminEventController extends Controller
 
         if ($form->handleRequest($request)->isValid()) {
             $data = $form->getData();
-
-            $widgetQueryString = 'event_kind_id=' . ($data['kind'] ? $data['kind']->getId() : '') . '&date_max=' . ($data['date_max'] ? $data['date_max'] : '') . '&limit=' . ($data['limit'] ? $data['limit'] : '') . '&title=' . ($data['title'] ? 1 : 0) . '&links=' . ($data['links'] ? 1 : 0);
+            $widgetQueryString = '';
+            if ($data['kind']) {
+                foreach ($data['kind'] as $kind) {
+                    $widgetQueryString .= 'event_kind_id[]=' . $kind->getId() . '&';
+                }
+            }
+            $widgetQueryString .= 'date_max=' . ($data['date_max'] ? $data['date_max'] : '') . '&limit=' . ($data['limit'] ? $data['limit'] : '') . '&title=' . ($data['title'] ? 1 : 0) . '&links=' . ($data['links'] ? 1 : 0);
 
             return $this->render('admin/event/widget_generator.html.twig', array(
                 'form' => $form->createView(),

--- a/src/AppBundle/Repository/EventRepository.php
+++ b/src/AppBundle/Repository/EventRepository.php
@@ -17,7 +17,7 @@ class EventRepository extends \Doctrine\ORM\EntityRepository
         return $this->findBy(array(), array('date' => 'DESC'));
     }
 
-    public function findFutureOrOngoing(EventKind $eventKind = null, bool $dislayedHome = false, \DateTime $max = null, int $limit = null)
+    public function findFutureOrOngoing(array $eventKinds = null, bool $dislayedHome = false, \DateTime $max = null, int $limit = null)
     {
         $qb = $this->createQueryBuilder('e')
             ->leftJoin('e.kind', 'ek')
@@ -25,10 +25,10 @@ class EventRepository extends \Doctrine\ORM\EntityRepository
             ->where('e.date > :now OR e.date < :now AND e.end IS NOT NULL AND e.end > :now')
             ->setParameter('now', new \Datetime('now'));
 
-        if ($eventKind) {
+        if ($eventKinds) {
             $qb
-                ->andwhere('e.kind = :kind')
-                ->setParameter('kind', $eventKind);
+                ->andwhere('e.kind in (:kinds)')
+                ->setParameter('kinds', $eventKinds);
         }
 
         if ($dislayedHome) {


### PR DESCRIPTION
### Quoi ?

Actuellement on peut créer un widget d'événement - #837 - avec un filtre optionnel sur le type d'événement.

A l'Elefan on souhaite pouvoir exclure un type d'événement de la liste (les Formations), pour pouvoir les afficher séparement. 
Au lieu de gérer une "exclusion", j'ai opté pour gérer une liste multiple.

### Capture d'écran

![image](https://github.com/elefan-grenoble/gestion-compte/assets/7147385/c336eaed-c4f3-4cc6-ba26-34a65a7ee623)
