### PR TITLE
fix: default-deny access_control terminal rule + api/oauth ordering

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -66,6 +66,7 @@ security:
     - { path: ^/sw/in/, role: IS_AUTHENTICATED_ANONYMOUSLY }
     - { path: ^/sw/.+/(qr|br)\.png$, role: IS_AUTHENTICATED_ANONYMOUSLY }
     - { path: ^/card_reader, role: IS_AUTHENTICATED_ANONYMOUSLY }
+    - { path: ^/cardReader$, role: IS_AUTHENTICATED_ANONYMOUSLY }
     - { path: ^/codes/close_all$, role: IS_AUTHENTICATED_ANONYMOUSLY }
     - { path: ^/member/new$, role: IS_AUTHENTICATED_ANONYMOUSLY }
     - { path: ^/member/add_beneficiary$, role: IS_AUTHENTICATED_ANONYMOUSLY }

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -56,5 +56,5 @@ security:
     - { path: ^/register, role: IS_AUTHENTICATED_ANONYMOUSLY }
     - { path: ^/resetting, role: IS_AUTHENTICATED_ANONYMOUSLY }
     - { path: ^/admin/, role: ROLE_ADMIN_PANEL }
-    - { path: ^/api, role: IS_AUTHENTICATED_FULLY }
     - { path: ^/api/oauth/, role: ROLE_OAUTH_LOGIN }
+    - { path: ^/api, role: IS_AUTHENTICATED_FULLY }

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -58,3 +58,28 @@ security:
     - { path: ^/admin/, role: ROLE_ADMIN_PANEL }
     - { path: ^/api/oauth/, role: ROLE_OAUTH_LOGIN }
     - { path: ^/api, role: IS_AUTHENTICATED_FULLY }
+    # --- Public routes (anonymous access required by design) ---
+    - { path: ^/$, role: IS_AUTHENTICATED_ANONYMOUSLY }
+    - { path: ^/about$, role: IS_AUTHENTICATED_ANONYMOUSLY }
+    - { path: ^/helloassoNotify$, role: IS_AUTHENTICATED_ANONYMOUSLY }
+    - { path: ^/oauth/(login|logout|callback)$, role: IS_AUTHENTICATED_ANONYMOUSLY }
+    - { path: ^/sw/in/, role: IS_AUTHENTICATED_ANONYMOUSLY }
+    - { path: ^/sw/.+/(qr|br)\.png$, role: IS_AUTHENTICATED_ANONYMOUSLY }
+    - { path: ^/card_reader, role: IS_AUTHENTICATED_ANONYMOUSLY }
+    - { path: ^/codes/close_all$, role: IS_AUTHENTICATED_ANONYMOUSLY }
+    - { path: ^/member/new$, role: IS_AUTHENTICATED_ANONYMOUSLY }
+    - { path: ^/member/add_beneficiary$, role: IS_AUTHENTICATED_ANONYMOUSLY }
+    - { path: ^/member/find_me$, role: IS_AUTHENTICATED_ANONYMOUSLY }
+    - { path: ^/member/[^/]+/set_email$, role: IS_AUTHENTICATED_ANONYMOUSLY }
+    - { path: ^/user/install_admin$, role: IS_AUTHENTICATED_ANONYMOUSLY }
+    - { path: ^/beneficiary/find_member_number$, role: IS_AUTHENTICATED_ANONYMOUSLY }
+    - { path: ^/beneficiary/[^/]+/confirm$, role: IS_AUTHENTICATED_ANONYMOUSLY }
+    - { path: ^/booking/bucket/[^/]+/show$, role: IS_AUTHENTICATED_ANONYMOUSLY }
+    - { path: ^/booking/day/, role: IS_AUTHENTICATED_ANONYMOUSLY }
+    - { path: ^/widget/$, role: IS_AUTHENTICATED_ANONYMOUSLY }
+    - { path: ^/openinghours/widget$, role: IS_AUTHENTICATED_ANONYMOUSLY }
+    - { path: ^/events/widget$, role: IS_AUTHENTICATED_ANONYMOUSLY }
+    - { path: ^/shift/widget$, role: IS_AUTHENTICATED_ANONYMOUSLY }
+    - { path: ^/closingexceptions/widget$, role: IS_AUTHENTICATED_ANONYMOUSLY }
+    # --- Default-deny terminal rule (SEC.1-1 / C-SEC-2) ---
+    - { path: ^/, role: IS_AUTHENTICATED_REMEMBERED }

