### PR TITLE
Fix Issue #1107 - Ne pas afficher le lien vers "création d'un nouveau compte" en mode OIDC.

### DIFF
--- a/app/Resources/views/default/index_anon.html.twig
+++ b/app/Resources/views/default/index_anon.html.twig
@@ -10,11 +10,19 @@
         <i class="material-icons left">lock_outline</i>Se connecter
     </a>
 </div>
+{% if not oidc_enable %}
 <div class="row center">
     <p class=" col s12 light"> Pas encore d'identifiant ?
         <a href="{{ path('find_me') }}" class="orange-text">Créer mon compte</a>
     </p>
 </div>
+{% else %}
+<div class="row center">
+    <p class=" col s12 light"> 
+         {{ oidc_no_account_message | raw }}.
+    </p>
+</div>
+{% endif %}
 {% include "booking/_partial/list.html.twig" with { bucketsByDay: bucketsByDay, display_names: false } %}
 {% endblock %}
 

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -153,6 +153,7 @@ twig:
     oidc_commissions_claim: "%oidc_commissions_claim%"
     oidc_commissions_map: "%oidc_commissions_map%"
     oidc_profile_custom_message: '%oidc_profile_custom_message%'
+    oidc_no_account_message: '%oidc_no_account_message%'
 # Doctrine Configuration
 doctrine:
   dbal:

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -195,6 +195,7 @@ parameters:
     # Open id client
     oidc_enable: false
     oidc_profile_custom_message : 'vos informations personnelles sont éditables <a href="http://localhost:8081/"> ici </a>'
+    oidc_no_account_message : 'Si vous n''avez pas de compte, merci d''envoyer un email à <a href="mailto:elefan@scopeli.fr?Subject=Cr%%C3%%A9ation%%20d%%20un%%20compte%%20Scop%%C3%%A9li">elefan@scopeli.fr </a>'
     oidc_issuer: 'http://host.docker.internal:8081/auth'
     oidc_realm: elefan
     oidc_client_id: elefan


### PR DESCRIPTION
Ajout d'un message spécifique, configurable, en mode OIDC