### PR TITLE
fix: forward-port du correctif de migration v1.31.3 (perte de données period_position)

### DIFF
--- a/src/Migrations/Version20210425170158.php
+++ b/src/Migrations/Version20210425170158.php
@@ -23,7 +23,8 @@ final class Version20210425170158 extends AbstractMigration
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE period DROP week_cycle');
-        $this->addSql('ALTER TABLE period ADD week_cycle LONGTEXT DEFAULT \'0,1,2,3\' NOT NULL COMMENT \'(DC2Type:simple_array)\'');
+        $this->addSql('ALTER TABLE period ADD week_cycle LONGTEXT NOT NULL COMMENT \'(DC2Type:simple_array)\'');
+        $this->addSql('UPDATE period SET week_cycle = "0,1,2,3"');
     }
 
     public function down(Schema $schema): void

--- a/src/Migrations/Version20211223205749.php
+++ b/src/Migrations/Version20211223205749.php
@@ -22,19 +22,121 @@ final class Version20211223205749 extends AbstractMigration
         // this up() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
-        $this->addSql('DROP TABLE period_position_period');
-        $this->addSql('DELETE FROM period_position');
-        $this->addSql('ALTER TABLE period DROP week_cycle');
         $this->addSql('ALTER TABLE period_position ADD period_id INT DEFAULT NULL, ADD shifter_id INT DEFAULT NULL, ADD booker_id INT DEFAULT NULL, ADD week_cycle VARCHAR(1) NOT NULL, ADD booked_time DATETIME DEFAULT NULL, DROP nb_of_shifter');
+        $this->addSql('ALTER TABLE shift ADD position_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE period DROP week_cycle');
+        $this->addSql('DROP TABLE period_position_period');
+
+        // Migrate PeriodPosition data. We plan a delete (not a truncate: period_position_free_log
+        // FKs onto this table with ON DELETE SET NULL, and MySQL refuses to truncate a table that
+        // is referenced by a foreign key), then we retrieve data to plan new inserts (addSql
+        // statements are executed after the return statement)
+        $this->addSql('DELETE FROM period_position');
+        $this->addSql('ALTER TABLE period_position AUTO_INCREMENT=1');
+
+        // period_position.created_at/updated_at (added by later migrations, not yet present
+        // when this fix was first written) are NOT NULL with no default, so the backfill
+        // insert below has to set them explicitly.
+        $insertPositions = 'INSERT INTO period_position (period_id, formation_id, week_cycle, created_at, updated_at) VALUES ';
+        $shouldInsertPositions = false;
+
+        $selectPeriods = <<<'EOT'
+                SELECT per.id, per.job_id, per.day_of_week, per.start, per.end, per.week_cycle
+                FROM period per
+            EOT;
+        $periods = $this->connection->fetchAllAssociative($selectPeriods);
+
+        foreach ($periods as $per) {
+            $weeks = explode(',', $per['week_cycle']);
+            foreach ($weeks as $numWeek) {
+                $charWeek = chr(65 + (int) $numWeek); // 1 -> A, 2 -> B, 3 -> C, 4 -> D
+                $selectPositions = <<<EOT
+                        SELECT pos.id, pos.formation_id, pos.nb_of_shifter
+                        FROM period_position pos
+                        JOIN period_position_period ppp ON pos.id = ppp.period_position_id
+                        WHERE ppp.period_id = {$per['id']}
+                    EOT;
+                $positions = $this->connection->fetchAllAssociative($selectPositions);
+
+                foreach ($positions as $pos) {
+                    for ($i = 0; $i < $pos['nb_of_shifter']; ++$i) {
+                        $shouldInsertPositions = true; // at least one position needs to be added
+                        $formationId = $pos['formation_id'] ?: 'NULL';
+                        $insertPositions .= "({$per['id']}, {$formationId}, '{$charWeek}', NOW(), NOW()), ";
+                    }
+                }
+            }
+        }
+        if ($shouldInsertPositions) {
+            $insertPositions = rtrim($insertPositions, ' ,') . ';';
+            $this->addSql($insertPositions);
+        }
+
+        // Foreign keys and Indexes
         $this->addSql('ALTER TABLE period_position ADD CONSTRAINT FK_2367D496EC8B7ADE FOREIGN KEY (period_id) REFERENCES period (id) ON DELETE CASCADE');
         $this->addSql('ALTER TABLE period_position ADD CONSTRAINT FK_2367D496A7DA74C1 FOREIGN KEY (shifter_id) REFERENCES beneficiary (id)');
         $this->addSql('ALTER TABLE period_position ADD CONSTRAINT FK_2367D4968B7E4006 FOREIGN KEY (booker_id) REFERENCES beneficiary (id)');
