### PR TITLE
Lien vers l'espace membre dans l'email de rappel de créneau

### DIFF
--- a/app/Resources/views/emails/cycle_start.html.twig
+++ b/app/Resources/views/emails/cycle_start.html.twig
@@ -1,6 +1,6 @@
 Bonjour {{ beneficiary.firstname | lower | capitalize }},<br />
 <br />
-{% if beneficiary.membership.beneficiaries | length %}
+{% if beneficiary.membership.beneficiaries | length > 1 %}
 Votre nouveau cycle commence aujourd'hui.<br />
 Pensez à aller sur <a href="{{ home_url }}">votre espace membre</a> pour réserver vos créneaux.<br />
 {% else %}

--- a/app/Resources/views/emails/shift_booked_confirmation.html.twig
+++ b/app/Resources/views/emails/shift_booked_confirmation.html.twig
@@ -4,5 +4,7 @@ Ta réservation du créneau
 {{ shift.job.name }} le {{ shift.displayDateLongWithTime }}
 est confirmée.<br />
 <br />
+Retrouve tes créneaux sur <a href="{{ home_url }}">ton espace membre</a>.<br />
+<br />
 Merci, et belle journée à toi.<br />
 Céleste, la petite fée des créneaux :)

--- a/app/Resources/views/emails/shift_reminder.html.twig
+++ b/app/Resources/views/emails/shift_reminder.html.twig
@@ -12,9 +12,11 @@ Voici la liste des nouveautés à {{ project_name }} depuis ton dernier créneau
     {% for update in (shift.shifter | last_shift_date | updates_list_from_date) %}
         <li>{{ update.date | date_fr_long }} - <a href="{{ update.link }}">{{ update.title }}</a> : {{ update.description }}</a></li>
     {% endfor %}
-</ul>
+</ul><br />
 {% endif %}
 {% endif %}
-
+<br />
+Tu peux retrouver tes créneaux sur <a href="{{ home_url }}">ton espace membre</a>.<br />
+<br />
 Belle journée à toi.<br />
 Céleste, la petite fée des créneaux :)

--- a/src/AppBundle/EventListener/EmailingEventListener.php
+++ b/src/AppBundle/EventListener/EmailingEventListener.php
@@ -388,6 +388,9 @@ class EmailingEventListener
         $shift = $event->getShift();
         $beneficiary = $shift->getShifter();
 
+        $router = $this->container->get('router');
+        $home_url = $router->generate('homepage', array(), UrlGeneratorInterface::ABSOLUTE_URL);
+
         $dynamicContent = $this->em->getRepository('AppBundle:DynamicContent')->findOneByCode("SHIFT_REMINDER_EMAIL")->getContent();
         $template = $this->container->get('twig')->createTemplate($dynamicContent);
         $dynamicContent = $this->container->get('twig')->render($template, array('beneficiary' => $beneficiary));
@@ -405,7 +408,8 @@ class EmailingEventListener
                         'emails/shift_reminder.html.twig',
                         array(
                             'shift' => $shift,
-                            'dynamicContent' => $dynamicContent
+                            'dynamicContent' => $dynamicContent,
+                            'home_url' => $home_url,
                         )
                     ),
                     'text/html'

--- a/src/AppBundle/EventListener/EmailingEventListener.php
+++ b/src/AppBundle/EventListener/EmailingEventListener.php
@@ -303,6 +303,9 @@ class EmailingEventListener
         $shift = $event->getShift();
         $beneficiary = $shift->getShifter();
 
+        $router = $this->container->get('router');
+        $home_url = $router->generate('homepage', array(), UrlGeneratorInterface::ABSOLUTE_URL);
+
         // send a "confirmation" e-mail to the beneficiary
         $emailObject = '[ESPACE MEMBRES] Réservation de ton créneau confirmée';
         $emailTo = $beneficiary->getEmail();
@@ -314,7 +317,8 @@ class EmailingEventListener
                 $this->renderView(
                     'emails/shift_booked_confirmation.html.twig',
                     array(
-                        'shift' => $shift
+                        'shift' => $shift,
+                        'home_url' => $home_url,
                     )
                 ),
                 'text/html'


### PR DESCRIPTION
Un simple lien vers le site dans le mail de rappel de créneau : au cas où l'utilisateur⋅ice veuille aller voir davantage d'infos (par exemple qui d'autre est sur le créneau).

Aussi un petit correctif sur la condition de tutoiement / vouvoiement (si plusieurs bénéficiaires) dans le mail de début de cycle.