### PR TITLE
#1126 Calendriers avec tous les créneaux du jour

### DIFF
--- a/src/AppBundle/Controller/DefaultController.php
+++ b/src/AppBundle/Controller/DefaultController.php
@@ -89,9 +89,10 @@ class DefaultController extends Controller
                 }
             }
         } else {
+            $from = new \Datetime('today');
             $to = new \DateTime();
             $to->modify('+7 days');
-            $shifts = $em->getRepository('AppBundle:Shift')->findFutures($to);
+            $shifts = $em->getRepository('AppBundle:Shift')->findFrom($from, $to);
             $bucketsByDay = $this->get('shift_service')->generateShiftBucketsByDayAndJob($shifts);
 
             return $this->render('default/index_anon.html.twig', [
@@ -142,7 +143,10 @@ class DefaultController extends Controller
     {
         $em = $this->getDoctrine()->getManager();
 
-        $shifts = $em->getRepository('AppBundle:Shift')->findFutures();
+        $from = new \Datetime('today');
+        $to = new \DateTime();
+        $to->modify('+7 days');
+        $shifts = $em->getRepository('AppBundle:Shift')->findFrom($from, $to);
         $bucketsByDay = $this->get('shift_service')->generateShiftBucketsByDayAndJob($shifts);
 
         return $this->render('booking/schedule.html.twig', [


### PR DESCRIPTION
Closes #1126 

Sur les calendriers en mode connecté ("planning") et non-connecté (page d'accueil), afficher tous les créneaux du jour, pas seulement les futurs.

> [!NOTE]
> Dans le [changement précédent](https://github.com/elefan-grenoble/gestion-compte/pull/760/files), on était passé de `->findFrom()` à `->findFutures()` (qui exclut les événements passés du jour).
> Je ne pense pas que c'était volontaire.