+
         $this->addSql('CREATE INDEX IDX_2367D496EC8B7ADE ON period_position (period_id)');
         $this->addSql('CREATE INDEX IDX_2367D496A7DA74C1 ON period_position (shifter_id)');
         $this->addSql('CREATE INDEX IDX_2367D4968B7E4006 ON period_position (booker_id)');
-        $this->addSql('ALTER TABLE shift ADD position_id INT DEFAULT NULL');
+
         $this->addSql('ALTER TABLE shift ADD CONSTRAINT FK_A50B3B45DD842E46 FOREIGN KEY (position_id) REFERENCES period_position (id) ON DELETE SET NULL');
         $this->addSql('CREATE INDEX IDX_A50B3B45DD842E46 ON shift (position_id)');
+    }
+
+    public function postUp(Schema $schema): void
+    {
+        // Match Shifts with new PeriodPositions
+        $selectShifts = <<<'EOT'
+                SELECT s.id, s.formation_id, s.job_id, s.start, s.end
+                FROM shift s
+            EOT;
+        $shifts = $this->connection->fetchAllAssociative($selectShifts);
+        $usedPositionIds = [];
+        foreach ($shifts as $shift) {
+            // The original hotfix omitted the AND on these first two conditions, which made
+            // the query below a SQL syntax error as soon as there was more than one WHERE
+            // clause fragment (i.e. always, since formation/week_cycle always follow) —
+            // fixed here while forward-porting.
+            //
+            // It also compared `per.start`/`per.end` (TIME columns) against the shift's full
+            // DATETIME string as-is. MariaDB accepts that in a SELECT expression (silently
+            // extracting the time part) but not as a WHERE filter, where it never matches —
+            // so this never actually relinked a single shift. Extracting the time-of-day in
+            // PHP first fixes that.
+            $perStart = $shift['start'] ? date('H:i:s', strtotime($shift['start'])) : null;
+            $perEnd = $shift['end'] ? date('H:i:s', strtotime($shift['end'])) : null;
+            $perStartTest = $perStart ? "per.start = \"{$perStart}\"" : 'per.start IS NULL';
+            $perEndTest = $perEnd ? "AND per.end = \"{$perEnd}\"" : 'AND per.end IS NULL';
+            $perJobIdTest = $shift['job_id'] ? "AND per.job_id = \"{$shift['job_id']}\"" : 'AND per.job_id IS NULL';
+            $formationIdTest = $shift['formation_id'] ? "AND pos.formation_id = {$shift['formation_id']}" : 'AND pos.formation_id IS NULL';
+            $weekCycleIndex = (date_create($shift['start'])->format('W') - 1) % 4; // 0 = (1-1)%4 (first week) through 51 (based on ShiftGenerateCommand)
+            $weekCycleChar = chr(65 + $weekCycleIndex);
+            $weekCycleTest = "AND pos.week_cycle = \"{$weekCycleChar}\"";
+            $usedPositionIdsStr = implode(',', $usedPositionIds);
+            $usedPositionIdsTest = $usedPositionIdsStr ? "AND pos.id NOT IN ({$usedPositionIdsStr})" : '';
+            $selectMatchingPositions = <<<EOT
+                    SELECT pos.id
+                    FROM period_position pos
+                    LEFT JOIN period per ON per.id = pos.period_id
+                    WHERE
+                        {$perStartTest}
+                        {$perEndTest}
+                        {$perJobIdTest}
+                        {$formationIdTest}
+                        {$weekCycleTest}
+                        {$usedPositionIdsTest}
+                EOT;
+
+            if ($matchingPosition = $this->connection->fetchAssociative($selectMatchingPositions)) {
+                $update = "UPDATE shift SET position_id = {$matchingPosition['id']} WHERE id = {$shift['id']}";
+                $this->connection->executeStatement($update);
+                $usedPositionIds[] = $matchingPosition['id'];
+
+                $this->write($update);
+            }
+        }
     }
 
     public function down(Schema $schema): void

