### PR TITLE
#1140 Créneaux matin/soir : confusion à l'affichage

### DIFF
--- a/app/Resources/views/layout.html.twig
+++ b/app/Resources/views/layout.html.twig
@@ -51,7 +51,7 @@
                         <div class="row">
                             <div class="col s12">
                                 <div class="card-panel teal {{ type }} lighten-1">
-                                    <span class="white-text">{{ message|trans({}, 'FOSUserBundle')|raw }}</span>
+                                    <span class="white-text" style="white-space: pre-line;">{{ message|trans({}, 'FOSUserBundle')|raw }}</span>
                                 </div>
                             </div>
                         </div>

--- a/src/AppBundle/Command/ShiftGenerateCommand.php
+++ b/src/AppBundle/Command/ShiftGenerateCommand.php
@@ -64,7 +64,7 @@ class ShiftGenerateCommand extends ContainerAwareCommand
 
             $closingException = $em->getRepository('AppBundle:ClosingException')->findBy(['date' => $date]);
             if ($closingException) {
-                $output->writeln('<fg=cyan;>>>></><fg=red;> FERMETURE EXCEPTIONNELLE : aucun créneau sera généré</>');
+                $output->writeln('<fg=cyan;>>>></><fg=red;> FERMETURE EXCEPTIONNELLE : aucun créneau ne sera généré</>');
             } else {
                 $dayOfWeek = $date->format('N') - 1; // 0 = 1-1 (for Monday) through 6 = 7-1 (for Sunday)
                 $periods = $em->getRepository('AppBundle:Period')->createQueryBuilder('p')

--- a/src/AppBundle/Entity/Shift.php
+++ b/src/AppBundle/Entity/Shift.php
@@ -336,7 +336,7 @@ class Shift
 
     public function getIntervalCode()
     {
-        return $this->start->format("h-i") . $this->end->format("h-i");
+        return $this->start->format("H-i") . $this->end->format("H-i");
     }
 
     /**


### PR DESCRIPTION
## Contexte

La récupération des postes se fait regroupée par horaire de créneau : 

https://github.com/elefan-grenoble/gestion-compte/blob/fd26c72ced8f6ea574de2020165e5cf9e35166fd/src/AppBundle/Service/ShiftService.php#L451-L455

## Problème

Mais l'intervalle est calculé via la classe `Shift`

```php
$interval = $shift->getIntervalCode();
```

et cette méthode ne différencie pas matin et après-midi : 

https://github.com/elefan-grenoble/gestion-compte/blob/fd26c72ced8f6ea574de2020165e5cf9e35166fd/src/AppBundle/Entity/Shift.php#L339

## Solution

Ce qui amène à une correction très simple via le premier commit de cette PR : 37c8e89

## Impact du correctif

Il semble que la méthode `Shift->getIntervalCode()` soit toujours utilisée pour générer des "shift buckets", soit des groupes de créneaux rangés par horaire – cf. [recherche dans le code](https://github.com/search?q=repo%3Aelefan-grenoble%2Fgestion-compte%20getIntervalCode&type=code).

À mon avis on ne veut jamais regrouper les créneaux 7h-8h et 19h-20h en un même groupe (affiché dans le même cadre, dans le planning).
Je pense donc que l'effet du correctif proposé sera neutre voire bénéfique aux autres endroits du code.