### PR TITLE
Fix Issue #1105 : Utilisation de la date du jour plutôt que de la date de premier créneau pour initier le champs BDD "membershift.first_shift_date"

### DIFF
--- a/src/AppBundle/Controller/ShiftController.php
+++ b/src/AppBundle/Controller/ShiftController.php
@@ -166,7 +166,7 @@ class ShiftController extends Controller
 
         $member = $beneficiary->getMembership();
         if ($member->getFirstShiftDate() == null) {
-            $firstDate = clone($shift->getStart());
+            $firstDate = new \DateTime('now');
             $firstDate->setTime(0, 0, 0);
             $member->setFirstShiftDate($firstDate);
             $em->persist($member);
@@ -225,7 +225,7 @@ class ShiftController extends Controller
 
                 $member = $beneficiary->getMembership();
                 if ($member->getFirstShiftDate() == null) {
-                    $firstDate = clone($shift->getStart());
+                    $firstDate = new \DateTime('now');
                     $firstDate->setTime(0, 0, 0);
                     $member->setFirstShiftDate($firstDate);
                     $em->persist($member);


### PR DESCRIPTION
Celà permet de fixer l'affichage pour les personnes qui souhaitent commencer à caler plus d'un créneau dans le temps en mode cycle personnel (non ABCD)