--- a/tests/Functional/Controller/SmokeTest.php
+++ b/tests/Functional/Controller/SmokeTest.php
@@ -425,10 +425,32 @@ class SmokeTest extends FunctionalTestCase
             // Vigenère magic-link route (no token supplied here): must reach
             // the controller, which then mutes/redirects on invalid input.
             'codes close_all' => ['/codes/close_all'],
-            // Badge-scan route (bogus code): must reach the controller,
-            // which handles an unknown code gracefully.
-            'swipe_in' => ['/sw/in/bogus-code'],
         ];
+    }
+
+    /**
+     * Badge-scan route: must reach the controller (not be gated by the
+     * firewall) even for an unknown code, which swipeInAction handles
+     * gracefully by redirecting to homepage. The code must decode cleanly
+     * through vigenereDecode() — an arbitrary string like "bogus-code" isn't
+     * valid base64 and causes an unrelated 500 deeper in the lookup, which
+     * would defeat the purpose of this test.
+     */
+    public function testSwipeInIsNotBlockedByFirewall(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', '/sw/in/' . urlencode($this->encodeInviteCode('unknown-badge-code')));
+
+        $response = $client->getResponse();
+        $this->assertTrue(
+            $response->isRedirection(),
+            sprintf('swipe_in with an unknown code should redirect (to homepage), got %d.', $response->getStatusCode())
+        );
+        $this->assertStringNotContainsString(
+            '/login',
+            $response->headers->get('Location'),
+            'swipe_in must not be gated by the terminal access_control rule.'
+        );
     }
 
     /**

--- a/tests/Functional/Controller/SmokeTest.php
+++ b/tests/Functional/Controller/SmokeTest.php
@@ -3,8 +3,10 @@
 namespace App\Tests\Functional\Controller;
 
 use App\Tests\Functional\FunctionalTestCase;
+use App\Entity\AnonymousBeneficiary;
 use App\Entity\Beneficiary;
 use App\Entity\Shift;
+use App\Helper\SwipeCard;
 
 /**
  * Smoke tests for routes with database fixtures loaded.
@@ -442,6 +444,102 @@ class SmokeTest extends FunctionalTestCase
         $this->assertNotNull($shift, 'Fixtures should contain at least one Shift.');
 
         $client->request('GET', sprintf('/booking/bucket/%d/show', $shift->getId()));
+
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+    }
+
+    /**
+     * Encodes a value the same way App\Helper\SwipeCard does, using the
+     * SWIPE_CARD_SECRET declared in .env.test. Instantiated directly rather
+     * than fetched from the container, since App\Helper\SwipeCard is not a
+     * public service.
+     */
+    private function encodeInviteCode(string $value): string
+    {
+        $swipeCard = new SwipeCard('SwipeSecretToEncryptNumberInUrl');
+
+        return $swipeCard->vigenereEncode($value);
+    }
+
+    /**
+     * The anonymous membership-registration entry point: member_new skips
+     * its own denyAccessUnlessGranted('create', ...) call entirely when a
+     * valid invite `code` resolves to an AnonymousBeneficiary — this is the
+     * highest-risk route for the terminal access_control rule to break,
+     * since it has no @Security annotation and self-gates purely on this
+     * business logic.
+     */
+    public function testMemberNewWithValidInviteCodeIsPubliclyReachable(): void
+    {
+        $client = static::createClient();
+
+        $email = 'invite-' . uniqid() . '@example.test';
+        $em = $client->getContainer()->get('doctrine')->getManager();
+        $anonymousBeneficiary = new AnonymousBeneficiary();
+        $anonymousBeneficiary->setEmail($email);
+        $em->persist($anonymousBeneficiary);
+        $em->flush();
+
+        $code = $this->encodeInviteCode($email);
+        $client->request('GET', '/member/new?code=' . urlencode($code));
+
+        $this->assertSame(
+            200,
+            $client->getResponse()->getStatusCode(),
+            'member_new with a valid invite code must render the registration form anonymously.'
+        );
+    }
+
+    /**
+     * Same as above for member_add_beneficiary (adding a beneficiary to an
+     * existing membership via invite code) — the code path either renders
+     * the form (200) or redirects to homepage on a business-rule violation
+     * (BeneficiaryCanHost), never to /login.
+     */
+    public function testMemberAddBeneficiaryWithValidInviteCodeIsNotBlockedByFirewall(): void
+    {
+        $client = static::createClient();
+
+        $em = $client->getContainer()->get('doctrine')->getManager();
+        $hostBeneficiary = $em->getRepository(Beneficiary::class)->findOneBy([]);
+        $this->assertNotNull($hostBeneficiary, 'Fixtures should contain at least one Beneficiary.');
+
+        $email = 'invite-' . uniqid() . '@example.test';
+        $anonymousBeneficiary = new AnonymousBeneficiary();
+        $anonymousBeneficiary->setEmail($email);
+        $anonymousBeneficiary->setJoinTo($hostBeneficiary);
+        $em->persist($anonymousBeneficiary);
+        $em->flush();
+
+        $code = $this->encodeInviteCode($email);
+        $client->request('GET', '/member/add_beneficiary?code=' . urlencode($code));
+
+        $response = $client->getResponse();
+        $isFormRendered = 200 === $response->getStatusCode();
+        $isNonLoginRedirect = $response->isRedirection() && false === strpos((string) $response->headers->get('Location'), '/login');
+
+        $this->assertTrue(
+            $isFormRendered || $isNonLoginRedirect,
+            sprintf('member_add_beneficiary with a valid invite code must not be gated by the firewall, got %d.', $response->getStatusCode())
+        );
+    }
+
+    /**
+     * set_email (the #1245 temp-email activation flow) always renders
+     * beneficiary/confirm.html.twig regardless of branch taken — it must
+     * never redirect to /login.
+     */
+    public function testSetEmailIsPubliclyReachable(): void
+    {
+        $client = static::createClient();
+
+        $em = $client->getContainer()->get('doctrine')->getManager();
+        $beneficiary = $em->getRepository(Beneficiary::class)->findOneBy([]);
+        $this->assertNotNull($beneficiary, 'Fixtures should contain at least one Beneficiary.');
+
+        $client->request('POST', sprintf('/member/%d/set_email', $beneficiary->getId()), [
+            'email' => 'new-email-' . uniqid() . '@example.test',
+        ]);
 
         $this->assertSame(200, $client->getResponse()->getStatusCode());
     }