--- a/tests/Functional/Migrations/Version20211223205749Test.php
+++ b/tests/Functional/Migrations/Version20211223205749Test.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace App\Tests\Functional\Migrations;
+
+use app\Migrations\Version20211223205749;
+use App\Tests\Functional\DatabasePrimer;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Schema\Schema;
+use Psr\Log\NullLogger;
+
+// Migration classes live under the `app\Migrations` namespace and are loaded
+// by the doctrine-migrations bundle from its own configured path, not via
+// Composer's PSR-4 autoloading (which only covers `App\` -> src/) — so this
+// class needs an explicit require to be usable here.
+require_once dirname(__DIR__, 3) . '/src/Migrations/Version20211223205749.php';
+
+/**
+ * Regression test for the migration that used to wipe `period_position`
+ * instead of migrating its data (fixed in v1.31.3, forward-ported to
+ * master here).
+ *
+ * The test database is built by replaying every migration in order
+ * (see SchemaBuiltFromMigrationsTest), so by the time this test runs
+ * Version20211223205749 has already executed against an empty schema —
+ * that never exercises the data-reconstruction path this migration
+ * exists for. To cover it, this test rewinds just the handful of tables
+ * this one migration touches back to their pre-migration shape, seeds
+ * legacy-shaped rows, then replays up()/postUp() exactly the way the
+ * Doctrine executor does (up() only queues SQL via addSql(), postUp()
+ * runs its own statements directly) and asserts the reconstructed data.
+ *
+ * It deliberately does not go through `doctrine:migrations:migrate` to
+ * step backwards: this migration's own down() re-adds `period.week_cycle`
+ * as `LONGTEXT ... DEFAULT '0,1,2,3'`, which MariaDB rejects (the same
+ * class of bug Version20210425170158 was fixed for) — a preexisting,
+ * unrelated issue in a migration nobody runs down() on in practice.
+ *
+ * @internal
+ *
+ * @coversNothing
+ */
+class Version20211223205749Test extends DatabasePrimer
+{
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        $client = static::createClient();
+        $this->connection = $client->getKernel()->getContainer()->get('doctrine.dbal.default_connection');
+    }
+
+    public function testUpRebuildsPeriodPositionsAndPostUpRelinksShifts(): void
+    {
+        $this->rewindToPreMigrationSchema();
+
+        $now = '2024-01-01 00:00:00';
+
+        $jobId = $this->insert('job', ['name' => 'Cuisine', 'color' => '#ffffff', 'created_at' => $now]);
+        $formationId = $this->insert('formation', ['name' => 'Plonge', 'roles' => serialize([]), 'created_at' => $now]);
+        $periodId = $this->insert('period', [
+            'job_id' => $jobId,
+            'day_of_week' => 1,
+            'start' => '08:00:00',
+            'end' => '10:00:00',
+            // Weeks 0 and 1 -> postUp() maps them to charWeek 'A' and 'B'.
+            'week_cycle' => '0,1',
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+        $legacyPositionId = $this->insert('period_position', [
+            'formation_id' => $formationId,
+            'nb_of_shifter' => 2,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+        $this->connection->executeStatement(
+            'INSERT INTO period_position_period (period_position_id, period_id) VALUES (?, ?)',
+            [$legacyPositionId, $periodId]
+        );
+        // ISO week 1 of 2024 -> weekCycleIndex (1 - 1) % 4 = 0 -> 'A', matching
+        // the period's week 0. Same start/end time-of-day as the period.
+        $shiftId = $this->insert('shift', [
+            'job_id' => $jobId,
+            'formation_id' => $formationId,
+            'start' => '2024-01-02 08:00:00',
+            'end' => '2024-01-02 10:00:00',
+            'created_at' => $now,
+        ]);
+
+        $this->runMigration();
+
+        $rebuilt = $this->connection->fetchAllAssociative(
+            'SELECT id, week_cycle FROM period_position WHERE period_id = ? ORDER BY week_cycle',
+            [$periodId]
+        );
+        // 2 weeks (A, B) x nb_of_shifter (2) = 4 reconstructed rows, one per legacy slot.
+        self::assertCount(4, $rebuilt, 'period_position should be rebuilt from period_position_period, not wiped');
+        self::assertSame(['A', 'A', 'B', 'B'], array_column($rebuilt, 'week_cycle'));
+
+        $weekAIds = array_map('intval', array_column(
+            array_filter($rebuilt, static fn(array $row) => 'A' === $row['week_cycle']),
+            'id'
+        ));
+
+        $shiftPositionId = $this->connection->fetchOne('SELECT position_id FROM shift WHERE id = ?', [$shiftId]);
+        self::assertNotFalse($shiftPositionId, 'shift should have been matched to a rebuilt period_position');
+        self::assertContains((int) $shiftPositionId, $weekAIds, 'shift should be linked to a week-A position for its period');
+    }
+
+    private function runMigration(): void
+    {
+        $migration = new Version20211223205749($this->connection, new NullLogger());
+        $schema = new Schema();
+
+        $migration->up($schema);
+        foreach ($migration->getSql() as $query) {
+            $this->connection->executeStatement($query->getStatement(), $query->getParameters(), $query->getTypes());
+        }
+        $migration->postUp($schema);
+    }
+
+    /**
+     * Undo just this migration's schema changes, without using its own
+     * down() (see class docblock for why).
+     */
+    private function rewindToPreMigrationSchema(): void
+    {
+        $this->connection->executeStatement('ALTER TABLE period ADD week_cycle LONGTEXT NOT NULL COMMENT \'(DC2Type:simple_array)\'');
+
+        $this->connection->executeStatement('ALTER TABLE shift DROP FOREIGN KEY FK_A50B3B45DD842E46');
+        $this->connection->executeStatement('DROP INDEX IDX_A50B3B45DD842E46 ON shift');
+        $this->connection->executeStatement('ALTER TABLE shift DROP position_id');
+
+        $this->connection->executeStatement('ALTER TABLE period_position DROP FOREIGN KEY FK_2367D496EC8B7ADE');
+        $this->connection->executeStatement('ALTER TABLE period_position DROP FOREIGN KEY FK_2367D496A7DA74C1');
+        $this->connection->executeStatement('ALTER TABLE period_position DROP FOREIGN KEY FK_2367D4968B7E4006');
+        $this->connection->executeStatement('DROP INDEX IDX_2367D496EC8B7ADE ON period_position');
+        $this->connection->executeStatement('DROP INDEX IDX_2367D496A7DA74C1 ON period_position');
+        $this->connection->executeStatement('DROP INDEX IDX_2367D4968B7E4006 ON period_position');
+        $this->connection->executeStatement('ALTER TABLE period_position ADD nb_of_shifter INT NOT NULL, DROP period_id, DROP shifter_id, DROP booker_id, DROP week_cycle, DROP booked_time');
+
+        $this->connection->executeStatement('CREATE TABLE period_position_period (period_position_id INT NOT NULL, period_id INT NOT NULL, INDEX IDX_A0A94FFFA95DF5B1 (period_position_id), INDEX IDX_A0A94FFFEC8B7ADE (period_id), PRIMARY KEY(period_position_id, period_id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB');
+        $this->connection->executeStatement('ALTER TABLE period_position_period ADD CONSTRAINT FK_A0A94FFFA95DF5B1 FOREIGN KEY (period_position_id) REFERENCES period_position (id) ON DELETE CASCADE');
+        $this->connection->executeStatement('ALTER TABLE period_position_period ADD CONSTRAINT FK_A0A94FFFEC8B7ADE FOREIGN KEY (period_id) REFERENCES period (id) ON DELETE CASCADE');
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function insert(string $table, array $data): int
+    {
+        $this->connection->insert($table, $data);
+
+        return (int) $this->connection->lastInsertId();
+    }
+}


### PR DESCRIPTION
## Contexte

La PR #1137 corrigeait la migration `Version20211223205749` qui, dans sa version d'origine, supprimait purement et simplement toutes les données de `period_position` (`DROP TABLE period_position_period` + `DELETE FROM period_position`) au lieu de les migrer. Cette PR a été mergée dans la branche `v1.31.3-fix-migration` — mais cette branche avait elle-même comme base `v1.31.3-fix-migration`, pas `master`. Le correctif n'a donc jamais atteint `master`, qui porte toujours la version destructrice de la migration.

Cette PR porte enfin le correctif sur `master`.

## Ce qui a changé par rapport au hotfix d'origine

`master` a beaucoup évolué depuis fin 2025 (déplacement de `app/DoctrineMigrations/` vers `src/Migrations/`, nouvelles colonnes, nouvelle table `period_position_free_log`), donc un simple cherry-pick n'était pas possible. Le portage a nécessité d'adapter la logique au schéma actuel, et l'écriture d'un test de régression exerçant réellement le chemin de reconstruction des données a révélé **trois bugs supplémentaires**, tous corrigés dans ce commit :

- `TRUNCATE period_position` échoue aujourd'hui car `period_position_free_log` (ajoutée après le hotfix d'origine) référence `period_position` par clé étrangère — remplacé par `DELETE FROM period_position` (toléré par le `ON DELETE SET NULL` de cette FK).
- L'`INSERT` de reconstruction ne renseignait pas `created_at`/`updated_at`, ajoutées en NOT NULL par des migrations postérieures au hotfix d'origine.
- La requête de ré-appariement des `shift` dans `postUp()` avait deux bugs déjà présents dans le commit historique original (vérifiés sur `b91be140`, pas introduits par ce portage) : des `AND` manquants (erreur de syntaxe SQL dès qu'un shift existe) et une comparaison d'une colonne `TIME` contre une chaîne datetime complète dans un `WHERE`, que MariaDB n'évalue jamais comme vraie dans ce contexte (contrairement à un `SELECT ... AS`) — ce qui explique probablement pourquoi `app:shift:fix_missing_position` avait dû être écrite comme rattrapage manuel.

## Tests

- Rejeu complet des migrations depuis zéro (`make db-reset`, 99 migrations, MariaDB) : OK.
- Suite fonctionnelle complète : 102 tests, 126 assertions, verts.
- Nouveau test de régression (`tests/Functional/Migrations/Version20211223205749Test.php`) qui seed des données au format pré-migration et rejoue `up()`/`postUp()` directement (comme le fait l'exécuteur Doctrine), pour couvrir précisément le chemin de reconstruction que le test existant (`SchemaBuiltFromMigrationsTest`, base vide) ne pouvait pas exercer.
- `php-cs-fixer` et PHPStan (sur les fichiers modifiés) clean.