### PR TITLE
fix: erreur 500 sur le planning, form inexistant

### DIFF
--- a/app/Resources/views/booking/_partial/bucket_modal.html.twig
+++ b/app/Resources/views/booking/_partial/bucket_modal.html.twig
@@ -63,22 +63,6 @@
                             le <i>{{ shift.bookedTime | date_fr_full_with_time }}</i>
                             par {% include "member/_partial/member_or_user_link.html.twig" with { user: shift.booker, target_blank: true, display_names: display_names } %}.
                         </p>
-                        <!-- shift (in)validate & free forms -->
-                        {% if is_granted('free', shift) %}
-                            {% if use_card_reader_to_validate_shifts and shift.isPastOrCurrent %}
-                                {{ form_start(shift_validate_invalidate_forms[shift.id], {'attr': { 'style': 'display:inline;' }}) }}
-                                    {% if shift.wasCarriedOut %}
-                                        <button type="submit" class="btn orange" title="Invalider la participation">
-                                            <i class="material-icons left">highlight_off</i>Invalider la participation
-                                        </button>
-                                    {% else %}
-                                        <button type="submit" class="btn green" title="Valider la participation">
-                                            <i class="material-icons left">check_circle</i>Valider la participation
-                                        </button>
-                                    {% endif %}
-                                {{ form_end(shift_validate_invalidate_forms[shift.id]) }}
-                            {% endif %}
-                        {% endif %}
                         <!-- shift.createdBy -->
                         {% if shift.createdBy %}
                             <p>
@@ -167,6 +151,5 @@
         event.preventDefault();
     }
     $('form[name^="shift_book_forms_"]').on('submit', {}, makeAjaxCall);
-    $('form[name^="shift_validate_invalidate_forms_"]').on('submit', {}, makeAjaxCall);
     $('.tooltipped').tooltip();
 </script>


### PR DESCRIPTION
Suite à #1154

suppression de l'utilisation de `shift_validate_invalidate_forms` dans le planning non admin. Cette variable n'est jamais définie dans ce contexte

Comme cette variable n'existe pas, on a des erreur 500 si les conditions des if qui l'englobent sont remplies

@njean42 J'ai pris le parti de supprimer le formulaire comme il n'existe pas du tout dans les pages non admin, mais si vous souhaitez un autre fonctionnement n'hésite pas à me le dire (il s'agit du formulaire permettant de valider la présence lors d'un créneau)