### PR TITLE
fix(ShiftService): mieux gérer le cas où maxTimeInAdvanceToBookExtraShifts est NULL

### DIFF
--- a/src/Service/ShiftService.php
+++ b/src/Service/ShiftService.php
@@ -83,7 +83,7 @@ class ShiftService
      */
     public function canBookExtraShift(Beneficiary $beneficiary, Shift $shift)
     {
-        if (true === $this->allowExtraShifts && NULL === $this->maxTimeInAdvanceToBookExtraShifts) {
+        if (true === $this->allowExtraShifts && empty($this->maxTimeInAdvanceToBookExtraShifts)) {
             return true;
         }
         return true === $this->allowExtraShifts && $shift->isBefore($this->maxTimeInAdvanceToBookExtraShifts);
@@ -143,7 +143,7 @@ class ShiftService
      */
     public function canBookDuration(Beneficiary $beneficiary, $duration, $cycle = 0)
     {
-        if (true === $this->allowExtraShifts && NULL === $this->maxTimeInAdvanceToBookExtraShifts) {
+        if (true === $this->allowExtraShifts && empty($this->maxTimeInAdvanceToBookExtraShifts)) {
             return true;
         }
 


### PR DESCRIPTION
### Pourquoi

à l'Elefan on a eu un bug de remonté
1. au passage à SF4 on avait mal migré la variable `maxTimeInAdvanceToBookExtraShifts`
  - conséquence : un message apparaissait décourageant les membres de faire des créneaux supplémentaires alors qu'ils le peuvent (et nourrir leur compteur épargne) 
2. en la corrigant et la passant à `maxTimeInAdvanceToBookExtraShifts: null`
  - ca faisait planter la réservation de créneaux (erreur 500)
  - `"An exception has been thrown during the rendering of a template (\"DateTime::__construct(): Failed to parse time string (null) at position 0 (n): The timezone could not be found in the database\")`
3. en la corrigant à nouveau à `maxTimeInAdvanceToBookExtraShifts:` (vide) ca produisait un string au lieu de null
  - les membres ayant atteint le nombre de créneaux à faire pour le cycle, avaient tous les créneaux du cycle en cours qui apparaissaient grisés

### Fix

- .env : mettre `maxTimeInAdvanceToBookExtraShifts:` (vide)
- ShiftService : remplacer `$this->maxTimeInAdvanceToBookExtraShifts === NULL` par `empty($this->maxTimeInAdvanceToBookExtraShifts)`