### PR TITLE
ci(release-please): ajout d'une Github Action pour vérifier le nom des PR (conventional commits)

### DIFF
--- a/.github/workflows/release-please-pr-title-check.yml
+++ b/.github/workflows/release-please-pr-title-check.yml
@@ -1,0 +1,23 @@
+# https://github.com/amannn/action-semantic-pull-request
+
+name: "release-please: PR title check"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: "PR: ensure title matches the Conventional Commits spec"
+    runs-on: ubuntu-slim
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,3 +1,5 @@
+# https://github.com/googleapis/release-please-action
+
 name: Run release-please
 
 on:


### PR DESCRIPTION
En lien avec #1156 

Pour que release-please puisse faire son boulot, il faut que les PR qu'on merge respecte bien le format [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) :)