### PR TITLE
fix: correction injection de dépendance dans les controller

### DIFF
--- a/src/Controller/CodeController.php
+++ b/src/Controller/CodeController.php
@@ -4,6 +4,7 @@ namespace App\Controller;
 
 use App\Entity\Code;
 use App\Event\CodeNewEvent;
+use App\Helper\SwipeCard as SwipeCardHelper;
 use App\Security\CodeVoter;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -234,7 +235,7 @@ class CodeController extends AbstractController
      *
      * @Route("/close_all", name="code_change_done", methods={"GET"})
      */
-    public function closeAllButMineAction(Request $request)
+    public function closeAllButMineAction(Request $request, SwipeCardHelper $swipeCardHelper)
     {
         $session = new Session();
         $em = $this->getDoctrine()->getManager();
@@ -248,7 +249,7 @@ class CodeController extends AbstractController
             $this->logger->info('CODE : confirm code change (logged in)',array('username'=>$current_app_user->getUsername()));
         }else{
             $token = $request->get('token');
-            $username = explode(',',$this->get('App\Helper\SwipeCard')->vigenereDecode($token))[0];
+            $username = explode(',',$swipeCardHelper->vigenereDecode($token))[0];
             $current_app_user = $em->getRepository('App:User')->findOneBy(array('username'=>$username));
             if ($current_app_user){
                 $previousToken = $this->get("security.token_storage")->getToken();

--- a/src/Controller/HelloassoController.php
+++ b/src/Controller/HelloassoController.php
@@ -5,6 +5,7 @@ namespace App\Controller;
 use App\Entity\HelloassoPayment;
 use App\Event\HelloassoEvent;
 use App\Form\AutocompleteBeneficiaryType;
+use App\Helper\SwipeCard as SwipeCardHelper;
 use App\Providers\Helloasso\HelloassoClient;
 use App\Providers\Helloasso\HelloassoPaymentHandler;
 use Psr\Http\Client\ClientExceptionInterface;
@@ -243,9 +244,9 @@ class HelloassoController extends AbstractController
      * @Route("/payment/{id}/resolve_orphan/{code}", name="helloasso_resolve_orphan", methods={"GET"})
      * @Security("is_granted('ROLE_USER')")
      */
-    public function resolveOrphan(HelloassoPayment $payment,$code){
+    public function resolveOrphan(HelloassoPayment $payment,$code, SwipeCardHelper $swipeCardHelper){
         $code = urldecode($code);
-        $email = $this->get('App\Helper\SwipeCard')->vigenereDecode($code);
+        $email = $swipeCardHelper->vigenereDecode($code);
         $session = new Session();
         if ($email == $payment->getEmail()){
             if ($payment->getRegistration()){
@@ -267,9 +268,9 @@ class HelloassoController extends AbstractController
      * @Route("/payment/{id}/confirm_resolve_orphan/{code}", name="helloasso_confirm_resolve_orphan", methods={"GET"})
      * @Security("is_granted('ROLE_USER')")
      */
-    public function confirmOrphan(HelloassoPayment $payment, $code, EventDispatcherInterface $event_dispatcher){
+    public function confirmOrphan(HelloassoPayment $payment, $code, EventDispatcherInterface $event_dispatcher, SwipeCardHelper $swipeCardHelper){
         $code = urldecode($code);
-        $email = $this->get('App\Helper\SwipeCard')->vigenereDecode($code);
+        $email = $swipeCardHelper->vigenereDecode($code);
         $session = new Session();
         if ($email == $payment->getEmail()) {
             $session->getFlashBag()->add('success', 'Merci !');

--- a/src/Controller/MembershipController.php
+++ b/src/Controller/MembershipController.php
@@ -866,7 +866,7 @@ class MembershipController extends AbstractController
      * @return Response
      * @throws
      */
-    public function addBeneficiaryAction(Request $request, EventDispatcherInterface $event_dispatcher, SwipeCardHelper $swipeCardHelper)
+    public function addBeneficiaryAction(Request $request, EventDispatcherInterface $event_dispatcher, SwipeCardHelper $swipeCardHelper, ValidatorInterface $validator)
     {
         $session = new Session();
 
@@ -894,7 +894,7 @@ class MembershipController extends AbstractController
         $member = $a_beneficiary->getJoinTo()->getMembership();
 
         $beneficiaryCanHostConstraint = new BeneficiaryCanHost();
-        $violations = $this->get('validator')->validate(
+        $violations = $validator->validate(
             $member->getMainBeneficiary(),
             $beneficiaryCanHostConstraint
         );

--- a/src/Controller/ServiceController.php
+++ b/src/Controller/ServiceController.php
@@ -6,6 +6,7 @@ namespace App\Controller;
 use App\Entity\Service;
 use App\Entity\Task;
 use App\Form\ServiceType;
+use Liip\ImagineBundle\Imagine\Cache\CacheManager;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Filesystem\Exception\IOException;
@@ -160,13 +161,12 @@ class ServiceController extends AbstractController
      * @param Service $service
      * @return string
      */
-    protected function resolveLogo(Service $service)
+    protected function resolveLogo(Service $service, CacheManager $cacheManager)
     {
         $helper = $this->container->get('vich_uploader.templating.helper.uploader_helper');
         $path = $helper->asset($service, 'logoFile');
-        $imagineCacheManager = $this->get('liip_imagine.cache.manager');
-        $resolvedPath = $imagineCacheManager->getBrowserPath($path, 'service_logo');
-        return $resolvedPath;
+
+        return $cacheManager->getBrowserPath($path, 'service_logo');
     }
 
     private function getErrorMessages(Form $form)


### PR DESCRIPTION
Dans le container d'un controller, les seuls services disponibles sont :
`doctrine`
`form.factory`
`http_kernel`
`parameter_bag`
`request_stack`
`router`
`security.authorization_checker`
`security.csrf.token_manager`
`security.token_storage`
`session`
`templating`
`twig`

Donc les `$this->get()` dans un controller qui récupère autre chose qu'un des services listés au dessus ne vont pas fonctionner et il faut les remplacer par l'utilisation de l'injection de dépendance