### PR TITLE
ci(release-please): maj de la config à la v4 (depuis la v3)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,4 +1,5 @@
 # https://github.com/googleapis/release-please-action
+# config here: release-please-config.json
 
 name: Run release-please
 
@@ -7,17 +8,10 @@ on:
     branches:
       - master
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   release-please:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
-      - uses: google-github-actions/release-please-action@v3
+      - uses: googleapis/release-please-action@v4
         with:
-          release-type: php
-          command: github-release
-          extra-files: |
-            app/config/config.yml
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,72 @@
+{
+  "changelog-sections": [
+    {
+      "hidden": false,
+      "section": "Nouveautés",
+      "type": "feat"
+    },
+    {
+      "hidden": false,
+      "section": "Corrections (bugs, typos...)",
+      "type": "fix"
+    },
+    {
+      "hidden": false,
+      "section": "Traductions",
+      "type": "l10n"
+    },
+    {
+      "hidden": false,
+      "section": "Technique",
+      "type": "style"
+    },
+    {
+      "hidden": false,
+      "section": "Documentation",
+      "type": "docs"
+    },
+    {
+      "hidden": false,
+      "section": "Technique",
+      "type": "test"
+    },
+    {
+      "hidden": false,
+      "section": "Technique",
+      "type": "chore"
+    },
+    {
+      "hidden": false,
+      "section": "Technique",
+      "type": "refactor"
+    },
+    {
+      "hidden": false,
+      "section": "Technique",
+      "type": "perf"
+    },
+    {
+      "hidden": false,
+      "section": "Technique",
+      "type": "ci"
+    },
+    {
+      "hidden": false,
+      "section": "Technique",
+      "type": "build"
+    },
+    {
+      "hidden": false,
+      "section": "Technique",
+      "type": "revert"
+    }
+  ],
+  "packages": {
+    ".": {
+      "release-type": "php",
+      "extra-files": [
+        "app/config/config.yml"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Suite à #1049 (mais qui n'a jamais tourné, peut-être mal configuré ?)

Ca change qq trucs (la config bascule dans un fichier dédié)

https://github.com/googleapis/release-please-action?tab=readme-ov-file#upgrading-from-v3-to-v4