--- a/tests/Functional/Controller/SmokeTest.php
+++ b/tests/Functional/Controller/SmokeTest.php
@@ -56,6 +56,7 @@ class SmokeTest extends FunctionalTestCase
             'about' => ['/about'],
             'homepage (anonymous)' => ['/'],
             'member find_me' => ['/member/find_me'],
+            'beneficiary find_member_number' => ['/beneficiary/find_member_number'],
         ];
     }
 
@@ -174,6 +175,7 @@ class SmokeTest extends FunctionalTestCase
             'profile' => ['/profile/'],
             'schedule' => ['/schedule'],
             'event index' => ['/events/'],
+            'tasks list' => ['/tasks/'],
         ];
     }
 
@@ -354,5 +356,93 @@ class SmokeTest extends FunctionalTestCase
             $client->getResponse()->getStatusCode(),
             sprintf('Admin URL "%s" should be forbidden for regular user.', $url)
         );
+    }
+
+    // -------------------------------------------------------
+    // Default-deny terminal rule (#1246): previously-unannotated
+    // controllers are now covered by the catch-all access_control rule.
+    // -------------------------------------------------------
+
+    /**
+     * BeneficiaryController has no @Security annotations at all — it relied
+     * solely on an inline denyAccessUnlessGranted() voter call. The terminal
+     * rule adds a second layer that must not change the observable behavior
+     * for a legitimate, already-covered anonymous request.
+     */
+    public function testBeneficiaryEditRequiresAuthentication(): void
+    {
+        $client = static::createClient();
+
+        $em = $client->getContainer()->get('doctrine')->getManager();
+        $beneficiary = $em->getRepository(Beneficiary::class)->findOneBy([]);
+        $this->assertNotNull($beneficiary, 'Fixtures should contain at least one Beneficiary.');
+
+        $client->request('GET', sprintf('/beneficiary/%d/edit', $beneficiary->getId()));
+
+        $response = $client->getResponse();
+        $this->assertTrue(
+            $response->isRedirection(),
+            sprintf('Anonymous beneficiary edit should redirect, got %d.', $response->getStatusCode())
+        );
+        $this->assertStringContainsString('/login', $response->headers->get('Location'));
+    }
+
+    // -------------------------------------------------------
+    // Default-deny terminal rule (#1246): anonymous flows that must stay
+    // reachable (magic-link / invite-code / bootstrap / badge-scan routes).
+    // A redirect to /login here would mean the security.yaml whitelist
+    // regex is missing or wrong.
+    // -------------------------------------------------------
+
+    /**
+     * @dataProvider anonymousFlowUrlProvider
+     */
+    public function testAnonymousFlowUrlIsNotBlockedByFirewall(string $url): void
+    {
+        $client = static::createClient();
+        $client->request('GET', $url);
+
+        $response = $client->getResponse();
+        $this->assertTrue(
+            $response->isRedirection(),
+            sprintf('URL "%s" should redirect (to homepage), got %d.', $url, $response->getStatusCode())
+        );
+        $this->assertStringNotContainsString(
+            '/login',
+            $response->headers->get('Location'),
+            sprintf('URL "%s" must not be gated by the terminal access_control rule.', $url)
+        );
+    }
+
+    public function anonymousFlowUrlProvider(): array
+    {
+        return [
+            // Bootstrap route: must stay reachable even once a super-admin
+            // already exists, since the controller itself no-ops in that case.
+            'user install_admin' => ['/user/install_admin'],
+            // Vigenère magic-link route (no token supplied here): must reach
+            // the controller, which then mutes/redirects on invalid input.
+            'codes close_all' => ['/codes/close_all'],
+            // Badge-scan route (bogus code): must reach the controller,
+            // which handles an unknown code gracefully.
+            'swipe_in' => ['/sw/in/bogus-code'],
+        ];
+    }
+
+    /**
+     * bucket_show renders anonymously with display_names conditioned on
+     * authentication (SEC.1-12) — must stay reachable without a session.
+     */
+    public function testBucketShowIsPubliclyReachable(): void
+    {
+        $client = static::createClient();
+
+        $em = $client->getContainer()->get('doctrine')->getManager();
+        $shift = $em->getRepository(Shift::class)->findOneBy([]);
+        $this->assertNotNull($shift, 'Fixtures should contain at least one Shift.');
+
+        $client->request('GET', sprintf('/booking/bucket/%d/show', $shift->getId()));
+
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
     }
 }


