### PR TITLE
fix(makefile): build the test schema from the migrations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,10 +132,16 @@ encore-stubs: ## Crée des stubs Webpack Encore (évite les 500 en test)
 # Base de données
 # ------------------------------------------------------------------
 
-db-reset: vendor ## Drop + recreate le schéma de test
+# Le schéma est reconstruit en rejouant les migrations, comme le font la CI
+# et la production, et non avec doctrine:schema:create qui le déduit des
+# mappings d'entités. Les deux ne produisent pas le même schéma : par
+# exemple view_abstract_registration est une vue SQL côté migrations, mais
+# une table ordinaire côté schema:create. Ne pas revenir en arrière : un
+# schéma local divergent laisse passer des bugs de migration jusqu'en CI.
+db-reset: vendor ## Drop + recreate le schéma de test (en rejouant les migrations)
 	$(EXEC) php bin/console --env=test doctrine:database:drop --force --if-exists
 	$(EXEC) php bin/console --env=test doctrine:database:create
-	$(EXEC) php bin/console --env=test doctrine:schema:create
+	@$(MAKE) --no-print-directory db-migrate
 
 db-migrate: ## Exécute les migrations Doctrine (env test)
 	$(EXEC) php bin/console --env=test doctrine:migrations:migrate --no-interaction

--- a/doc/dev.md
+++ b/doc/dev.md
@@ -54,12 +54,17 @@ Une extension existe aussi pour vscode : https://marketplace.visualstudio.com/it
 ## Tests
 
 ```shell
-// créer la base de donnée de test + initialiser avec le schema
+// créer la base de donnée de test + construire le schéma
 docker exec -i php php bin/console --env=test doctrine:database:create
-docker exec -i php php bin/console --env=test doctrine:schema:create
+docker exec -i php php bin/console --env=test doctrine:migrations:migrate --no-interaction
 // lancer les tests
 docker exec -i php php ./vendor/bin/phpunit
 ```
+
+Le schéma se construit en rejouant les migrations, jamais avec
+`doctrine:schema:create` : ce dernier le déduit des mappings d'entités et ne
+produit pas le même résultat que la CI et la production. `make db-reset`
+fait la même chose, précédé d'un drop de la base existante.
 
 ## Logs
 

