### PR TITLE
fix: URLs dans les mails récurrents (cron)

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -145,6 +145,9 @@ parameters:
   registration_every_civil_year: '%env(bool:REGISTRATION_EVERY_CIVIL_YEAR)%'
   reserve_new_shift_to_prior_shifter: '%env(bool:RESERVE_NEW_SHIFT_TO_PRIOR_SHIFTER)%'
   reserve_new_shift_to_prior_shifter_delay: '%env(bool:RESERVE_NEW_SHIFT_TO_PRIOR_SHIFTER_DELAY)%'
+  # NOTE: https://symfony.com/doc/4.x/routing.html#generating-urls-in-commands
+  router.request_context.host: '%env(ROUTER_REQUEST_CONTEXT_HOST)%'
+  router.request_context.base_url: '%env(ROUTER_REQUEST_CONTEXT_BASE_URL)%'
   site_name: '%env(SITE_NAME)%'
   super_admin.initial_password: '%env(SUPER_ADMIN_INITIAL_PASSWORD)%'
   super_admin.username: '%env(SUPER_ADMIN_USERNAME)%'

--- a/src/EventListener/HelloassoEventListener.php
+++ b/src/EventListener/HelloassoEventListener.php
@@ -98,7 +98,7 @@ class HelloassoEventListener
             $membership = $beneficiary->getMembership();
             if (!$this->container->get('membership_service')->canRegister($membership)) {
                 //throw new \LogicException('user cannot register yet');
-                $this->container->get('event_dispatcher')->dispatch(HelloassoEvent::TOO_EARLY,new HelloassoEvent($payment,$user));
+                $this->container->get('event_dispatcher')->dispatch(new HelloassoEvent($payment,$user), HelloassoEvent::TOO_EARLY);
             } else {
                 $registration = new Registration();
                 $registration->setAmount($payment->getAmount());
@@ -133,7 +133,7 @@ class HelloassoEventListener
 
                 $this->em->flush();
 
-                $this->container->get('event_dispatcher')->dispatch(HelloassoEvent::RE_REGISTRATION_SUCCESS,new HelloassoEvent($payment,$beneficiary->getUser()));
+                $this->container->get('event_dispatcher')->dispatch(new HelloassoEvent($payment,$beneficiary->getUser()), HelloassoEvent::RE_REGISTRATION_SUCCESS);
             }
         } else {
             throw new \LogicException('user without beneficiary');

--- a/src/EventListener/TimeLogEventListener.php
+++ b/src/EventListener/TimeLogEventListener.php
@@ -257,7 +257,7 @@ class TimeLogEventListener
             $currentCycleShifts = $this->em->getRepository('App:Shift')->findShiftsForMembership($member, $current_cycle_start, $current_cycle_end);
 
             $dispatcher = $this->container->get('event_dispatcher');
-            $dispatcher->dispatch(MemberCycleStartEvent::NAME, new MemberCycleStartEvent($member, $date, $currentCycleShifts));
+            $dispatcher->dispatch(new MemberCycleStartEvent($member, $date, $currentCycleShifts), MemberCycleStartEvent::NAME);
         }
     }
 


### PR DESCRIPTION
Closes #1201 

D'après [la doc](https://symfony.com/doc/4.x/routing.html#generating-urls-in-commands), on a besoin de spécifier le "contexte de requête" pour que les URLs générées depuis une commande aient connaissance du domaine du site.

J'ai aussi repassé des arguments de `->dispatch()` dans le bon ordre.
(Je ne sais pas comment l'envoi des mails de début de cycle peut fonctionner sur notre prod ; en local ça plantait sans ce correctif…)