### PR DESCRIPTION
## Summary

- Reorders the `^/api/oauth/` access_control rule before `^/api` (Symfony access_control is first-match-wins, so it was previously unreachable and `ROLE_OAUTH_LOGIN` was only enforced by per-action `@Security` annotations).
- Adds a terminal `{ path: ^/, role: IS_AUTHENTICATED_REMEMBERED }` default-deny rule, preceded by an explicit whitelist of every route confirmed to be anonymous-by-design (verified by reading each target controller's inline auth logic, not guessed from route names).

## Whitelisted routes and why

homepage/about, HelloAsso webhook, OIDC login/logout/callback, badge-scan (`sw/in`, `qr`/`br` images), the physical card reader (IP-gated internally via `PlaceIP`, but the access_control layer runs *before* that voter — must be whitelisted or the reader breaks even from an allowed IP), the Vigenère magic-link (`codes/close_all`), the anonymous invite-code registration flow (`member/new`, `member/add_beneficiary` — both explicitly skip their own voter check when a valid code resolves), the temp-email activation flow (`find_me`, `find_member_number`, `set_email`, `beneficiary/confirm`), the admin bootstrap route (`user/install_admin`), the anonymously-viewable booking bucket (SEC.1-12), and the embeddable widgets.

`beneficiary/confirm` keeps zero ownership check (any id renders that beneficiary) — this is the known enumeration surface already tracked separately as `m-SEC-10` in `TODO-PRIORISEE.md` (rate-limiting fix), intentionally not addressed here.

All voters (`MembershipVoter`, `UserVoter`, `TaskVoter`, `NoteVoter`, `CodeVoter`) already deny anonymous by default, so the terminal rule is defense-in-depth for most of the 42 controllers and closes real gaps for the handful of actions with zero inline check (`ShiftController::contactFormAction`, `CommissionController::add/removeBeneficiaryAction`, `EventController::detailAction`, etc.).

## Test plan

- [x] Extended `SmokeTest.php`: newly-protected route (`/tasks/`, `/beneficiary/{id}/edit`) now redirects anonymous to `/login`
- [x] Every whitelisted route covered by a test proving it is *not* gated by the firewall, including the anonymous invite-code registration flow (`member_new`, `member_add_beneficiary`, `set_email`) flagged as highest-risk by pre-PR review
- [x] `gitleaks detect` clean on the branch
- [ ] Could not run the PHP test suite locally (no PHP interpreter on this VM, local `docker-compose.yml` is broken independently of this change — missing `wait-for.sh`, pre-existing). Relying on CI (`symfony-tests` job) for the authoritative run — please check the CI status on this PR before merging.

Closes #1250
Closes #1246