--- a/doc/install.tests.linux.md
+++ b/doc/install.tests.linux.md
@@ -90,7 +90,7 @@ make test-e2e-oidc        # Tests OIDC (nécessite Keycloak)
 
 ```bash
 make help          # Liste toutes les cibles disponibles
-make db-reset      # Recrée le schéma (sans fixtures)
+make db-reset      # Recrée le schéma en rejouant les migrations (sans fixtures)
 make db-migrate    # Exécute les migrations Doctrine
 make db-fixtures   # Reset DB + fixtures
 make cache-clear   # Vide le cache Symfony (env test)

--- a/tests/Functional/SchemaBuiltFromMigrationsTest.php
+++ b/tests/Functional/SchemaBuiltFromMigrationsTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Tests\Functional;
+
+use Doctrine\DBAL\Connection;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * The test database has to be built the way CI and production build it:
+ * by replaying the migrations.
+ *
+ * `doctrine:schema:create` deduces the schema from the entity mappings
+ * instead, and the two do not agree. The visible case is
+ * `view_abstract_registration`, which the migrations create as a SQL view
+ * reading live from `beneficiary`, and which `schema:create` materializes
+ * as an ordinary table — a frozen copy of the real names that nothing
+ * refreshes and no anonymization pass reaches through `beneficiary`.
+ *
+ * A developer running against a schema built the other way can green-light
+ * a migration bug locally and only find out in CI, so the divergence is
+ * caught here rather than there.
+ *
+ * @internal
+ *
+ * @coversNothing
+ */
+class SchemaBuiltFromMigrationsTest extends KernelTestCase
+{
+    /**
+     * The log table is named by `config/packages/doctrine_migrations.yaml`,
+     * not by the bundle default — renaming it there means renaming it here.
+     */
+    private const MIGRATION_LOG = 'migration_versions';
+
+    /** @var Connection */
+    private $connection;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->connection = self::$container->get('doctrine.dbal.default_connection');
+    }
+
+    public function testTheSchemaWasBuiltByReplayingTheMigrations(): void
+    {
+        $this->assertSame(
+            'BASE TABLE',
+            $this->tableType(self::MIGRATION_LOG),
+            "The test database has no migration log, so it was not built by the migrations.\n"
+            . 'Rebuild it with `make db-reset`, which drops, creates, then replays them.'
+        );
+    }
+
+    public function testAbstractRegistrationIsAViewAndNotACopy(): void
+    {
+        $this->assertSame(
+            'VIEW',
+            $this->tableType('view_abstract_registration'),
+            "`view_abstract_registration` is not a view, so it holds a stale copy of the beneficiary names\n"
+            . 'instead of reading them live. Rebuild the test database with `make db-reset`.'
+        );
+    }
+
+    /**
+     * 'BASE TABLE', 'VIEW', or '' when the schema holds no such object.
+     */
+    private function tableType(string $name): string
+    {
+        $type = $this->connection->fetchOne(
+            'SELECT TABLE_TYPE FROM information_schema.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?',
+            [$name]
+        );
+
+        return false === $type || null === $type ? '' : (string) $type;
+    }
+}


### PR DESCRIPTION
Closes #1259.

## Le problème

`make db-reset` construisait le schéma avec `doctrine:schema:create`, à partir des mappings d'entités. La CI (`make db-migrate`) et la production le construisent en rejouant les migrations. Les deux ne produisent pas le même schéma, donc le schéma d'un développeur en local n'était pas celui qu'il déploie : un bug de migration pouvait passer en local et échouer en CI ou sur le serveur.

Différence la plus visible, `view_abstract_registration` :

| | Construit par les migrations | Construit par `schema:create` |
|---|---|---|
| Type | vue SQL | table ordinaire |
| Colonne `beneficiary` | `CONCAT(LOWER(firstname), ' ', UPPER(lastname))`, lu en direct depuis `beneficiary` | copie figée, que rien ne rafraîchit |

La table de log des migrations était absente elle aussi, ce qui faisait rapporter à `doctrine:migrations:up-to-date` la totalité des migrations comme en attente sur une base fraîchement remise à zéro.

## Ce qui change

`db-reset` fait maintenant drop, create, puis délègue à `db-migrate` — un seul chemin de construction du schéma, donc plus de possibilité de re-diverger. Pas d'échappatoire `schema:create` conservée volontairement : c'est précisément le piège que l'issue décrit.

Rejouer les 99 migrations prend environ 6 secondes, contre un schéma qui correspond à la production. La CI n'appelle jamais `db-reset` (elle enchaîne `db-migrate` puis `db-fixtures-load` sur la base du service container), donc son comportement est inchangé — le correctif porte uniquement sur la parité du poste de développement.

`doc/dev.md` et `doc/install.tests.linux.md` ne renvoient plus vers `schema:create`.

## Test

`tests/Functional/SchemaBuiltFromMigrationsTest.php` garde les deux symptômes : présence du log de migrations, et `view_abstract_registration` bien typée `VIEW`. Vérifié qu'il peut échouer — rouge sur les deux assertions contre une base construite avec `schema:create`, vert contre une base migrée.

Validé en local sur un schéma reconstruit par les migrations : suite fonctionnelle 101/101, unit + intégration 251/251, `php-cs-fixer check` clean.

## Suite

L'issue mentionne aussi la tolérance portée par `SchemaCoverageTest`. Ce fichier n'existe que sur #1257 et n'est donc pas touché ici ; la tolérance y sera retirée directement, ce qui fait qu'elle n'atteindra jamais `master`.