### PR TITLE
fix(réservation de créneau): Pouvoir déplier les quelques jours après la fin de cycle

### DIFF
--- a/templates/booking/_partial/list.html.twig
+++ b/templates/booking/_partial/list.html.twig
@@ -31,7 +31,7 @@
         {% if beneficiary and (( membership_service.endOfCycle(beneficiary.membership, current_cycle) | date('Y-m-d') ) == ((first_shift.start) | date('Y-m-d') )) %}
                 {% set current_cycle = current_cycle + 1 %}
             </ul>
-            <ul class="collapsible" accordion="false">
+            <ul class="collapsible collapsible-expandable" accordion="false">
         {% endif %}
     {% endfor %}
     {% if (bucketsByDay | length) > 7 %}


### PR DESCRIPTION
## :teacher: Contexte

Sur la page de réservation de créneau `/booking`, on affiche les X prochaines semaines.

Pour y visualiser le changement de cycle, il y a un léger décrochage après le dernier jour du cycle : 

<img height="400" alt="image" src="https://github.com/user-attachments/assets/c45e9996-5ab1-48ad-abb2-b4de625e08fc" />

Ce décrochage est codé ici : 
https://github.com/elefan-grenoble/gestion-compte/blob/2dd592f28e697be30c45149891976f3ed0ad5d8b/templates/booking/_partial/list.html.twig#L31-L35

## :boom: Problème 

Suite aux modifs de #1191, les jours après la fin de cycle (et jusqu'au prochain début de semaine :upside_down_face:) ne se chargent plus.

## :bulb: Solution

Embarquer dans l'élément `<ul>` la classe `collapsible-expandable` qui permet de déclencher l'événement _materialize_ `opened`, et exécuter le code de chargement du planning du jour, comme pour les autres.